### PR TITLE
ci: integration matrix (mssql/postgres/sqlite) + fix MSSQL cursor never advancing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,68 @@ jobs:
         run: go vet ./...
       - name: Unit tests
         run: go test ./...
+
+  integration:
+    name: Integration (${{ matrix.db }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [mssql, postgres, sqlite]
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: ${{ secrets.DBTOOLS_TEST_MSSQL_SA_PASSWORD }}
+          MSSQL_PID: Developer
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $$MSSQL_SA_PASSWORD -C -Q 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dbtools
+          POSTGRES_PASSWORD: dbtools
+          POSTGRES_DB: dbtools_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dbtools"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+      # The stock MSSQL image ships no user databases; the integration
+      # suite expects one named `dbtools`. Create it once per run.
+      - name: Create MSSQL test database
+        if: matrix.db == 'mssql'
+        env:
+          MSSQL_SA_PASSWORD: ${{ secrets.DBTOOLS_TEST_MSSQL_SA_PASSWORD }}
+        run: |
+          /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "IF DB_ID('dbtools') IS NULL CREATE DATABASE dbtools" -b
+      - name: Integration tests
+        env:
+          DBTOOLS_TEST_MSSQL_URL: "mssql://sa:${{ secrets.DBTOOLS_TEST_MSSQL_SA_PASSWORD }}@localhost:1433?database=dbtools&TrustServerCertificate=true&x-migrations-table=schema_migrations"
+          DBTOOLS_TEST_POSTGRES_URL: "postgres://dbtools:dbtools@localhost:5432/dbtools_test?sslmode=disable"
+          DBTOOLS_TEST_SQLITE_URL: "sqlite:///tmp/dbtools-it.db"
+        run: |
+          case "${{ matrix.db }}" in
+            mssql)
+              go test -tags=integration ./... -count=1
+              ;;
+            postgres)
+              go test -tags=integration ./internal/engine/postgresengine/... -count=1
+              ;;
+            sqlite)
+              go test -tags=integration ./internal/engine/sqliteengine/... -count=1
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,17 @@ jobs:
         with:
           go-version: "1.25"
       # The stock MSSQL image ships no user databases; the integration
-      # suite expects one named `dbtools`. Create it once per run.
+      # suite expects one named `dbtools`. Create it inside the service
+      # container (sqlcmd lives only there, not on the runner host).
       - name: Create MSSQL test database
         if: matrix.db == 'mssql'
         env:
           MSSQL_SA_PASSWORD: ${{ secrets.DBTOOLS_TEST_MSSQL_SA_PASSWORD }}
         run: |
-          /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "IF DB_ID('dbtools') IS NULL CREATE DATABASE dbtools" -b
+          container_id=$(docker ps -q --filter "ancestor=mcr.microsoft.com/mssql/server:2022-latest" | head -1)
+          docker exec "$container_id" /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C \
+            -Q "IF DB_ID('dbtools') IS NULL CREATE DATABASE dbtools" -b
       - name: Integration tests
         env:
           DBTOOLS_TEST_MSSQL_URL: "mssql://sa:${{ secrets.DBTOOLS_TEST_MSSQL_SA_PASSWORD }}@localhost:1433?database=dbtools&TrustServerCertificate=true&x-migrations-table=schema_migrations"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,12 @@ jobs:
           MSSQL_PID: Developer
         ports:
           - 1433:1433
+        # Readiness is checked without credentials: SQL Server logs
+        # "Recovery is complete" to the error log once it accepts logins.
+        # (A `-P $VAR` health check is unreliable here — the runner leaves
+        # `$$` for the container shell, where `$$` is the PID.)
         options: >-
-          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $$MSSQL_SA_PASSWORD -C -Q 'SELECT 1'"
+          --health-cmd "bash -c 'grep -q \"Recovery is complete\" /var/opt/mssql/log/errorlog || exit 1'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10

--- a/internal/engine/sqliteengine/migrate_integration_test.go
+++ b/internal/engine/sqliteengine/migrate_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package sqliteengine
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/migrator"
+)
+
+// TestLiveMigrateUpAndLedger exercises the full golang-migrate path and
+// the ledger round trip against a real SQLite file — the shared migration
+// machinery (migrator.Open, Up, Version, ledger.Sync/SetStatus/List) that
+// the MSSQL/Postgres engines already cover in their own integration tests
+// but SQLite had none for.
+func TestLiveMigrateUpAndLedger(t *testing.T) {
+	rawURL := os.Getenv("DBTOOLS_TEST_SQLITE_URL")
+	if rawURL == "" {
+		t.Skip("DBTOOLS_TEST_SQLITE_URL not set, skipping integration test")
+	}
+
+	// Isolate each run: the URL names a file path (sqlite:///tmp/...);
+	// drop any file left by a previous run so this test starts blank.
+	if p := PathFromURL(rawURL); p != "" {
+		for _, sidecar := range []string{p, p + "-wal", p + "-shm"} {
+			os.Remove(sidecar)
+		}
+	}
+
+	eng := SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	defer db.Close()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "20260817000001_widgets.up.sql"),
+		[]byte("CREATE TABLE it_widgets (id INTEGER PRIMARY KEY, label TEXT NOT NULL);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := migrator.Open(rawURL, dir)
+	if err != nil {
+		t.Fatalf("migrator.Open() returned error: %v", err)
+	}
+	defer m.Close()
+
+	applied, err := m.Up()
+	if err != nil {
+		t.Fatalf("Up() returned error: %v", err)
+	}
+	if !applied {
+		t.Fatal("Up() = false, want an applied migration")
+	}
+	version, dirty, hasVersion, err := m.Version()
+	if err != nil || dirty || !hasVersion || version != 20260817000001 {
+		t.Fatalf("Version() = %d dirty=%v has=%v err=%v", version, dirty, hasVersion, err)
+	}
+
+	// Ledger round trip through the engine seam.
+	store := ledgerStore{}
+	if err := store.Sync(db, m, dir); err != nil {
+		t.Fatalf("Sync() returned error: %v", err)
+	}
+	if err := store.SetStatus(db, 20260817000001, "applied", "applied via integration test"); err != nil {
+		t.Fatalf("SetStatus() returned error: %v", err)
+	}
+	entries, err := store.List(db)
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Version != 20260817000001 {
+		t.Fatalf("List() = %+v, want one row for version 20260817000001", entries)
+	}
+
+	// The migration's table must exist, proving the migration SQL ran.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='it_widgets'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("it_widgets table count = %d, want 1", n)
+	}
+
+	// The cursor and ledger must both see the file as up to date now.
+	if err := m.Close(); err != nil {
+		t.Fatal(err)
+	}
+	m2, err := migrator.Open(rawURL, dir)
+	if err != nil {
+		t.Fatalf("re-open migrator: %v", err)
+	}
+	defer m2.Close()
+	applied, err = m2.Up()
+	if err != nil {
+		t.Fatalf("second Up() returned error: %v", err)
+	}
+	if applied {
+		t.Fatal("second Up() = true, want no-change (ErrNoChange path)")
+	}
+}
+
+// TestLiveMigrateRollbackOnBadSQL guards the shared migrate path against a
+// regression where a failing migration would leave the cursor dirty and a
+// subsequent run would replay earlier migrations.
+func TestLiveMigrateDirtyFlag(t *testing.T) {
+	rawURL := os.Getenv("DBTOOLS_TEST_SQLITE_URL")
+	if rawURL == "" {
+		t.Skip("DBTOOLS_TEST_SQLITE_URL not set, skipping integration test")
+	}
+	if p := PathFromURL(rawURL); p != "" {
+		for _, sidecar := range []string{p, p + "-wal", p + "-shm"} {
+			os.Remove(sidecar)
+		}
+	}
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "1_good.up.sql"), []byte("CREATE TABLE good_t (id INTEGER);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "2_bad.up.sql"), []byte("THIS IS NOT SQL"), 0o644)
+
+	m, err := migrator.Open(rawURL, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	if _, err := m.Up(); err == nil {
+		t.Fatal("Up() with a bad second migration should error")
+	}
+	version, dirty, has, err := m.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has || !dirty || version != 2 {
+		t.Fatalf("after failed Up(): version=%d dirty=%v has=%v; want version=2 dirty=true has=true", version, dirty, has)
+	}
+
+	// The cursor must be dirty so a consumer (ledger.Sync's dirty check)
+	// can refuse to backfill over it.
+	_ = sql.ErrNoRows // keep database/sql import used if this test is trimmed
+}

--- a/internal/migrator/godriver.go
+++ b/internal/migrator/godriver.go
@@ -53,28 +53,15 @@ func (d *goSplitDriver) Close() error  { return d.inner.Close() }
 func (d *goSplitDriver) Lock() error   { return d.inner.Lock() }
 func (d *goSplitDriver) Unlock() error { return d.inner.Unlock() }
 
+// SetVersion delegates to the stock driver: it writes the version table
+// through the same [SCHEMA_NAME()].[MigrationsTable] path it reads from,
+// honouring x-migrations-table. The previous override hardcoded
+// dbo.schema_migrations, so a login whose default schema was not dbo (or a
+// URL setting x-migrations-table) read one table and wrote another — the
+// cursor never advanced and every `up` replayed the whole migration set
+// against a populated database.
 func (d *goSplitDriver) SetVersion(version int, dirty bool) error {
-	db, err := dbconn.Open(d.rawURL)
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.Exec("DELETE FROM dbo.schema_migrations"); err != nil {
-		return err
-	}
-	if version >= 0 {
-		if _, err := tx.Exec("INSERT INTO dbo.schema_migrations (version, dirty) VALUES (@p1, @p2)", version, dirty); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
+	return d.inner.SetVersion(version, dirty)
 }
 
 func (d *goSplitDriver) Version() (int, bool, error) { return d.inner.Version() }


### PR DESCRIPTION
## Summary
- **CI**: add an `integration` job running the `-tags=integration` suite against live MSSQL (2022), Postgres (17), and SQLite service containers. Previously 12 integration files were build-tag excluded and never ran in CI — every engine regression landed silently.
- **SQLite coverage**: add `internal/engine/sqliteengine/migrate_integration_test.go` exercising the shared migrate+ledger path and the dirty-cursor path — the only engine with zero integration coverage.
- **MSSQL cursor fix**: `goSplitDriver.SetVersion` hardcoded `dbo.schema_migrations` while reads went through the stock driver's `[SCHEMA_NAME()].[MigrationsTable]` (honouring `x-migrations-table`). With a non-dbo default schema login or a custom migrations table, reads and writes hit different tables, the cursor never advanced, and every `up` replayed the whole set against a populated DB. Now delegates to the inner driver — one-line fix, catastrophic-class bug.

Closes the two highest-leverage items from the review handoff (R1 + R4).