### PR TITLE
ledger: content hashes + truthfulness (R2/R3, C7, H5/M3)

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -20,7 +20,10 @@ var verifyCmd = &cobra.Command{
 	},
 }
 
+var verifyInitLedger bool
+
 func init() {
+	verifyCmd.Flags().BoolVar(&verifyInitLedger, "init-ledger", false, "create the ledger table and backfill rows for already-applied migrations (default: verify is read-only and reports an uninitialised ledger)")
 	rootCmd.AddCommand(verifyCmd)
 }
 
@@ -51,8 +54,27 @@ func runVerify(targetName string) error {
 	}
 	defer m.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
-		return err
+	entries, err := eng.Ledger().List(db)
+	if err != nil {
+		// No ledger table at all: with --init-ledger, create it (and
+		// backfill); without it, refuse — verify must not perform DDL/DML
+		// on a target it was asked to inspect read-only.
+		if verifyInitLedger {
+			if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+				return err
+			}
+			entries, err = eng.Ledger().List(db)
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("ledger for %q is not initialised — refusing to create it on a read-only check; pass --init-ledger to create and backfill it", targetName)
+		}
+	}
+	if len(entries) == 0 {
+		if !verifyInitLedger {
+			return fmt.Errorf("ledger for %q is empty — refusing to create it on a read-only check; pass --init-ledger to create and backfill it", targetName)
+		}
 	}
 
 	report, err := verify.Collect(db, eng, cfg.MigrationsDir, targetName)

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -11,10 +11,11 @@ import (
 )
 
 // Run resolves targetName's connection string (or uses urlOverride when
-// provided — see ResolveURLOrFlag), applies every pending migration,
-// records each newly-applied version in the migration ledger, and returns
-// the post-apply status. Both `dbtools up` and `dbtools push <target>`
-// call this — there is exactly one apply path.
+// provided — see ResolveURLOrFlag), applies every pending migration one
+// step at a time, records each newly-applied version in the migration
+// ledger (with its file's content hash), and returns the post-apply
+// status. Both `dbtools up` and `dbtools push <target>` call this — there
+// is exactly one apply path.
 func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo.Status, error) {
 	url, err := cfg.ResolveURLOrFlag(targetName, urlOverride)
 	if err != nil {
@@ -42,22 +43,43 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	versionBefore, _, hasVersionBefore, err := m.Version()
-	if err != nil {
-		return nil, fmt.Errorf("target %q: %w", targetName, err)
-	}
-	all, err := statusinfo.ListMigrationFiles(cfg.MigrationsDir)
-	if err != nil {
-		return nil, fmt.Errorf("target %q: %w", targetName, err)
-	}
-	newlyPending := statusinfo.ComputePendingVersions(versionBefore, hasVersionBefore, all)
+	// Apply one migration at a time, recording the ledger row immediately
+	// after each success. If migration N fails, migrations 1..N-1 are
+	// applied in the database AND recorded — the next run sees them as
+	// applied and re-attempts only N. (An all-or-nothing m.Up() would
+	// leave the database advanced and the ledger empty, which is exactly
+	// the lie this ledger exists to prevent.)
+	for {
+		versionBefore, dirty, hasVersionBefore, err := m.Version()
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+		if dirty {
+			return nil, fmt.Errorf("target %q: migration cursor is dirty at version %d (a previous apply failed partway); run `dbtools repair %s` to resolve it", targetName, versionBefore, targetName)
+		}
 
-	if _, err := m.Up(); err != nil {
-		return nil, fmt.Errorf("target %q: %w", targetName, err)
-	}
+		applied, err := m.Step()
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+		if !applied {
+			break // no pending migrations left
+		}
 
-	for _, v := range newlyPending {
-		if err := eng.Ledger().SetStatus(db, v, ledger.StatusApplied, "applied via up/push"); err != nil {
+		versionAfter, _, _, err := m.Version()
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+		// Step applies exactly the next pending version; guard against a
+		// driver whose cursor jumps in unexpected ways.
+		if versionAfter != versionBefore+1 && !(!hasVersionBefore && versionAfter > versionBefore) {
+			return nil, fmt.Errorf("target %q: migration cursor advanced unexpectedly (was %d, now %d)", targetName, versionBefore, versionAfter)
+		}
+		hash, err := migrator.ContentHash(cfg.MigrationsDir, versionAfter)
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+		if err := eng.Ledger().SetStatusWithHash(db, versionAfter, ledger.StatusApplied, "applied via up/push", hash); err != nil {
 			return nil, fmt.Errorf("target %q: %w", targetName, err)
 		}
 	}

--- a/internal/apply/apply_partial_integration_test.go
+++ b/internal/apply/apply_partial_integration_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package apply
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/config"
+	"github.com/dbtools/dbtools/internal/engine"
+	_ "github.com/dbtools/dbtools/internal/engine/sqliteengine"
+	"github.com/dbtools/dbtools/internal/ledger"
+	"github.com/dbtools/dbtools/internal/migrator"
+)
+
+var migratorOpen = migrator.Open
+
+// TestRun_RecordsPartiallyAppliedMigrationsOnFailure is the C2 regression:
+// with three pending migrations where the third fails, the first two are
+// applied to the database AND must be recorded in the ledger, so the next
+// run re-attempts only the third (instead of replaying everything or
+// lying about the failed one).
+func TestRun_RecordsPartiallyAppliedMigrationsOnFailure(t *testing.T) {
+	rawURL := os.Getenv("DBTOOLS_TEST_SQLITE_URL")
+	if rawURL == "" {
+		t.Skip("DBTOOLS_TEST_SQLITE_URL not set, skipping integration test")
+	}
+	if p := sqlitePath(rawURL); p != "" {
+		for _, s := range []string{p, p + "-wal", p + "-shm"} {
+			os.Remove(s)
+		}
+	}
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "1_create_a.up.sql"), []byte("CREATE TABLE migrate_a (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "2_create_b.up.sql"), []byte("CREATE TABLE migrate_b (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "3_bad.up.sql"), []byte("THIS IS NOT SQL"), 0o644)
+
+	cfg := &config.Config{
+		MigrationsDir: dir,
+		Targets:       map[string]config.Target{"local": {URLEnv: "DBTOOLS_APPLY_FAIL_URL"}},
+	}
+	t.Setenv("DBTOOLS_APPLY_FAIL_URL", rawURL)
+
+	_, err := Run(cfg, "local", "")
+	if err == nil {
+		t.Fatal("Run() with a bad third migration should error")
+	}
+	if !strings.Contains(err.Error(), "version 3") && !strings.Contains(err.Error(), "3") {
+		t.Logf("error mentions migration 3: %v", err)
+	}
+
+	eng, err := engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	entries, err := eng.Ledger().List(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("ledger has %d entries, want exactly the 2 applied migrations (got %+v)", len(entries), entries)
+	}
+	for _, e := range entries {
+		if e.Status != ledger.StatusApplied {
+			t.Errorf("entry %+v: want applied", e)
+		}
+		if e.ContentSHA256 == "" {
+			t.Errorf("entry %+v: want a content hash", e)
+		}
+	}
+
+	// The failed migration must NOT be recorded as applied.
+	for _, e := range entries {
+		if e.Version == 3 {
+			t.Fatalf("failed migration 3 was recorded as applied: %+v", e)
+		}
+	}
+
+	// Fix the bad migration. The dirty cursor (a failed apply at version 3)
+	// must block a blind re-run — the ledger refuses to backfill over a
+	// dirty cursor (C3), forcing an explicit repair decision. This is the
+	// protection: the failed migration can never silently become "applied".
+	os.WriteFile(filepath.Join(dir, "3_bad.up.sql"), []byte("CREATE TABLE migrate_c (id INTEGER PRIMARY KEY);"), 0o644)
+	_, err = Run(cfg, "local", "")
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("Run() over a dirty cursor = %v, want a dirty-cursor error", err)
+	}
+
+	// After repair the failed migration stays reverted — the correct
+	// recovery is to add a new migration. A run applies it and records it
+	// with a hash. (repair.Run does both of these: ledger SetStatus
+	// reverted + Stamp past the dirty cursor.)
+	eng, err = engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err = eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := eng.Ledger().SetStatus(db, 3, ledger.StatusReverted, "repair: previously failed"); err != nil {
+		t.Fatalf("marking 3 reverted: %v", err)
+	}
+	m, err := migratorOpen(rawURL, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if err := m.Stamp(3); err != nil {
+		t.Fatalf("stamp version 3 clean: %v", err)
+	}
+	os.WriteFile(filepath.Join(dir, "4_create_c.up.sql"), []byte("CREATE TABLE migrate_c (id INTEGER PRIMARY KEY);"), 0o644)
+	if _, err := Run(cfg, "local", ""); err != nil {
+		t.Fatalf("Run() after adding migration 4 returned error: %v", err)
+	}
+	entries, err = eng.Ledger().List(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("after repair+run: ledger has %d entries, want 4 (v1, v2 applied; v3 reverted; v4 applied)", len(entries))
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Version == 4 {
+			found = true
+			if e.Status != ledger.StatusApplied {
+				t.Fatalf("migration 4 status = %s, want applied: %+v", e.Status, e)
+			}
+			if e.ContentSHA256 == "" {
+				t.Fatalf("migration 4 recorded without hash: %+v", e)
+			}
+		}
+		if e.Version == 3 {
+			if e.Status != ledger.StatusReverted {
+				t.Fatalf("repaired migration 3 status = %s, want reverted: %+v", e.Status, e)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("migration 4 not recorded")
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migrate_c'`).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("migrate_c count = %d, err = %v; want 1", n, err)
+	}
+}
+
+func sqlitePath(rawURL string) string {
+	const prefix = "sqlite://"
+	if !strings.HasPrefix(rawURL, prefix) {
+		return ""
+	}
+	p := strings.TrimPrefix(rawURL, prefix)
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	return p
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -64,9 +64,16 @@ type DDLDialect interface {
 // ledger (see internal/ledger for the semantics each method must keep).
 type LedgerStore interface {
 	// Sync ensures the ledger table exists and backfills a row for every
-	// version the migrate cursor already considers applied.
+	// version the migrate cursor already considers applied. Refuses to
+	// backfill when the cursor is dirty.
 	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error
+	// SetStatus upserts version's ledger row, preserving content_sha256
+	// when the row already exists.
 	SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error
+	// SetStatusWithHash is SetStatus plus recording the applied migration
+	// file's content hash, so verify can detect edits after apply. Used by
+	// the apply path only.
+	SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error
 	List(db ledger.DBTX) ([]ledger.Entry, error)
 	AppliedVersions(db ledger.DBTX) ([]uint64, error)
 }

--- a/internal/engine/mssqlengine/mssqlengine.go
+++ b/internal/engine/mssqlengine/mssqlengine.go
@@ -61,6 +61,10 @@ func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Statu
 	return ledger.SetStatus(db, version, status, note)
 }
 
+func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+	return ledger.SetStatusWithHash(db, version, status, note, contentHash)
+}
+
 func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 	return ledger.List(db)
 }

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -17,13 +17,20 @@ type ledgerStore struct{}
 func (ledgerStore) ensureSchema(db ledger.DBTX) error {
 	_, err := db.Exec(`
 CREATE TABLE IF NOT EXISTS dbtools_migration_history (
-    version     BIGINT       NOT NULL PRIMARY KEY,
-    status      VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
-    recorded_at TIMESTAMPTZ  NULL,
-    note        VARCHAR(400) NULL
+    version         BIGINT       NOT NULL PRIMARY KEY,
+    status          VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
+    recorded_at     TIMESTAMPTZ  NULL,
+    note            VARCHAR(400) NULL,
+    content_sha256  CHAR(64)     NULL
 )`)
 	if err != nil {
 		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+	}
+	// Column added by dbtools builds before content hashing existed —
+	// idempotent when already present.
+	_, err = db.Exec(`ALTER TABLE dbtools_migration_history ADD COLUMN IF NOT EXISTS content_sha256 CHAR(64) NULL`)
+	if err != nil {
+		return fmt.Errorf("adding content_sha256 to dbtools_migration_history: %w", err)
 	}
 	return nil
 }
@@ -59,7 +66,8 @@ ON CONFLICT (version) DO NOTHING`, int64(v))
 	return nil
 }
 
-// SetStatus upserts version's ledger row.
+// SetStatus upserts version's ledger row, preserving content_sha256 on
+// update (the applied file's hash must not be clobbered by a status edit).
 func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
@@ -76,9 +84,27 @@ SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDE
 	return nil
 }
 
+// SetStatusWithHash is SetStatus plus recording the applied migration
+// file's content hash, so verify can detect edits after apply.
+func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(`
+INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+VALUES ($1, $2, now(), $3, $4)
+ON CONFLICT (version) DO UPDATE
+SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`,
+		int64(version), string(status), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row, ordered by version ascending.
 func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note FROM dbtools_migration_history ORDER BY version ASC`)
+	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -90,8 +116,8 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note); err != nil {
+		var note, contentHash sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -104,6 +130,7 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 			e.RecordedAt = &t
 		}
 		e.Note = note.String
+		e.ContentSHA256 = contentHash.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -126,13 +153,18 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 
 // Sync mirrors ledger.Sync for Postgres: ensure the table exists and
 // backfill a row for every version m's cursor already considers applied.
+// Refuses to backfill when the cursor is dirty (a previous apply failed
+// partway) — see ledger.Sync.
 func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
 	if err := s.ensureSchema(db); err != nil {
 		return err
 	}
-	version, _, hasVersion, err := m.Version()
+	version, dirty, hasVersion, err := m.Version()
 	if err != nil {
 		return err
+	}
+	if dirty {
+		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair <target>` to resolve it before syncing the ledger", version)
 	}
 	allVersions, err := migrator.ListVersions(migrationsDir)
 	if err != nil {

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -28,13 +28,25 @@ func checkVersionRange(version uint64) error {
 func (ledgerStore) ensureSchema(db ledger.DBTX) error {
 	_, err := db.Exec(`
 CREATE TABLE IF NOT EXISTS dbtools_migration_history (
-    version     INTEGER NOT NULL PRIMARY KEY,
-    status      TEXT    NOT NULL CHECK (status IN ('applied', 'reverted')),
-    recorded_at TIMESTAMP NULL,
-    note        TEXT    NULL
+    version         INTEGER NOT NULL PRIMARY KEY,
+    status          TEXT    NOT NULL CHECK (status IN ('applied', 'reverted')),
+    recorded_at     TIMESTAMP NULL,
+    note            TEXT    NULL,
+    content_sha256  TEXT    NULL
 )`)
 	if err != nil {
 		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+	}
+	// Column added by dbtools builds before content hashing existed.
+	cols, err := db.Query(`SELECT name FROM pragma_table_info('dbtools_migration_history') WHERE name = 'content_sha256'`)
+	if err != nil {
+		return fmt.Errorf("inspecting dbtools_migration_history columns: %w", err)
+	}
+	defer cols.Close()
+	if !cols.Next() {
+		if _, err := db.Exec(`ALTER TABLE dbtools_migration_history ADD COLUMN content_sha256 TEXT NULL`); err != nil {
+			return fmt.Errorf("adding content_sha256 to dbtools_migration_history: %w", err)
+		}
 	}
 	return nil
 }
@@ -61,7 +73,8 @@ ON CONFLICT (version) DO NOTHING`, int64(v))
 	return nil
 }
 
-// SetStatus upserts version's ledger row.
+// SetStatus upserts version's ledger row, preserving content_sha256 on
+// update (the applied file's hash must not be clobbered by a status edit).
 func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
@@ -78,9 +91,27 @@ SET status = excluded.status, recorded_at = excluded.recorded_at, note = exclude
 	return nil
 }
 
+// SetStatusWithHash is SetStatus plus recording the applied migration
+// file's content hash, so verify can detect edits after apply.
+func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(`
+INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (version) DO UPDATE
+SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`,
+		int64(version), string(status), time.Now().UTC(), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row, ordered by version ascending.
 func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note FROM dbtools_migration_history ORDER BY version ASC`)
+	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -92,8 +123,8 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note); err != nil {
+		var note, contentHash sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -106,6 +137,7 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 			e.RecordedAt = &t
 		}
 		e.Note = note.String
+		e.ContentSHA256 = contentHash.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -128,13 +160,18 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 
 // Sync mirrors ledger.Sync for SQLite: ensure the table exists and
 // backfill a row for every version m's cursor already considers applied.
+// Refuses to backfill when the cursor is dirty (a previous apply failed
+// partway) — see ledger.Sync.
 func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
 	if err := s.ensureSchema(db); err != nil {
 		return err
 	}
-	version, _, hasVersion, err := m.Version()
+	version, dirty, hasVersion, err := m.Version()
 	if err != nil {
 		return err
+	}
+	if dirty {
+		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair <target>` to resolve it before syncing the ledger", version)
 	}
 	allVersions, err := migrator.ListVersions(migrationsDir)
 	if err != nil {

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -22,6 +22,9 @@ type Entry struct {
 	Status     Status
 	RecordedAt *time.Time // nil for backfilled rows whose original apply time is unknown
 	Note       string
+	// ContentSHA256 is the hex SHA-256 of the migration file that was
+	// applied, or "" for backfilled rows recorded before hashes existed.
+	ContentSHA256 string
 }
 
 // DBTX is the subset of *sql.DB's interface every function in this package
@@ -34,17 +37,24 @@ type DBTX interface {
 	QueryRow(query string, args ...any) *sql.Row
 }
 
-// EnsureSchema creates dbtools_migration_history if it doesn't already exist.
+// EnsureSchema creates dbtools_migration_history if it doesn't already
+// exist, and adds the content_sha256 column to an existing table created
+// by an earlier version of dbtools (idempotent either way).
 func EnsureSchema(db DBTX) error {
 	_, err := db.Exec(`
 IF OBJECT_ID(N'dbtools_migration_history', N'U') IS NULL
 BEGIN
     CREATE TABLE dbtools_migration_history (
-        version     BIGINT        NOT NULL PRIMARY KEY,
-        status      VARCHAR(10)   NOT NULL CHECK (status IN ('applied', 'reverted')),
-        recorded_at DATETIME2(0)  NULL,
-        note        NVARCHAR(400) NULL
+        version         BIGINT        NOT NULL PRIMARY KEY,
+        status          VARCHAR(10)   NOT NULL CHECK (status IN ('applied', 'reverted')),
+        recorded_at     DATETIME2(0)  NULL,
+        note            NVARCHAR(400) NULL,
+        content_sha256  CHAR(64)      NULL
     );
+END;
+ELSE IF COL_LENGTH(N'dbtools_migration_history', N'content_sha256') IS NULL
+BEGIN
+    ALTER TABLE dbtools_migration_history ADD content_sha256 CHAR(64) NULL;
 END;`)
 	if err != nil {
 		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
@@ -52,10 +62,21 @@ END;`)
 	return nil
 }
 
+// checkVersionRange rejects versions that would wrap when stored in the
+// ledger's signed BIGINT column.
+func checkVersionRange(version uint64) error {
+	if version > 1<<63-1 {
+		return fmt.Errorf("migration version %d exceeds the ledger's BIGINT range", version)
+	}
+	return nil
+}
+
 // Backfill inserts an "applied" row (recorded_at NULL, noted as backfilled)
 // for every version in allVersions that is <= currentVersion and not
 // already present in the ledger. If hasVersion is false, nothing is
-// backfilled — no migration has ever been applied.
+// backfilled — no migration has ever been applied. Backfilled rows carry
+// no content hash: the migration may have been applied before hashes
+// existed.
 func Backfill(db DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64) error {
 	if !hasVersion {
 		return nil
@@ -64,10 +85,13 @@ func Backfill(db DBTX, currentVersion uint64, hasVersion bool, allVersions []uin
 		if v > currentVersion {
 			continue
 		}
+		if err := checkVersionRange(v); err != nil {
+			return err
+		}
 		_, err := db.Exec(`
 IF NOT EXISTS (SELECT 1 FROM dbtools_migration_history WHERE version = @p1)
 INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
-VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, v)
+VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, int64(v))
 		if err != nil {
 			return fmt.Errorf("backfilling version %d: %w", v, err)
 		}
@@ -77,14 +101,43 @@ VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, v)
 
 // SetStatus upserts version's ledger row.
 func SetStatus(db DBTX, version uint64, status Status, note string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	// HOLDLOCK serializes concurrent upserts of the same version so the
+	// IF EXISTS / INSERT cannot race into a duplicate-PK error (repair can
+	// run multiple writers in one transaction).
 	_, err := db.Exec(`
-IF EXISTS (SELECT 1 FROM dbtools_migration_history WHERE version = @p1)
+IF EXISTS (SELECT 1 FROM dbtools_migration_history WITH (HOLDLOCK) WHERE version = @p1)
     UPDATE dbtools_migration_history
     SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3
     WHERE version = @p1
 ELSE
     INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
-    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3);`, version, string(status), note)
+    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3);`, int64(version), string(status), note)
+	if err != nil {
+		return fmt.Errorf("setting status for version %d: %w", version, err)
+	}
+	return nil
+}
+
+// SetStatusWithHash is SetStatus plus recording the applied migration
+// file's content hash, so verify can detect edits after apply.
+func SetStatusWithHash(db DBTX, version uint64, status Status, note, contentHash string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	// HOLDLOCK serializes concurrent upserts of the same version so the
+	// IF EXISTS / INSERT cannot race into a duplicate-PK error (repair can
+	// run multiple writers in one transaction).
+	_, err := db.Exec(`
+IF EXISTS (SELECT 1 FROM dbtools_migration_history WITH (HOLDLOCK) WHERE version = @p1)
+    UPDATE dbtools_migration_history
+    SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3
+    WHERE version = @p1
+ELSE
+    INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3, @p4);`, int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
 	}
@@ -93,7 +146,7 @@ ELSE
 
 // List returns every ledger row, ordered by version ascending.
 func List(db DBTX) ([]Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note FROM dbtools_migration_history ORDER BY version ASC`)
+	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -102,18 +155,24 @@ func List(db DBTX) ([]Entry, error) {
 	var entries []Entry
 	for rows.Next() {
 		var e Entry
+		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note sql.NullString
-		if err := rows.Scan(&e.Version, &status, &recordedAt, &note); err != nil {
+		var note, contentHash sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
+		if version < 0 {
+			return nil, fmt.Errorf("ledger contains negative version %d; the table was modified outside dbtools", version)
+		}
+		e.Version = uint64(version)
 		e.Status = Status(status)
 		if recordedAt.Valid {
 			t := recordedAt.Time
 			e.RecordedAt = &t
 		}
 		e.Note = note.String
+		e.ContentSHA256 = contentHash.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -136,17 +195,22 @@ func AppliedVersions(db DBTX) ([]uint64, error) {
 
 // Sync ensures db's ledger table exists and has a backfilled row for every
 // version m's cursor already considers applied — the ledger's baseline
-// state before verify or repair reason about it. Note: m.Version() discards
-// golang-migrate's dirty flag, so if a prior Up() failed partway and left
-// the cursor dirty at that version, Sync backfills that version as applied
-// too — verify, not Sync, is what catches that case.
+// state before verify or repair reason about it.
+//
+// If the cursor is dirty (a previous apply failed partway), Sync refuses
+// to backfill: the dirty version may not actually be applied, and writing
+// "applied" for it would make the ledger lie about exactly the situation
+// it exists to surface. Use `repair` to resolve the dirty cursor first.
 func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
 	if err := EnsureSchema(db); err != nil {
 		return err
 	}
-	version, _, hasVersion, err := m.Version()
+	version, dirty, hasVersion, err := m.Version()
 	if err != nil {
 		return err
+	}
+	if dirty {
+		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair %s` to resolve it before syncing the ledger", version, "target")
 	}
 	allVersions, err := migrator.ListVersions(migrationsDir)
 	if err != nil {

--- a/internal/ledger/sync_dirty_test.go
+++ b/internal/ledger/sync_dirty_test.go
@@ -1,0 +1,103 @@
+package ledger_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/engine/sqliteengine"
+	"github.com/dbtools/dbtools/internal/migrator"
+)
+
+// migratorOpenDB opens the sqlite file directly (like eng.Open would). The
+// "sqlite" driver is registered by internal/migrator's sqlite import.
+func migratorOpenDB(rawURL string) (*sql.DB, error) {
+	p := strings.TrimPrefix(rawURL, "sqlite://")
+	return sql.Open("sqlite", p)
+}
+
+// TestSync_RefusesDirtyCursor is the C3 regression: when a previous apply
+// failed partway, the cursor is dirty and Sync must refuse to backfill —
+// otherwise the failed migration silently becomes "applied" in the ledger.
+func TestSync_RefusesDirtyCursor(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "1_create_a.up.sql"), []byte("CREATE TABLE ledger_sync_a (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "2_bad.up.sql"), []byte("THIS IS NOT SQL"), 0o644)
+
+	rawURL := "sqlite://" + filepath.Join(dir, "sync.db")
+	m, err := migrator.Open(rawURL, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	// Apply version 1, then let version 2 fail — leaving the cursor dirty.
+	if _, err := m.Step(); err != nil {
+		t.Fatalf("step 1: %v", err)
+	}
+	if _, err := m.Step(); err == nil {
+		t.Fatal("step 2 should fail (bad SQL)")
+	}
+	v, dirty, _, err := m.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dirty {
+		t.Fatalf("cursor should be dirty after failed apply, got version=%d dirty=%v", v, dirty)
+	}
+
+	db, err := migratorOpenDB(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ls := sqliteengine.SQLite{}.Ledger()
+	err = ls.Sync(db, m, dir)
+	if err == nil {
+		t.Fatal("Sync() over a dirty cursor should refuse")
+	}
+	if !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("Sync() error = %v, want it to mention the dirty cursor", err)
+	}
+
+	// And the ledger must NOT have backfilled the failed version.
+	entries, err := ls.List(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ledger has %d entries after refused Sync, want 0 (nothing backfilled over a dirty cursor)", len(entries))
+	}
+}
+
+func TestSync_BackfillSkipsDirty(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "1_create_a.up.sql"), []byte("CREATE TABLE ledger_sync_skip (id INTEGER PRIMARY KEY);"), 0o644)
+	rawURL := "sqlite://" + filepath.Join(dir, "sync.db")
+	m, err := migrator.Open(rawURL, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if _, err := m.Step(); err != nil {
+		t.Fatalf("step 1: %v", err)
+	}
+	db, err := migratorOpenDB(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := (sqliteengine.SQLite{}).Ledger().Sync(db, m, dir); err != nil {
+		t.Fatalf("Sync() clean: %v", err)
+	}
+	entries, err := (sqliteengine.SQLite{}).Ledger().List(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Version != 1 {
+		t.Fatalf("ledger = %+v, want exactly version 1 applied", entries)
+	}
+}

--- a/internal/migrator/findfile.go
+++ b/internal/migrator/findfile.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
-// FindMigrationFile returns the filename (not full path) of the migration
-// file for version in migrationsDir, or an error if no file matches.
+// FindMigrationFile returns the filename (not full path) of the .up.sql
+// migration file for version in migrationsDir, or an error if no file
+// matches.
 func FindMigrationFile(migrationsDir string, version uint64) (string, error) {
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
@@ -24,6 +26,9 @@ func FindMigrationFile(migrationsDir string, version uint64) (string, error) {
 		v, err := strconv.ParseUint(m[1], 10, 64)
 		if err != nil || v != version {
 			continue
+		}
+		if !strings.HasSuffix(e.Name(), ".up.sql") {
+			continue // a .down.sql file for this version — not what callers want
 		}
 		return e.Name(), nil
 	}

--- a/internal/migrator/hash.go
+++ b/internal/migrator/hash.go
@@ -1,0 +1,26 @@
+package migrator
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ContentHash returns the hex SHA-256 of a migration file's contents. It
+// is what the ledger stores when a migration is applied, so verify can
+// detect an applied migration being edited after the fact — the most
+// common real-world schema drift.
+func ContentHash(migrationsDir string, version uint64) (string, error) {
+	filename, err := FindMigrationFile(migrationsDir, version)
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(filepath.Join(migrationsDir, filename))
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", filename, err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -33,6 +34,26 @@ func (mg *Migrator) Up() (applied bool, err error) {
 	}
 	if err != nil {
 		return false, fmt.Errorf("applying migrations: %w", err)
+	}
+	return true, nil
+}
+
+// Step applies the single next pending migration. applied is false if there
+// was nothing to do. Callers that need to record per-migration side effects
+// (e.g. the ledger) must use Step in a loop instead of Up, so a migration
+// that fails partway through a batch leaves the already-applied ones
+// recorded.
+//
+// golang-migrate's Steps(1) reports os.ErrNotExist ("file does not exist")
+// when the last migration has already been applied and there is no "next"
+// file — treat that as no-change, same as ErrNoChange.
+func (mg *Migrator) Step() (applied bool, err error) {
+	err = mg.m.Steps(1)
+	if errors.Is(err, migrate.ErrNoChange) || errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("applying next migration: %w", err)
 	}
 	return true, nil
 }

--- a/internal/verify/collect.go
+++ b/internal/verify/collect.go
@@ -29,18 +29,21 @@ type Report struct {
 
 // Collect checks every ledger row in db against migrationsDir's files:
 // versions marked "applied" must have every object their migration creates
-// actually present; versions marked "reverted" must not.
+// actually present AND the migration file's content must still match the
+// hash recorded when it was applied; versions marked "reverted" must not.
 func Collect(db *sql.DB, eng engine.Engine, migrationsDir, targetName string) (*Report, error) {
 	entries, err := eng.Ledger().List(db)
 	if err != nil {
 		return nil, err
 	}
 
-	// Objects any applied migration explicitly DROPs are expected-absent — an
-	// earlier migration's CREATE for the same object no longer existing is
-	// intentional removal, not drift (e.g. a legacy table created by an early
-	// migration and legitimately dropped by a later one).
-	dropped := make(map[ddlcheck.ObjectRef]bool)
+	// Objects any applied migration explicitly DROPs are expected-absent.
+	// Track drops per-object but allow a later migration to re-create the
+	// object: a version's CREATE is only excused by a drop that came
+	// BEFORE it and was not itself superseded by a re-create. (A global
+	// unordered union would mark a re-created object as permanently
+	// dropped and hide genuine later disappearance.)
+	droppedBefore := make(map[ddlcheck.ObjectRef]uint64) // object -> version that dropped it
 	for _, e := range entries {
 		if e.Status != ledger.StatusApplied {
 			continue
@@ -54,7 +57,12 @@ func Collect(db *sql.DB, eng engine.Engine, migrationsDir, targetName string) (*
 			return nil, err
 		}
 		for _, obj := range eng.DDL().ExtractDroppedObjects(string(content)) {
-			dropped[obj] = true
+			droppedBefore[obj] = e.Version
+		}
+		// If this migration itself re-creates the object, it cancels any
+		// earlier drop: a later genuine disappearance must be DRIFT.
+		for _, obj := range eng.DDL().ExtractObjects(string(content)) {
+			delete(droppedBefore, obj)
 		}
 	}
 
@@ -82,12 +90,30 @@ func Collect(db *sql.DB, eng engine.Engine, migrationsDir, targetName string) (*
 
 		status := "OK"
 		var details []string
+
+		// Content-hash check: an applied migration whose file was edited
+		// after apply is drift even when every object still exists — the
+		// DB no longer matches what the file says. Backfilled rows have no
+		// hash (recorded before hashing existed) and are skipped.
+		if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" {
+			sum, err := migrator.ContentHash(migrationsDir, e.Version)
+			if err != nil {
+				return nil, err
+			}
+			if sum != e.ContentSHA256 {
+				status = "DRIFT"
+				details = append(details, "migration file was edited after it was applied (content hash mismatch)")
+			}
+		}
+
 		for _, obj := range objects {
 			exists, err := eng.DDL().Exists(db, obj)
 			if err != nil {
 				return nil, err
 			}
-			if e.Status == ledger.StatusApplied && !exists && !dropped[obj] {
+			droppedAt, wasDropped := droppedBefore[obj]
+			excused := wasDropped && droppedAt < e.Version
+			if e.Status == ledger.StatusApplied && !exists && !excused {
 				status = "DRIFT"
 				details = append(details, fmt.Sprintf("%s.%s: claimed applied but missing", obj.Schema, obj.Name))
 			}

--- a/internal/verify/dropped_recreate_test.go
+++ b/internal/verify/dropped_recreate_test.go
@@ -1,0 +1,82 @@
+package verify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/engine"
+	_ "github.com/dbtools/dbtools/internal/engine/sqliteengine"
+	"github.com/dbtools/dbtools/internal/ledger"
+)
+
+// TestCollect_DropThenRecreateIsNotPermanentDrift is the review's §3
+// dropped-set regression: v1 drops widgets, v9 re-creates them. A later
+// genuine disappearance of widgets must be reported as DRIFT — not excused
+// by the stale "dropped at v1" fact.
+func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "1_drop_widgets.up.sql"), []byte("DROP TABLE IF EXISTS dbtools_test_recreate_widgets;"), 0o644)
+	os.WriteFile(filepath.Join(dir, "2_create_widgets.up.sql"), []byte("CREATE TABLE dbtools_test_recreate_widgets (id INTEGER PRIMARY KEY);"), 0o644)
+
+	rawURL := "sqlite://" + filepath.Join(dir, "verify.db")
+	eng, err := engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+		version INTEGER NOT NULL PRIMARY KEY,
+		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
+		recorded_at TIMESTAMP NULL,
+		note TEXT NULL,
+		content_sha256 TEXT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	// v1 drops (recorded), v2 re-creates (recorded) and the object exists.
+	if _, err := db.Exec(`CREATE TABLE dbtools_test_recreate_widgets (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	defer db.Exec(`DROP TABLE dbtools_test_recreate_widgets`)
+
+	if err := eng.Ledger().SetStatus(db, 1, ledger.StatusApplied, "drops widgets"); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.Ledger().SetStatus(db, 2, ledger.StatusApplied, "re-creates widgets"); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Collect(db, eng, dir, "test-target")
+	if err != nil {
+		t.Fatalf("Collect() returned error: %v", err)
+	}
+	for _, e := range report.Entries {
+		if e.Status != "OK" {
+			t.Errorf("entry %d = %s (%s), want OK when the object exists after re-create", e.Version, e.Status, e.Detail)
+		}
+	}
+
+	// Now the object genuinely disappears — with the old global unordered
+	// dropped-set this was reported OK forever; it must now be DRIFT.
+	if _, err := db.Exec(`DROP TABLE dbtools_test_recreate_widgets`); err != nil {
+		t.Fatal(err)
+	}
+	report, err = Collect(db, eng, dir, "test-target")
+	if err != nil {
+		t.Fatalf("second Collect() returned error: %v", err)
+	}
+	found := false
+	for _, e := range report.Entries {
+		if e.Version == 2 && e.Status == "DRIFT" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Collect() after genuine drop = %+v, want v2 (the re-create) reported DRIFT", report.Entries)
+	}
+}

--- a/internal/verify/hash_drift_test.go
+++ b/internal/verify/hash_drift_test.go
@@ -1,0 +1,142 @@
+package verify
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/engine"
+	_ "github.com/dbtools/dbtools/internal/engine/sqliteengine"
+	"github.com/dbtools/dbtools/internal/ledger"
+)
+
+// TestCollect_DetectsEditedMigrationAfterApply is the R2 regression: a
+// migration file edited after it was applied (the most common real drift)
+// must be reported even when every object still exists. The hash is
+// recorded at apply time; a different file hash is DRIFT.
+func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "20260101000000_create_widgets.up.sql")
+	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_drift (id INTEGER PRIMARY KEY);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rawURL := "sqlite://" + filepath.Join(dir, "verify.db")
+	eng, err := engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Create the ledger table (as apply.Run's Sync would).
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+		version INTEGER NOT NULL PRIMARY KEY,
+		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
+		recorded_at TIMESTAMP NULL,
+		note TEXT NULL,
+		content_sha256 TEXT NULL)`); err != nil {
+		t.Fatalf("creating ledger: %v", err)
+	}
+
+	// Simulate an apply: record the migration as applied WITH its current
+	// file hash.
+	hash, err := hashOf(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.Ledger().SetStatusWithHash(db, 20260101000000, ledger.StatusApplied, "applied via up/push", hash); err != nil {
+		t.Fatal(err)
+	}
+	// The migration's object actually exists (it was really applied).
+	if _, err := db.Exec(`CREATE TABLE dbtools_test_hash_drift (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	defer db.Exec(`DROP TABLE dbtools_test_hash_drift`)
+
+	// Verify clean before any edit.
+	report, err := Collect(db, eng, dir, "test-target")
+	if err != nil {
+		t.Fatalf("Collect() returned error: %v", err)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != "OK" {
+		t.Fatalf("Collect() before edit = %+v, want one OK entry", report.Entries)
+	}
+
+	// Edit the applied migration — the classic drift: an ALTER added by
+	// hand to a file that already ran against prod.
+	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_drift (id INTEGER PRIMARY KEY);\nALTER TABLE dbtools_test_hash_drift ADD COLUMN extra TEXT;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report, err = Collect(db, eng, dir, "test-target")
+	if err != nil {
+		t.Fatalf("Collect() after edit returned error: %v", err)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != "DRIFT" {
+		t.Fatalf("Collect() after edit = %+v, want one DRIFT entry", report.Entries)
+	}
+	if !strings.Contains(report.Entries[0].Detail, "edited after it was applied") {
+		t.Fatalf("DRIFT detail = %q, want it to mention the file was edited after apply", report.Entries[0].Detail)
+	}
+}
+
+func hashOf(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// TestCollect_BackfilledRowsWithoutHashAreNotDrift: rows recorded before
+// content hashing existed (empty hash) must not be reported as drift on
+// their own — there is no baseline to compare against.
+func TestCollect_BackfilledRowsWithoutHashAreNotDrift(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "20260101000000_create_widgets.up.sql")
+	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_backfill (id INTEGER PRIMARY KEY);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rawURL := "sqlite://" + filepath.Join(dir, "verify.db")
+	eng, err := engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+		version INTEGER NOT NULL PRIMARY KEY,
+		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
+		recorded_at TIMESTAMP NULL,
+		note TEXT NULL,
+		content_sha256 TEXT NULL)`); err != nil {
+		t.Fatalf("creating ledger: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE dbtools_test_hash_backfill (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	defer db.Exec(`DROP TABLE dbtools_test_hash_backfill`)
+	if err := eng.Ledger().SetStatus(db, 20260101000000, ledger.StatusApplied, "backfilled: applied before ledger existed"); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Collect(db, eng, dir, "test-target")
+	if err != nil {
+		t.Fatalf("Collect() returned error: %v", err)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != "OK" {
+		t.Fatalf("Collect() = %+v, want one OK entry (no hash baseline)", report.Entries)
+	}
+}


### PR DESCRIPTION
Fixes the 2026-08-21 review's critical findings: **R2** (content hashes in the ledger + verify compare), **R3** (ledger truthfulness: C2 partial-apply recording, C3 Sync refuses a dirty cursor), plus **C7** (verify read-only) and **H5/M3** (MSSQL upsert race + version-range check).

## What changed
- `dbtools_migration_history` gains `content_sha256`; apply records each migration file's SHA-256 on success → editing an applied migration is now detectable drift.
- `apply.Run` steps one migration at a time and records the ledger after each success (was: all-or-nothing `m.Up()`, DB advanced but ledger empty).
- `Sync` refuses to backfill over a dirty cursor — a failed migration can never silently become "applied". `repair` stays the explicit recovery.
- `verify` is read-only by default (no table → refusal); `--init-ledger` creates + backfills. `OK` now also means the file's content matches what was applied.
- verify's dropped-set is per-object, version-ordered, re-create-cancelling.
- `migrator.Step()` + `ContentHash()` added; `FindMigrationFile` returns only `.up.sql`.
- MSSQL upsert gains `HOLDLOCK`; version-range check added to mssql dialect.

## Tests
- Unit: `TestSQLiteFullLoop`, `TestSync_RefusesDirtyCursor`, `TestSync_BackfillSkipsDirty`, `TestCollect_DetectsEditedMigrationAfterApply`, `TestCollect_BackfilledRowsWithoutHashAreNotDrift`, `TestCollect_DropThenRecreateIsNotPermanentDrift`.
- Integration (sqlite, run locally): `TestRun_RecordsPartiallyAppliedMigrationsOnFailure` — the C2/C3 regression.
- CLI-verified: `verify` refusal → `--init-ledger` → `up` → OK → edit file → content-hash DRIFT.