### PR TITLE
cmd: target protection + one openTarget preamble (R5)

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -48,7 +48,14 @@ func init() {
 }
 
 func runGenerate(targetName string) error {
-	if targetName == "prod" && !generateYes {
+	// generate is read-only, but generating from a prod target without
+	// --yes is still a surprising thing to do (M5: the old guard only
+	// matched the literal name "prod").
+	if cfg, err := config.Load("dbtools.toml"); err == nil {
+		if t, ok := cfg.Targets[targetName]; ok && t.Protected && !generateYes {
+			return fmt.Errorf("refusing to generate from protected target %q without --yes", targetName)
+		}
+	} else if targetName == "prod" && !generateYes {
 		return fmt.Errorf("refusing to generate from %q without --yes", targetName)
 	}
 

--- a/cmd/guards_test.go
+++ b/cmd/guards_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtools/dbtools/internal/apply"
+	"github.com/dbtools/dbtools/internal/config"
+	"github.com/dbtools/dbtools/internal/statusinfo"
+)
+
+func TestUpRefusesNonLocalTarget(t *testing.T) {
+	// C1: `up --target prod` must refuse before touching anything — the
+	// push preview+--yes path is the only way to reach a remote target.
+	upTarget = "prod"
+	defer func() { upTarget = "local" }()
+
+	// Any attempt to load config that would lead to apply.Run is a test
+	// failure: the guard must fire before config is even needed.
+	loadConfig = func(string) (*config.Config, error) {
+		t.Fatal("config loaded — the guard must fire before config resolution")
+		return nil, nil
+	}
+	defer func() { loadConfig = config.Load }()
+
+	cmd := upCmd
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("up --target prod should refuse")
+	}
+	if !strings.Contains(err.Error(), "use `push prod --yes`") {
+		t.Fatalf("error = %v, want it to point at push --yes", err)
+	}
+}
+
+func TestUpAllowsLocalTarget(t *testing.T) {
+	// The guard must not break the normal local dev loop. We stub apply.Run
+	// so no real database is touched.
+	upTarget = "local"
+	defer func() { upTarget = "local" }()
+
+	loadConfig = func(string) (*config.Config, error) {
+		return &config.Config{MigrationsDir: "migrations", Targets: map[string]config.Target{"local": {URLEnv: "DBTOOLS_LOCAL_URL"}}}, nil
+	}
+	defer func() { loadConfig = config.Load }()
+	applyRun = func(cfg *config.Config, targetName string, _ string) (*statusinfo.Status, error) {
+		if targetName != "local" {
+			t.Fatalf("apply.Run called for %q, want local", targetName)
+		}
+		return &statusinfo.Status{Target: "local", CurrentVersion: 1}, nil
+	}
+	defer func() { applyRun = apply.Run }()
+
+	cmd := upCmd
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("up (local) returned error: %v", err)
+	}
+}
+
+func TestPushRefusesProtectedTarget(t *testing.T) {
+	// Protected target: push must refuse before the --yes check.
+	loadConfig = func(string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets: map[string]config.Target{
+				"prod": {URLEnv: "DBTOOLS_PROD_URL", Protected: true},
+			},
+		}, nil
+	}
+	defer func() { loadConfig = config.Load }()
+	pushYes = true
+	defer func() { pushYes = false }()
+
+	err := runPush("prod")
+	if err == nil {
+		t.Fatal("push to a protected target should refuse")
+	}
+	if !strings.Contains(err.Error(), "protected") {
+		t.Fatalf("error = %v, want it to mention protected", err)
+	}
+}
+
+func TestRepairRefusesProtectedTarget(t *testing.T) {
+	loadConfig = func(string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets: map[string]config.Target{
+				"prod": {URLEnv: "DBTOOLS_PROD_URL", Protected: true},
+			},
+		}, nil
+	}
+	defer func() { loadConfig = config.Load }()
+	repairYes = true
+	defer func() { repairYes = false }()
+
+	err := runRepair("prod", nil)
+	if err == nil {
+		t.Fatal("repair on a protected target should refuse")
+	}
+	if !strings.Contains(err.Error(), "protected") {
+		t.Fatalf("error = %v, want it to mention protected", err)
+	}
+}
+
+func TestStatusURLScoping(t *testing.T) {
+	// H1 regression: `status --url $X --target prod` must apply the URL
+	// only to prod — never to every target in the loop.
+	loadConfig = func(string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets: map[string]config.Target{
+				"local": {URLEnv: "DBTOOLS_LOCAL_URL"},
+				"prod":  {URLEnv: "DBTOOLS_PROD_URL"},
+			},
+		}, nil
+	}
+	defer func() { loadConfig = config.Load }()
+
+	statusTarget = "prod"
+	statusURL = "sqlserver://override"
+	defer func() { statusTarget = ""; statusURL = "" }()
+
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statuses, failures := collectStatuses(cfg)
+	// prod resolves with the override URL; local must NOT appear at all
+	// (--target narrows the iteration).
+	if len(statuses)+len(failures) != 1 {
+		t.Fatalf("collectStatuses returned %d statuses + %d failures, want exactly prod (1)", len(statuses), len(failures))
+	}
+	// prod should fail to connect (override URL unreachable) — that's fine;
+	// the point is it was the ONLY target attempted, and the URL override
+	// reached only it.
+	if len(failures) != 1 || failures[0].Target != "prod" {
+		t.Fatalf("failures = %+v, want exactly one prod failure (engine mismatch/unreachable)", failures)
+	}
+}

--- a/cmd/openTarget.go
+++ b/cmd/openTarget.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/dbtools/dbtools/internal/config"
+	"github.com/dbtools/dbtools/internal/engine"
+	"github.com/dbtools/dbtools/internal/migrator"
+)
+
+// openTarget resolves a target's connection string (or --url override),
+// validates its engine, and opens both the database connection and the
+// migrate cursor. It is the single shared preamble for every command that
+// acts on one named target — verify, repair, push, generate, apply.
+//
+// The caller owns closing db and m. The returned url is what the caller
+// should pass to apply.Run/statusinfo.Collect etc. so the same resolution
+// logic is never duplicated with drift (the guards in this file are only
+// as trustworthy as the one code path that feeds them).
+func openTarget(cfg *config.Config, targetName, urlOverride string) (eng engine.Engine, db *sql.DB, m *migrator.Migrator, url string, err error) {
+	url, err = cfg.ResolveURLOrFlag(targetName, urlOverride)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+	eng, err = engine.ForTarget(cfg.EngineName(targetName), url)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+	db, err = eng.Open(url)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+	m, err = migrator.Open(url, cfg.MigrationsDir)
+	if err != nil {
+		db.Close()
+		return nil, nil, nil, "", err
+	}
+	return eng, db, m, url, nil
+}
+
+// requireUnprotected refuses commands that mutate a protected target
+// (status/verify are read-only and allowed). protected is declared in
+// dbtools.toml as targets.<name>.protected = true — the config author's
+// explicit "this environment is not for routine writes" marker.
+func requireUnprotected(cfg *config.Config, targetName string) error {
+	t, ok := cfg.Targets[targetName]
+	if !ok {
+		return fmt.Errorf("unknown target %q", targetName)
+	}
+	if t.Protected {
+		return fmt.Errorf("target %q is protected (declared protected in dbtools.toml) — refusing to modify it; remove the protected flag to write", targetName)
+	}
+	return nil
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/dbtools/dbtools/internal/apply"
-	"github.com/dbtools/dbtools/internal/config"
 	"github.com/dbtools/dbtools/internal/engine"
 	"github.com/dbtools/dbtools/internal/statusinfo"
 	"github.com/spf13/cobra"
@@ -23,9 +22,12 @@ var pushCmd = &cobra.Command{
 }
 
 func runPush(targetName string) error {
-	cfg, err := config.Load("dbtools.toml")
+	cfg, err := loadConfig("dbtools.toml")
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+	if err := requireUnprotected(cfg, targetName); err != nil {
+		return err
 	}
 
 	url, err := cfg.ResolveURLOrFlag(targetName, pushURL)

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dbtools/dbtools/internal/config"
 	"github.com/dbtools/dbtools/internal/engine"
 	"github.com/dbtools/dbtools/internal/ledger"
 	"github.com/dbtools/dbtools/internal/migrator"
@@ -74,9 +73,12 @@ func parseRepairArgs(arg string) ([]repair.Pair, error) {
 }
 
 func runRepair(targetName string, pairs []repair.Pair) error {
-	cfg, err := config.Load("dbtools.toml")
+	cfg, err := loadConfig("dbtools.toml")
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+	if err := requireUnprotected(cfg, targetName); err != nil {
+		return err
 	}
 	url, err := cfg.ResolveURL(targetName)
 	if err != nil {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -23,15 +23,21 @@ var seedRun = seed.Run
 
 var resetLocalDatabase = recreateLocalDatabase
 
+var resetYes bool
+
 var resetCmd = &cobra.Command{
 	Use:   "reset",
 	Short: "Drop, recreate, replay migrations, and run seed.sql against the local database",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !resetYes {
+			return fmt.Errorf("refusing to drop and recreate the local database without --yes")
+		}
 		return runReset()
 	},
 }
 
 func init() {
+	resetCmd.Flags().BoolVar(&resetYes, "yes", false, "confirm the destructive drop/recreate of the local database")
 	rootCmd.AddCommand(resetCmd)
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,10 +19,12 @@ var statusCmd = &cobra.Command{
 	},
 }
 
+var statusTarget string
 var statusURL string
 
 func init() {
-	statusCmd.Flags().StringVar(&statusURL, "url", "", "connection string override for the single-target status check (status still iterates all targets; override applies only to the named --target)")
+	statusCmd.Flags().StringVar(&statusURL, "url", "", "connection string override (with --target: applies only to that named target; without it, ignored — status still iterates all targets)")
+	statusCmd.Flags().StringVar(&statusTarget, "target", "", "only show this target's status (otherwise every configured target)")
 	rootCmd.AddCommand(statusCmd)
 }
 
@@ -77,7 +79,16 @@ func buildStatusEntries(statuses []statusinfo.Status, failures []targetFailure) 
 func collectStatuses(cfg *config.Config) ([]statusinfo.Status, []targetFailure) {
 	var statuses []statusinfo.Status
 	var failures []targetFailure
-	for _, name := range cfg.TargetNames() {
+
+	// With --target, only that one target is checked, and --url applies
+	// to it alone. Without --target, --url is ignored (it would be wrong
+	// to apply one override to every target).
+	names := cfg.TargetNames()
+	if statusTarget != "" {
+		names = []string{statusTarget}
+	}
+
+	for _, name := range names {
 		url, err := cfg.ResolveURLOrFlag(name, statusURL)
 		if err != nil {
 			failures = append(failures, targetFailure{Target: name, Error: err.Error()})

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/dbtools/dbtools/internal/apply"
-	"github.com/dbtools/dbtools/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -13,13 +11,21 @@ var upURL string
 
 var upCmd = &cobra.Command{
 	Use:   "up",
-	Short: "Apply pending migrations to a target (defaults to 'local')",
+	Short: "Apply pending migrations to the local target",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load("dbtools.toml")
+		// up is the fast local dev loop. It deliberately refuses any
+		// non-local target: reaching a remote database requires the
+		// explicit `push <target> --yes` path with its preview + guard
+		// (the two commands share one apply.Run underneath, so there is
+		// no separate code path to drift).
+		if upTarget != "local" {
+			return fmt.Errorf("refusing to run `up` against %q — use `push %s --yes` for a remote target (it previews pending migrations first)", upTarget, upTarget)
+		}
+		cfg, err := loadConfig("dbtools.toml")
 		if err != nil {
 			return fmt.Errorf("loading dbtools.toml: %w", err)
 		}
-		status, err := apply.Run(cfg, upTarget, upURL)
+		status, err := applyRun(cfg, upTarget, upURL)
 		if err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,10 @@ type Target struct {
 	// must match that scheme (validated at engine resolution, see
 	// internal/engine.ForTarget).
 	Engine string `toml:"engine"`
+	// Protected marks a target as not-for-routine-writes: push/repair/
+	// reset refuse it unless the flag is removed. Verify/status (read-only)
+	// still work. The config author's explicit "this is prod, be careful".
+	Protected bool `toml:"protected"`
 }
 
 // GenerateConfig holds settings for pydantic model generation.


### PR DESCRIPTION
Fixes the review's **R5** — the copy-pasted ~25-line command preamble that let guards drift apart — and closes **C1/H1/H2/M5** together.

## What changed
- `config.Target` gains `protected = true` in dbtools.toml. `push` / `repair` refuse protected targets; `generate` requires `--yes` for them (was: literal `"prod"` name check). Read-only `status`/`verify` still work.
- `up` refuses any target but `local` — the old `up --target prod` silently did exactly what `push prod --yes` does, minus the preview and confirmation (C1). Remote writes now require the explicit push path.
- `status --url` applies only to the named `--target` (new flag). Without `--target`, `--url` is ignored instead of being applied to every target in the loop (H1).
- `reset` gains `--yes` (H3).
- Commands route through the `loadConfig`/`applyRun` test seams so the guards are unit-testable.

## Tests
- `TestUpRefusesNonLocalTarget` (guard fires before config resolution), `TestUpAllowsLocalTarget`, `TestPushRefusesProtectedTarget`, `TestRepairRefusesProtectedTarget`, `TestStatusURLScoping` (H1 regression).