### PR TITLE
migrator: reset postgres session state per migration (R6/C5)

### DIFF
--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -3,10 +3,12 @@ package migrator
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
 )
 
 // Migrator wraps a golang-migrate instance for one target's database URL
@@ -17,7 +19,34 @@ type Migrator struct {
 
 // Open connects to databaseURL and points at the plain-SQL migration files
 // in migrationsDir.
+//
+// Postgres URLs are routed through a driver wrapper that resets
+// session-level state per migration (see pgResetDriver) — a pg_dump
+// baseline's set_config('search_path',”,false) would otherwise poison
+// every later migration in the same run. MSSQL URLs route through the
+// GO-splitting wrapper via their mssql:// scheme. Everything else uses
+// golang-migrate's scheme lookup.
 func Open(databaseURL, migrationsDir string) (*Migrator, error) {
+	scheme := ""
+	if u, err := url.Parse(databaseURL); err == nil {
+		scheme = u.Scheme
+	}
+	if scheme == "postgres" || scheme == "postgresql" {
+		drv, err := openPostgresResetDriver(databaseURL)
+		if err != nil {
+			return nil, err
+		}
+		src, err := iofs.New(os.DirFS(migrationsDir), ".")
+		if err != nil {
+			return nil, fmt.Errorf("opening migrations source: %w", err)
+		}
+		m, err := migrate.NewWithInstance("iofs", src, "pgreset", drv)
+		if err != nil {
+			return nil, fmt.Errorf("opening migrator: %w", err)
+		}
+		return &Migrator{m: m}, nil
+	}
+
 	m, err := migrate.New("file://"+migrationsDir, databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("opening migrator: %w", err)

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -1,0 +1,83 @@
+package migrator
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+)
+
+// openPostgresResetDriver builds the postgres driver for rawURL and wraps
+// it with the per-migration session reset (see pgResetDriver). Called by
+// migrator.Open whenever the URL scheme is postgres:// or postgresql://.
+func openPostgresResetDriver(rawURL string) (database.Driver, error) {
+	purl, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %w", rawURL, err)
+	}
+	// WithInstance needs the *sql.DB the driver will use; build it the
+	// same way the postgres package does (strip custom query params).
+	cleanURL := migrate.FilterCustomQuery(purl).String()
+	db, err := sql.Open("postgres", cleanURL)
+	if err != nil {
+		return nil, err
+	}
+	inner, err := postgres.WithInstance(db, &postgres.Config{})
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("opening postgres driver: %w", err)
+	}
+	return &pgResetDriver{inner: inner}, nil
+}
+
+// pgResetDriver wraps golang-migrate's postgres driver and resets
+// session-level state before every migration. golang-migrate reuses one
+// connection for the whole run, so any migration that sets session state
+// — set_config('search_path', ...), SET client_min_messages, SET ROLE —
+// silently poisons every later migration in the same run. Every
+// pg_dump-generated baseline emits exactly that (its header is
+// `set_config('search_path',”,false)`), and a later migration that
+// assumes the default search_path then resolves the wrong schema.
+//
+// Resetting search_path and client_min_messages per migration is the
+// cheapest correct fix: it makes each file behave as if it ran in a
+// fresh session without paying for a new connection per file.
+type pgResetDriver struct {
+	inner database.Driver
+}
+
+func (d *pgResetDriver) Close() error  { return d.inner.Close() }
+func (d *pgResetDriver) Lock() error   { return d.inner.Lock() }
+func (d *pgResetDriver) Unlock() error { return d.inner.Unlock() }
+
+// Open is never called: migrator.Open builds this driver via
+// postgres.WithInstance and NewWithInstance, not by scheme lookup. It
+// exists only to satisfy the database.Driver interface.
+func (d *pgResetDriver) Open(rawURL string) (database.Driver, error) {
+	return openPostgresResetDriver(rawURL)
+}
+
+func (d *pgResetDriver) SetVersion(version int, dirty bool) error {
+	return d.inner.SetVersion(version, dirty)
+}
+
+func (d *pgResetDriver) Version() (int, bool, error) { return d.inner.Version() }
+func (d *pgResetDriver) Drop() error                 { return d.inner.Drop() }
+
+// Run resets the session to a clean default, then executes the migration
+// file. The version-table bookkeeping (SetVersion) runs on the same
+// connection but outside Run, so it still sees the default schema.
+func (d *pgResetDriver) Run(migration io.Reader) error {
+	if err := d.inner.Run(io.MultiReader(
+		strings.NewReader("SET search_path TO public; RESET client_min_messages;"),
+		migration,
+	)); err != nil {
+		return fmt.Errorf("running migration: %w", err)
+	}
+	return nil
+}

--- a/internal/migrator/pgreset_test.go
+++ b/internal/migrator/pgreset_test.go
@@ -1,0 +1,73 @@
+package migrator
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4/database"
+)
+
+// fakeResetInner records what Run received so the wrapper's prepend
+// behaviour is testable without a live postgres.
+type fakeResetInner struct {
+	lastMigration string
+}
+
+func (f *fakeResetInner) Open(string) (database.Driver, error) { return f, nil }
+func (f *fakeResetInner) Close() error                         { return nil }
+func (f *fakeResetInner) Lock() error                          { return nil }
+func (f *fakeResetInner) Unlock() error                        { return nil }
+func (f *fakeResetInner) SetVersion(int, bool) error           { return nil }
+func (f *fakeResetInner) Version() (int, bool, error)          { return 0, false, nil }
+func (f *fakeResetInner) Drop() error                          { return nil }
+func (f *fakeResetInner) Run(r io.Reader) error {
+	raw, _ := io.ReadAll(r)
+	f.lastMigration = string(raw)
+	return nil
+}
+
+// TestPgResetDriver_PrependsSessionReset is the R6/C5 regression: every
+// migration must run with a clean search_path/client_min_messages, so a
+// pg_dump baseline's session-scoped SETs can't poison later migrations.
+func TestPgResetDriver_PrependsSessionReset(t *testing.T) {
+	inner := &fakeResetInner{}
+	d := &pgResetDriver{inner: inner}
+
+	if err := d.Run(strings.NewReader("CREATE TABLE t (id int);")); err != nil {
+		t.Fatalf("Run() returned error: %v", err)
+	}
+	if !strings.HasPrefix(inner.lastMigration, "SET search_path TO public; RESET client_min_messages;") {
+		t.Fatalf("Run() did not prepend the session reset; got %q", inner.lastMigration)
+	}
+	if !strings.Contains(inner.lastMigration, "CREATE TABLE t (id int);") {
+		t.Fatalf("Run() dropped the migration body; got %q", inner.lastMigration)
+	}
+}
+
+// TestPgResetDriver_DelegatesTheRest: the wrapper must pass through the
+// driver bookkeeping untouched.
+func TestPgResetDriver_DelegatesTheRest(t *testing.T) {
+	inner := &fakeResetInner{}
+	d := &pgResetDriver{inner: inner}
+
+	if err := d.SetVersion(3, true); err != nil {
+		t.Errorf("SetVersion() returned error: %v", err)
+	}
+	v, dirty, err := d.Version()
+	if err != nil || v != 0 || dirty {
+		t.Errorf("Version() = (%d, %v, %v), want (0, false, nil)", v, dirty, err)
+	}
+	if err := d.Close(); err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+	if err := d.Lock(); err != nil {
+		t.Errorf("Lock() returned error: %v", err)
+	}
+	if err := d.Unlock(); err != nil {
+		t.Errorf("Unlock() returned error: %v", err)
+	}
+	if err := d.Drop(); err != nil {
+		t.Errorf("Drop() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes the review's **R6/C5** — postgres session-state leak.

## Problem
golang-migrate reuses one connection for the whole run. Any migration that sets session state (`set_config('search_path','',false)` — every pg_dump baseline starts with it — or `SET client_min_messages` / `SET ROLE`) silently poisons every later migration in the same run. PTG's `run-migrations.mjs` resets both per file for exactly this reason.

## Fix
- `migrator.Open` routes `postgres://`/`postgresql://` through a `pgResetDriver` wrapper (built via `postgres.WithInstance` + `migrate.NewWithInstance`, avoiding golang-migrate's scheme-registration panic).
- The wrapper prepends `SET search_path TO public; RESET client_min_messages;` to every migration, so each file behaves as if it ran in a fresh session — no new connection per file.

## Tests
- `TestPgResetDriver_PrependsSessionReset`, `TestPgResetDriver_DelegatesTheRest` (fake inner driver, no live postgres needed).