### PR TITLE
docs: renumber ADRs to start sequentially from 001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # db-tools
 
-`dbtools` is a standalone Go CLI (wrapping `golang-migrate`) providing a Supabase-CLI-style local dev loop and migration authority for MSSQL/Postgres/future engines. Not a business bounded context — a dev-tooling component living at `tools/db-tools/`. See `docs/adr/016-dbtools-migration-authority.md` for why it exists and what it replaces.
+`dbtools` is a standalone Go CLI (wrapping `golang-migrate`) providing a Supabase-CLI-style local dev loop and migration authority for MSSQL/Postgres/future engines. Not a business bounded context — a dev-tooling component living at `tools/db-tools/`. See `docs/adr/001-dbtools-migration-authority.md` for why it exists and what it replaces.
 
 ## Language
 
@@ -13,8 +13,8 @@ Applying migrations not yet recorded in a target's version table (version-sync).
 _Avoid_: sync, deploy, schema sync
 
 **version-sync**:
-The guarantee `up`/`push` provide: a target's recorded migration history matches local migration files up to the latest one applied. Distinct from full schema-sync (verifying every column/type/constraint of live DB structure matches expectations), which `dbtools` still does not implement — that would require per-engine live-schema introspection and diffing, ruled out as a dialect-abstraction cost too large for this tool. `verify`/`repair` (see `docs/adr/021-dbtools-migration-ledger-and-drift-detection.md`) check a much narrower thing — whether the named objects a migration's DDL creates actually exist — which is not the same as schema-sync.
-_Avoid_: "in sync" (always qualify — ambiguous on its own), calling `verify` full schema-sync (it isn't — see ADR-021)
+The guarantee `up`/`push` provide: a target's recorded migration history matches local migration files up to the latest one applied. Distinct from full schema-sync (verifying every column/type/constraint of live DB structure matches expectations), which `dbtools` still does not implement — that would require per-engine live-schema introspection and diffing, ruled out as a dialect-abstraction cost too large for this tool. `verify`/`repair` (see `docs/adr/002-dbtools-migration-ledger-and-drift-detection.md`) check a much narrower thing — whether the named objects a migration's DDL creates actually exist — which is not the same as schema-sync.
+_Avoid_: "in sync" (always qualify — ambiguous on its own), calling `verify` full schema-sync (it isn't — see ADR-002)
 
 **reset**:
 Local-only operation: drop the ephemeral local database, recreate it, replay every migration from the start, then run `seed.sql` if present.

--- a/docs/adr/001-dbtools-migration-authority.md
+++ b/docs/adr/001-dbtools-migration-authority.md
@@ -1,4 +1,4 @@
-# ADR 016: dbtools as Migration Authority and Local Dev-Loop
+# ADR 001: dbtools as Migration Authority and Local Dev-Loop
 
 ## Status
 Accepted

--- a/docs/adr/002-dbtools-migration-ledger-and-drift-detection.md
+++ b/docs/adr/002-dbtools-migration-ledger-and-drift-detection.md
@@ -1,4 +1,4 @@
-# ADR 021: Migration Ledger Tracking and Read-Only Drift Detection
+# ADR 002: Migration Ledger Tracking and Read-Only Drift Detection
 
 ## Status
 Accepted

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,6 +104,7 @@
 
     .brand-badge {
       background: var(--gradient-accent);
+      background-clip: text;
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
@@ -186,6 +187,7 @@
 
     .highlight {
       background: var(--gradient-accent);
+      background-clip: text;
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
@@ -438,7 +440,7 @@
           <a href="#features">Features</a>
           <a href="#demo">Preview</a>
           <a href="#commands">Commands</a>
-          <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/016-dbtools-migration-authority.md">ADRs</a>
+          <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/001-dbtools-migration-authority.md">ADRs</a>
           <a href="https://github.com/seanpham99/dbtools" class="btn-github" target="_blank" rel="noopener noreferrer">
             <svg height="18" width="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
             GitHub
@@ -617,8 +619,8 @@ Target: local
       <div style="margin-top: 14px;">
         <a href="https://github.com/seanpham99/dbtools">GitHub Repository</a>
         <a href="https://github.com/seanpham99/dbtools/releases">Releases</a>
-        <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/016-dbtools-migration-authority.md">ADR-016</a>
-        <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/021-dbtools-migration-ledger-and-drift-detection.md">ADR-021</a>
+        <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/001-dbtools-migration-authority.md">ADR-001</a>
+        <a href="https://github.com/seanpham99/dbtools/blob/main/docs/adr/002-dbtools-migration-ledger-and-drift-detection.md">ADR-002</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- Renumbers ADRs to start from 001:
  - `016-dbtools-migration-authority.md` -> `001-dbtools-migration-authority.md`
  - `021-dbtools-migration-ledger-and-drift-detection.md` -> `002-dbtools-migration-ledger-and-drift-detection.md`
- Updates internal ADR header numbering.
- Updates references and hyperlinks in `CONTEXT.md` and `docs/index.html`.