### PR TITLE
feat(lint): add dbtools lint command for static migration directory validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ dbtools status
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |
 | `reset` | `dbtools reset [--target local] [--yes]` | Local-only: drops database, replays all migrations from zero, and executes `seed.sql`. |
 | `generate` | `dbtools generate [target] [--out models.py]` | Introspects live schema and renders Pydantic v2 Python models. |
+| `lint` | `dbtools lint [--dir <path>] [--json]` | Validates filenames, duplicate versions, and empty files without database connection. |
 | `dashboard` | `dbtools dashboard` | Opens terminal UI showing live target status (`r` to refresh, `q` to quit). |
 | `start` / `stop` | `dbtools start` / `stop` | Starts or stops ephemeral tool-owned local MSSQL Docker container. |
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/migrator"
+	"github.com/spf13/cobra"
+)
+
+var (
+	lintDirFlag  string
+	lintJSONFlag bool
+)
+
+var lintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Validate migration filenames, version numbers, and file hygiene",
+	Long:  "Statically checks migration files for duplicate version prefixes, invalid filename patterns, and empty files without connecting to a database.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := lintDirFlag
+		if dir == "" {
+			cfg, err := config.Load("dbtools.toml")
+			if err != nil {
+				// Fallback to default "migrations" if dbtools.toml is absent
+				dir = "migrations"
+			} else {
+				dir = cfg.MigrationsDir
+			}
+		}
+
+		report, err := migrator.Lint(dir)
+		if err != nil {
+			return err
+		}
+
+		if lintJSONFlag {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(report); err != nil {
+				return err
+			}
+		} else {
+			if !report.HasErrors() {
+				fmt.Printf("✓ %d migration files in %q checked, 0 issues found.\n", report.Total, dir)
+			} else {
+				fmt.Fprintf(os.Stderr, "Found %d issue(s) in %q:\n\n", len(report.Findings), dir)
+				for _, f := range report.Findings {
+					fmt.Fprintf(os.Stderr, "  • [%s] %s: %s\n", f.Rule, f.File, f.Message)
+				}
+			}
+		}
+
+		if report.HasErrors() {
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func init() {
+	lintCmd.Flags().StringVar(&lintDirFlag, "dir", "", "Path to migrations directory (defaults to migrations_dir from dbtools.toml)")
+	lintCmd.Flags().BoolVar(&lintJSONFlag, "json", false, "Output results in JSON format")
+	rootCmd.AddCommand(lintCmd)
+}

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+func TestLint_Integration(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "20260101000000_init.up.sql"), []byte("CREATE TABLE test (id INT);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "20260102000000_update.up.sql"), []byte("ALTER TABLE test ADD col INT;"), 0o644)
+
+	report, err := migrator.Lint(dir)
+	if err != nil {
+		t.Fatalf("migrator.Lint() returned error: %v", err)
+	}
+	if report.HasErrors() {
+		t.Errorf("expected no errors, got %+v", report.Findings)
+	}
+	if report.Total != 2 {
+		t.Errorf("expected 2 files checked, got %d", report.Total)
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -603,6 +603,11 @@ Target: local
               <td>Introspects schema and outputs typed Pydantic Python models.</td>
             </tr>
             <tr>
+              <td><code>lint</code></td>
+              <td><code>dbtools lint [--dir &lt;path&gt;] [--json]</code></td>
+              <td>Statically validates filename formatting, duplicate version numbers, and file hygiene.</td>
+            </tr>
+            <tr>
               <td><code>dashboard</code></td>
               <td><code>dbtools dashboard</code></td>
               <td>Interactive Bubble Tea TUI monitor (<code>r</code> to refresh, <code>q</code> to quit).</td>

--- a/internal/migrator/lint.go
+++ b/internal/migrator/lint.go
@@ -1,0 +1,117 @@
+package migrator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// LintFinding represents a single issue discovered in a migration directory.
+type LintFinding struct {
+	File    string
+	Rule    string
+	Message string
+}
+
+// LintReport contains all findings across the inspected migration files.
+type LintReport struct {
+	Dir      string
+	Findings []LintFinding
+	Total    int
+}
+
+// HasErrors returns true if any lint findings were discovered.
+func (r *LintReport) HasErrors() bool {
+	return len(r.Findings) > 0
+}
+
+var (
+	validMigrationFilenamePattern = regexp.MustCompile(`^(\d+)_([a-zA-Z0-9_-]+)\.(up|down)\.sql$`)
+)
+
+// Lint scans migrationsDir and validates that:
+// 1. All migration filenames follow `{version}_{name}.up.sql` (or `.down.sql`).
+// 2. No two files share the exact same version number prefix (duplicate versions).
+// 3. Migration files are not empty.
+func Lint(migrationsDir string) (*LintReport, error) {
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("migrations directory %q does not exist", migrationsDir)
+		}
+		return nil, fmt.Errorf("reading migrations directory %q: %w", migrationsDir, err)
+	}
+
+	report := &LintReport{Dir: migrationsDir}
+	versionToUpFiles := make(map[uint64][]string)
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") || strings.EqualFold(name, "README.md") {
+			continue
+		}
+
+		report.Total++
+		match := validMigrationFilenamePattern.FindStringSubmatch(name)
+		if match == nil {
+			report.Findings = append(report.Findings, LintFinding{
+				File:    name,
+				Rule:    "invalid-filename-format",
+				Message: "filename must match '{timestamp}_{name}.up.sql' or '{timestamp}_{name}.down.sql'",
+			})
+			continue
+		}
+
+		verStr := match[1]
+		kind := match[3]
+
+		ver, err := strconv.ParseUint(verStr, 10, 64)
+		if err != nil {
+			report.Findings = append(report.Findings, LintFinding{
+				File:    name,
+				Rule:    "invalid-version-number",
+				Message: fmt.Sprintf("cannot parse version number %q: %v", verStr, err),
+			})
+			continue
+		}
+
+		if kind == "up" {
+			versionToUpFiles[ver] = append(versionToUpFiles[ver], name)
+		}
+
+		fullPath := filepath.Join(migrationsDir, name)
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading file %s: %w", name, err)
+		}
+
+		trimmed := strings.TrimSpace(string(content))
+		if len(trimmed) == 0 {
+			report.Findings = append(report.Findings, LintFinding{
+				File:    name,
+				Rule:    "empty-migration-file",
+				Message: "migration file is empty",
+			})
+		}
+	}
+
+	for ver, files := range versionToUpFiles {
+		if len(files) > 1 {
+			for _, f := range files {
+				report.Findings = append(report.Findings, LintFinding{
+					File:    f,
+					Rule:    "duplicate-version-number",
+					Message: fmt.Sprintf("version %d is duplicated across multiple files: %s", ver, strings.Join(files, ", ")),
+				})
+			}
+		}
+	}
+
+	return report, nil
+}

--- a/internal/migrator/lint_test.go
+++ b/internal/migrator/lint_test.go
@@ -1,0 +1,64 @@
+package migrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLint_CleanDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "20260101000000_create_users.up.sql"), []byte("CREATE TABLE users (id INT);"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "20260102000000_add_orders.up.sql"), []byte("CREATE TABLE orders (id INT);"), 0o644)
+	os.WriteFile(filepath.Join(tmp, ".gitkeep"), []byte(""), 0o644)
+	os.WriteFile(filepath.Join(tmp, "README.md"), []byte("Migrations notes"), 0o644)
+
+	report, err := Lint(tmp)
+	if err != nil {
+		t.Fatalf("Lint() error: %v", err)
+	}
+	if report.HasErrors() {
+		t.Errorf("Lint() findings = %+v, want none", report.Findings)
+	}
+	if report.Total != 2 {
+		t.Errorf("Lint() total = %d, want 2", report.Total)
+	}
+}
+
+func TestLint_DuplicateVersions(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "20260820100002_rebuild_trading.up.sql"), []byte("SELECT 1;"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "20260820100002_add_indexes.up.sql"), []byte("SELECT 2;"), 0o644)
+
+	report, err := Lint(tmp)
+	if err != nil {
+		t.Fatalf("Lint() error: %v", err)
+	}
+	if !report.HasErrors() {
+		t.Fatal("Lint() expected errors for duplicate versions, got none")
+	}
+
+	foundDup := false
+	for _, f := range report.Findings {
+		if f.Rule == "duplicate-version-number" {
+			foundDup = true
+		}
+	}
+	if !foundDup {
+		t.Errorf("Lint() findings = %+v, want duplicate-version-number", report.Findings)
+	}
+}
+
+func TestLint_InvalidNamesAndEmptyFiles(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "invalid_no_version.sql"), []byte("SELECT 1;"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "20260101000000_empty.up.sql"), []byte("   \n\t  "), 0o644)
+
+	report, err := Lint(tmp)
+	if err != nil {
+		t.Fatalf("Lint() error: %v", err)
+	}
+	if len(report.Findings) != 2 {
+		t.Fatalf("Lint() findings count = %d, want 2 (%+v)", len(report.Findings), report.Findings)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `dbtools lint` subcommand to validate migration directories without database connections.
- Statically detects duplicate version prefixes, invalid filename patterns, and empty migration files.
- Supports `--dir <path>` to inspect custom folders and `--json` for CI integrations.
- Returns non-zero exit code on lint errors with descriptive actionable findings.