### PR TITLE
ci(release): add GoReleaser multi-platform binary release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+version: 2
+
+project_name: dbtools
+
+builds:
+  - id: dbtools
+    main: .
+    binary: dbtools
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/seanpham99/dbtools/cmd.version={{.Version}} -X github.com/seanpham99/dbtools/cmd.commit={{.Commit}} -X github.com/seanpham99/dbtools/cmd.date={{.Date}}
+
+archives:
+  - id: default
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE
+      - CHANGELOG.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print dbtools version and build information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("dbtools version %s (commit: %s, date: %s)\n", version, commit, date)
+	},
+}
+
+func init() {
+	rootCmd.Version = version
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestVersionCommand(t *testing.T) {
+	if versionCmd == nil {
+		t.Fatal("expected versionCmd to be defined")
+	}
+	if versionCmd.Use != "version" {
+		t.Errorf("versionCmd.Use = %q, want %q", versionCmd.Use, "version")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `.goreleaser.yaml` to build cross-platform binaries (Linux amd64/arm64, macOS amd64/arm64, Windows amd64).
- Adds `.github/workflows/release.yml` to automatically build, package, checksum, and attach binary releases on tag push (`v*`).
- Adds `dbtools version` subcommand and build ldflags metadata.