### PR TITLE
feat: add down migrations and ledger-only rollback commands with production gates

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/seanpham99/dbtools/internal/down"
+	"github.com/spf13/cobra"
+)
+
+var (
+	downYes     bool
+	downPreview bool
+	downURL     string
+)
+
+var downCmd = &cobra.Command{
+	Use:   "down <target> [N]",
+	Short: "Revert the last N applied migrations (default 1) using .down.sql files",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		targetName := args[0]
+		steps := 1
+		if len(args) == 2 {
+			n, err := strconv.Atoi(args[1])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("invalid step count %q: must be a positive integer", args[1])
+			}
+			steps = n
+		}
+		return runDown(targetName, steps)
+	},
+}
+
+func init() {
+	downCmd.Flags().BoolVarP(&downYes, "yes", "y", false, "confirm applying down migrations")
+	downCmd.Flags().BoolVar(&downPreview, "preview", false, "preview down migrations that would be executed without applying them")
+	downCmd.Flags().StringVar(&downURL, "url", "", "connection string override")
+	rootCmd.AddCommand(downCmd)
+}
+
+func runDown(targetName string, steps int) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+
+	target, ok := cfg.Targets[targetName]
+	if !ok {
+		return fmt.Errorf("unknown target %q", targetName)
+	}
+
+	plan, err := down.Preview(cfg, targetName, steps, downURL)
+	if err != nil {
+		return err
+	}
+
+	if len(plan) == 0 {
+		fmt.Printf("%s: no applied migrations to revert\n", targetName)
+		return nil
+	}
+
+	if downPreview {
+		fmt.Printf("%s: %d down migration(s) would be executed:\n", targetName, len(plan))
+		for _, f := range plan {
+			fmt.Printf("  %s\n", f.Filename)
+		}
+		return nil
+	}
+
+	if target.Protected {
+		fmt.Printf("%s: [PROTECTED TARGET] %d down migration(s) will be executed:\n", targetName, len(plan))
+		for _, f := range plan {
+			fmt.Printf("  %s\n", f.Filename)
+		}
+		if !downYes {
+			return fmt.Errorf("target %q is protected — refusing to run destructive down migrations without --yes", targetName)
+		}
+	}
+
+	res, err := down.Run(cfg, targetName, steps, downURL)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s: reverted %d migration(s)\n", targetName, len(res.RevertedVersions))
+	for _, v := range res.RevertedVersions {
+		fmt.Printf("  reverted v%d\n", v)
+	}
+	if res.HasVersion {
+		fmt.Printf("%s: now at version %d\n", targetName, res.CurrentVersion)
+	} else {
+		fmt.Printf("%s: no migrations remaining (version 0)\n", targetName)
+	}
+	return nil
+}

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+)
+
+func TestDownCmd_ArgumentValidation(t *testing.T) {
+	err := downCmd.RunE(downCmd, []string{"local", "invalid-number"})
+	if err == nil {
+		t.Fatal("expected error for invalid step number, got nil")
+	}
+}
+
+func TestDownCmd_ProtectedTargetRefusesWithoutYes(t *testing.T) {
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join("migrations", "20260101000000_init.up.sql"), []byte("CREATE TABLE test (id INT);"), 0o644)
+	os.WriteFile(filepath.Join("migrations", "20260101000000_init.down.sql"), []byte("DROP TABLE test;"), 0o644)
+
+	dbURL := "sqlite://" + filepath.Join(dir, "prod.db")
+	t.Setenv("DBTOOLS_PROD_URL", dbURL)
+
+	configContent := `migrations_dir = "migrations"
+
+[targets.prod]
+url_env = "DBTOOLS_PROD_URL"
+protected = true
+`
+	if err := os.WriteFile("dbtools.toml", []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load("dbtools.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migration first
+	if _, err := apply.Run(cfg, "prod", ""); err != nil {
+		t.Fatalf("apply.Run() failed: %v", err)
+	}
+
+	// Try down without --yes
+	downYes = false
+	downPreview = false
+	err = downCmd.RunE(downCmd, []string{"prod", "1"})
+	if err == nil {
+		t.Fatal("expected error when down on protected target without --yes, got nil")
+	}
+}

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/seanpham99/dbtools/internal/rollback"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rollbackYes bool
+	rollbackURL string
+)
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback <target> [N]",
+	Short: "Soft-revert the last N applied migrations in the ledger (metadata-only, safe for production)",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		targetName := args[0]
+		steps := 1
+		if len(args) == 2 {
+			n, err := strconv.Atoi(args[1])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("invalid step count %q: must be a positive integer", args[1])
+			}
+			steps = n
+		}
+		return runRollback(targetName, steps)
+	},
+}
+
+func init() {
+	rollbackCmd.Flags().BoolVarP(&rollbackYes, "yes", "y", false, "confirm soft-reverting migrations in the ledger")
+	rollbackCmd.Flags().StringVar(&rollbackURL, "url", "", "connection string override")
+	rootCmd.AddCommand(rollbackCmd)
+}
+
+func runRollback(targetName string, steps int) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+
+	target, ok := cfg.Targets[targetName]
+	if !ok {
+		return fmt.Errorf("unknown target %q", targetName)
+	}
+
+	if target.Protected && !rollbackYes {
+		return fmt.Errorf("target %q is protected — refusing to soft-revert ledger status without --yes", targetName)
+	}
+
+	res, err := rollback.Run(cfg, targetName, steps, rollbackURL)
+	if err != nil {
+		return err
+	}
+
+	if len(res.RevertedVersions) == 0 {
+		fmt.Printf("%s: no applied migrations to soft-revert\n", targetName)
+		return nil
+	}
+
+	fmt.Printf("%s: soft-reverted %d migration(s) in ledger (no tables dropped)\n", targetName, len(res.RevertedVersions))
+	for _, v := range res.RevertedVersions {
+		fmt.Printf("  marked v%d reverted\n", v)
+	}
+	if res.HasCursor {
+		fmt.Printf("%s: cursor recomputed to version %d\n", targetName, res.NewCursor)
+	} else {
+		fmt.Printf("%s: no applied migrations remaining\n", targetName)
+	}
+	return nil
+}

--- a/cmd/rollback_test.go
+++ b/cmd/rollback_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRollbackCmd_ArgumentValidation(t *testing.T) {
+	err := rollbackCmd.RunE(rollbackCmd, []string{"local", "invalid-number"})
+	if err == nil {
+		t.Fatal("expected error for invalid step number, got nil")
+	}
+}
+
+func TestRollbackCmd_ProtectedTargetRefusesWithoutYes(t *testing.T) {
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join("migrations", "20260101000000_init.up.sql"), []byte("CREATE TABLE test (id INT);"), 0o644)
+
+	dbURL := "sqlite://" + filepath.Join(dir, "prod.db")
+	t.Setenv("DBTOOLS_PROD_URL", dbURL)
+
+	configContent := `migrations_dir = "migrations"
+
+[targets.prod]
+url_env = "DBTOOLS_PROD_URL"
+protected = true
+`
+	if err := os.WriteFile("dbtools.toml", []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rollbackYes = false
+	rollbackURL = ""
+	err = rollbackCmd.RunE(rollbackCmd, []string{"prod", "1"})
+	if err == nil {
+		t.Fatal("expected error when rollback on protected target without --yes, got nil")
+	}
+}

--- a/cmd/sqlite_loop_test.go
+++ b/cmd/sqlite_loop_test.go
@@ -130,6 +130,37 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 		t.Fatalf("Introspect() tables = %+v, want just users", tables)
 	}
 
+	// down: revert migration 20260817000001
+	downYes = true
+	downPreview = false
+	downURL = ""
+	if err := runDown("local", 1); err != nil {
+		t.Fatalf("runDown() returned error: %v", err)
+	}
+
+	// verify: after down, table is gone and ledger records reverted (not drift)
+	report, err = verify.Collect(db2, eng, "migrations", "local")
+	if err != nil {
+		t.Fatalf("verify.Collect() after down returned error: %v", err)
+	}
+	for _, e := range report.Entries {
+		if e.Status != "OK" {
+			t.Errorf("verify entry %d after down = %s (%s), want OK", e.Version, e.Status, e.Detail)
+		}
+	}
+
+	// re-apply up for rollback test
+	if _, err := apply.Run(cfg, "local", ""); err != nil {
+		t.Fatalf("apply.Run() failed: %v", err)
+	}
+
+	// rollback: soft-revert in ledger without dropping table
+	rollbackYes = true
+	rollbackURL = ""
+	if err := runRollback("local", 1); err != nil {
+		t.Fatalf("runRollback() returned error: %v", err)
+	}
+
 	// start/stop are graceful no-ops
 	if err := runStart(); err != nil {
 		t.Errorf("runStart() returned error: %v", err)

--- a/internal/down/down.go
+++ b/internal/down/down.go
@@ -1,0 +1,155 @@
+package down
+
+import (
+	"fmt"
+
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/engine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+// Result summarizes what down.Run executed.
+type Result struct {
+	Target           string   `json:"target"`
+	RevertedVersions []uint64 `json:"reverted_versions"`
+	CurrentVersion   uint64   `json:"current_version"`
+	HasVersion       bool     `json:"has_version"`
+}
+
+// Preview returns the list of down migration files that would be executed for targetName
+// without modifying the database or ledger.
+func Preview(cfg *config.Config, targetName string, steps int, urlOverride string) ([]migrator.File, error) {
+	url, err := cfg.ResolveURLOrFlag(targetName, urlOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	m, err := migrator.Open(url, cfg.MigrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	defer m.Close()
+
+	db, err := eng.Open(url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+	defer db.Close()
+
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	applied, err := eng.Ledger().AppliedVersions(db)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	return dir.DownPlan(applied, steps)
+}
+
+// Run executes down migrations for targetName in reverse order up to steps count.
+// Each reverted version is recorded in the ledger with its .down.sql content hash.
+func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (*Result, error) {
+	url, err := cfg.ResolveURLOrFlag(targetName, urlOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	m, err := migrator.Open(url, cfg.MigrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	defer m.Close()
+
+	db, err := eng.Open(url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+	defer db.Close()
+
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	versionBefore, dirty, _, err := m.Version()
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+	if dirty {
+		return nil, fmt.Errorf("target %q: migration cursor is dirty at version %d; run `dbtools repair %s` to resolve it", targetName, versionBefore, targetName)
+	}
+
+	applied, err := eng.Ledger().AppliedVersions(db)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	if len(applied) == 0 {
+		return &Result{
+			Target:           targetName,
+			RevertedVersions: nil,
+			CurrentVersion:   0,
+			HasVersion:       false,
+		}, nil
+	}
+
+	plan, err := dir.DownPlan(applied, steps)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	reverted := make([]uint64, 0, len(plan))
+	for _, f := range plan {
+		stepDone, err := m.StepDown()
+		if err != nil {
+			return nil, fmt.Errorf("target %q: reverting version %d (%s): %w", targetName, f.Version, f.Filename, err)
+		}
+		if !stepDone {
+			break
+		}
+
+		hash, err := dir.DownContentHash(f.Version)
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+
+		if err := eng.Ledger().SetStatusWithHash(db, f.Version, ledger.StatusReverted, "reverted via down", hash); err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
+		reverted = append(reverted, f.Version)
+	}
+
+	curVer, _, hasVer, err := m.Version()
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	return &Result{
+		Target:           targetName,
+		RevertedVersions: reverted,
+		CurrentVersion:   curVer,
+		HasVersion:       hasVer,
+	}, nil
+}

--- a/internal/down/down_test.go
+++ b/internal/down/down_test.go
@@ -1,0 +1,73 @@
+package down
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	_ "github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+)
+
+func TestDown_Run(t *testing.T) {
+	tmpDir := t.TempDir()
+	migDir := filepath.Join(tmpDir, "migrations")
+	if err := os.MkdirAll(migDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 migrations with up and down
+	os.WriteFile(filepath.Join(migDir, "20260101000000_create_users.up.sql"), []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(migDir, "20260101000000_create_users.down.sql"), []byte("DROP TABLE users;"), 0o644)
+	os.WriteFile(filepath.Join(migDir, "20260102000000_create_orders.up.sql"), []byte("CREATE TABLE orders (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(migDir, "20260102000000_create_orders.down.sql"), []byte("DROP TABLE orders;"), 0o644)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	t.Setenv("DBTOOLS_TEST_DOWN_URL", "sqlite://"+dbPath)
+
+	cfg := &config.Config{
+		MigrationsDir: migDir,
+		Targets: map[string]config.Target{
+			"local": {URLEnv: "DBTOOLS_TEST_DOWN_URL"},
+		},
+	}
+
+	// Up both
+	if _, err := apply.Run(cfg, "local", ""); err != nil {
+		t.Fatalf("apply.Run() failed: %v", err)
+	}
+
+	// Preview 1 step down
+	plan, err := Preview(cfg, "local", 1, "")
+	if err != nil {
+		t.Fatalf("Preview() failed: %v", err)
+	}
+	if len(plan) != 1 || plan[0].Version != 20260102000000 {
+		t.Fatalf("Preview() = %+v, want [20260102000000]", plan)
+	}
+
+	// Down 1 step
+	res, err := Run(cfg, "local", 1, "")
+	if err != nil {
+		t.Fatalf("Run() down 1 step failed: %v", err)
+	}
+	if len(res.RevertedVersions) != 1 || res.RevertedVersions[0] != 20260102000000 {
+		t.Errorf("RevertedVersions = %v, want [20260102000000]", res.RevertedVersions)
+	}
+	if !res.HasVersion || res.CurrentVersion != 20260101000000 {
+		t.Errorf("CurrentVersion = %d (hasVersion=%v), want 20260101000000", res.CurrentVersion, res.HasVersion)
+	}
+
+	// Down remaining step
+	res2, err := Run(cfg, "local", 1, "")
+	if err != nil {
+		t.Fatalf("Run() down remaining failed: %v", err)
+	}
+	if len(res2.RevertedVersions) != 1 || res2.RevertedVersions[0] != 20260101000000 {
+		t.Errorf("RevertedVersions = %v, want [20260101000000]", res2.RevertedVersions)
+	}
+	if res2.HasVersion {
+		t.Errorf("HasVersion = true, want false after reverting all migrations")
+	}
+}

--- a/internal/migrator/dir.go
+++ b/internal/migrator/dir.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	validUpFilenamePattern = regexp.MustCompile(`^(\d+)_.+\.up\.sql$`)
+	validUpFilenamePattern   = regexp.MustCompile(`^(\d+)_.+\.up\.sql$`)
+	validDownFilenamePattern = regexp.MustCompile(`^(\d+)_.+\.down\.sql$`)
 )
 
 // File represents one plain-SQL migration file on disk.
@@ -26,59 +27,80 @@ type File struct {
 
 // Dir is an in-memory indexed view of a local migrations directory.
 type Dir struct {
-	path      string
-	upFiles   []File
-	byVersion map[uint64]File
+	path          string
+	upFiles       []File
+	downFiles     []File
+	byVersion     map[uint64]File
+	byVersionDown map[uint64]File
 }
 
 // ReadDir scans migrationsDir, parses version numbers, sorts ascending, and indexes
-// all *.up.sql migration files in memory.
+// all *.up.sql and *.down.sql migration files in memory.
 func ReadDir(migrationsDir string) (*Dir, error) {
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &Dir{
-				path:      migrationsDir,
-				upFiles:   nil,
-				byVersion: make(map[uint64]File),
+				path:          migrationsDir,
+				upFiles:       nil,
+				downFiles:     nil,
+				byVersion:     make(map[uint64]File),
+				byVersionDown: make(map[uint64]File),
 			}, nil
 		}
 		return nil, fmt.Errorf("reading migrations dir %q: %w", migrationsDir, err)
 	}
 
 	var upFiles []File
+	var downFiles []File
 	byVersion := make(map[uint64]File)
+	byVersionDown := make(map[uint64]File)
 
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		name := e.Name()
-		m := validUpFilenamePattern.FindStringSubmatch(name)
-		if m == nil {
-			continue
+		if m := validUpFilenamePattern.FindStringSubmatch(name); m != nil {
+			ver, err := strconv.ParseUint(m[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			f := File{
+				Version:  ver,
+				Filename: name,
+				Path:     filepath.Join(migrationsDir, name),
+			}
+			upFiles = append(upFiles, f)
+			byVersion[ver] = f
+		} else if m := validDownFilenamePattern.FindStringSubmatch(name); m != nil {
+			ver, err := strconv.ParseUint(m[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			f := File{
+				Version:  ver,
+				Filename: name,
+				Path:     filepath.Join(migrationsDir, name),
+			}
+			downFiles = append(downFiles, f)
+			byVersionDown[ver] = f
 		}
-		ver, err := strconv.ParseUint(m[1], 10, 64)
-		if err != nil {
-			continue
-		}
-		f := File{
-			Version:  ver,
-			Filename: name,
-			Path:     filepath.Join(migrationsDir, name),
-		}
-		upFiles = append(upFiles, f)
-		byVersion[ver] = f
 	}
 
 	sort.Slice(upFiles, func(i, j int) bool {
 		return upFiles[i].Version < upFiles[j].Version
 	})
+	sort.Slice(downFiles, func(i, j int) bool {
+		return downFiles[i].Version < downFiles[j].Version
+	})
 
 	return &Dir{
-		path:      migrationsDir,
-		upFiles:   upFiles,
-		byVersion: byVersion,
+		path:          migrationsDir,
+		upFiles:       upFiles,
+		downFiles:     downFiles,
+		byVersion:     byVersion,
+		byVersionDown: byVersionDown,
 	}, nil
 }
 
@@ -89,7 +111,14 @@ func (d *Dir) List() []File {
 	return result
 }
 
-// ListVersions returns every migration version in ascending order.
+// ListDown returns every *.down.sql migration file in ascending order.
+func (d *Dir) ListDown() []File {
+	result := make([]File, len(d.downFiles))
+	copy(result, d.downFiles)
+	return result
+}
+
+// ListVersions returns every up migration version in ascending order.
 func (d *Dir) ListVersions() []uint64 {
 	versions := make([]uint64, len(d.upFiles))
 	for i, f := range d.upFiles {
@@ -98,12 +127,20 @@ func (d *Dir) ListVersions() []uint64 {
 	return versions
 }
 
-// Find returns the File matching version, or an error if not found.
+// Find returns the *.up.sql File matching version, or an error if not found.
 func (d *Dir) Find(version uint64) (File, error) {
 	if f, ok := d.byVersion[version]; ok {
 		return f, nil
 	}
 	return File{}, fmt.Errorf("version %d does not match any migration file in %s", version, d.path)
+}
+
+// FindDown returns the *.down.sql File matching version, or an error if not found.
+func (d *Dir) FindDown(version uint64) (File, error) {
+	if f, ok := d.byVersionDown[version]; ok {
+		return f, nil
+	}
+	return File{}, fmt.Errorf("version %d does not have a matching .down.sql migration file in %s", version, d.path)
 }
 
 // PendingAfter returns the files for every migration whose version is greater than
@@ -136,6 +173,32 @@ func (d *Dir) PendingVersions(currentVersion uint64, hasVersion bool) []uint64 {
 		versions[i] = f.Version
 	}
 	return versions
+}
+
+// DownPlan returns the list of down migration files to apply in reverse order (newest first)
+// for the given applied versions (which are in ascending order), up to steps count.
+// If steps <= 0 or steps >= len(appliedVersions), all applied versions are planned.
+func (d *Dir) DownPlan(appliedVersions []uint64, steps int) ([]File, error) {
+	if len(appliedVersions) == 0 {
+		return nil, nil
+	}
+
+	count := steps
+	if count <= 0 || count > len(appliedVersions) {
+		count = len(appliedVersions)
+	}
+
+	plan := make([]File, 0, count)
+	// Iterate backwards from the latest applied version
+	for i := len(appliedVersions) - 1; i >= len(appliedVersions)-count; i-- {
+		ver := appliedVersions[i]
+		downFile, err := d.FindDown(ver)
+		if err != nil {
+			return nil, err
+		}
+		plan = append(plan, downFile)
+	}
+	return plan, nil
 }
 
 // NextVersion computes max(clock_version, max_existing_version + 1), ensuring
@@ -178,6 +241,20 @@ func (d *Dir) ContentHash(version uint64) (string, error) {
 	data, err := os.ReadFile(f.Path)
 	if err != nil {
 		return "", fmt.Errorf("reading migration file %s: %w", f.Filename, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// DownContentHash computes the SHA-256 hex string of version's *.down.sql file.
+func (d *Dir) DownContentHash(version uint64) (string, error) {
+	f, err := d.FindDown(version)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(f.Path)
+	if err != nil {
+		return "", fmt.Errorf("reading down migration file %s: %w", f.Filename, err)
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil

--- a/internal/migrator/dir_test.go
+++ b/internal/migrator/dir_test.go
@@ -57,6 +57,69 @@ func TestReadDir(t *testing.T) {
 	if len(hash) != 64 {
 		t.Errorf("d.ContentHash() = %q, want 64-char hex string", hash)
 	}
+
+	// Down file checks
+	downFiles := d.ListDown()
+	if len(downFiles) != 1 {
+		t.Fatalf("d.ListDown() returned %d files, want 1", len(downFiles))
+	}
+	if downFiles[0].Version != 20260101000000 {
+		t.Errorf("down file version = %d, want 20260101000000", downFiles[0].Version)
+	}
+
+	downFile, err := d.FindDown(20260101000000)
+	if err != nil {
+		t.Fatalf("d.FindDown() returned error: %v", err)
+	}
+	if downFile.Filename != "20260101000000_create_users.down.sql" {
+		t.Errorf("d.FindDown() = %q, want 20260101000000_create_users.down.sql", downFile.Filename)
+	}
+
+	downHash, err := d.DownContentHash(20260101000000)
+	if err != nil {
+		t.Fatalf("d.DownContentHash() error: %v", err)
+	}
+	if len(downHash) != 64 {
+		t.Errorf("d.DownContentHash() = %q, want 64-char hex string", downHash)
+	}
+}
+
+func TestDir_DownPlan(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "20260101000000_create_users.up.sql"), []byte("CREATE TABLE users (id INT);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "20260101000000_create_users.down.sql"), []byte("DROP TABLE users;"), 0o644)
+	os.WriteFile(filepath.Join(dir, "20260102000000_add_orders.up.sql"), []byte("CREATE TABLE orders (id INT);"), 0o644)
+	os.WriteFile(filepath.Join(dir, "20260102000000_add_orders.down.sql"), []byte("DROP TABLE orders;"), 0o644)
+
+	d, err := ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applied := []uint64{20260101000000, 20260102000000}
+	plan1, err := d.DownPlan(applied, 1)
+	if err != nil {
+		t.Fatalf("DownPlan(1) error: %v", err)
+	}
+	if len(plan1) != 1 || plan1[0].Version != 20260102000000 {
+		t.Errorf("DownPlan(1) = %+v, want [20260102000000]", plan1)
+	}
+
+	planAll, err := d.DownPlan(applied, 0)
+	if err != nil {
+		t.Fatalf("DownPlan(0) error: %v", err)
+	}
+	if len(planAll) != 2 || planAll[0].Version != 20260102000000 || planAll[1].Version != 20260101000000 {
+		t.Errorf("DownPlan(0) = %+v, want [20260102000000, 20260101000000]", planAll)
+	}
+
+	// Missing down file error
+	os.Remove(filepath.Join(dir, "20260102000000_add_orders.down.sql"))
+	d2, _ := ReadDir(dir)
+	_, err = d2.DownPlan(applied, 1)
+	if err == nil {
+		t.Fatal("expected error when down file missing, got nil")
+	}
 }
 
 func TestDir_NextVersion(t *testing.T) {

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -87,6 +87,31 @@ func (mg *Migrator) Step() (applied bool, err error) {
 	return true, nil
 }
 
+// StepDown rolls back the single most recently applied migration using its .down.sql file.
+// applied is false if there was nothing to do.
+func (mg *Migrator) StepDown() (applied bool, err error) {
+	err = mg.m.Steps(-1)
+	if errors.Is(err, migrate.ErrNoChange) || errors.Is(err, os.ErrNotExist) || errors.Is(err, migrate.ErrNilVersion) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reverting migration: %w", err)
+	}
+	return true, nil
+}
+
+// Down rolls back all applied migrations.
+func (mg *Migrator) Down() (applied bool, err error) {
+	err = mg.m.Down()
+	if errors.Is(err, migrate.ErrNoChange) || errors.Is(err, migrate.ErrNilVersion) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reverting migrations: %w", err)
+	}
+	return true, nil
+}
+
 // Version reports the current migration version. hasVersion is false if no
 // migration has ever been applied (golang-migrate's ErrNilVersion).
 func (mg *Migrator) Version() (version uint64, dirty bool, hasVersion bool, err error) {

--- a/internal/rollback/rollback.go
+++ b/internal/rollback/rollback.go
@@ -1,0 +1,110 @@
+package rollback
+
+import (
+	"fmt"
+
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/engine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+// Result summarizes what rollback.Run executed.
+type Result struct {
+	Target           string   `json:"target"`
+	RevertedVersions []uint64 `json:"reverted_versions"`
+	NewCursor        uint64   `json:"new_cursor"`
+	HasCursor        bool     `json:"has_cursor"`
+}
+
+// Run performs a ledger-only soft-revert for targetName up to steps count.
+// It marks versions as StatusReverted in the ledger and recomputes the
+// migration cursor without executing any .down.sql files or dropping objects.
+func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (*Result, error) {
+	url, err := cfg.ResolveURLOrFlag(targetName, urlOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	m, err := migrator.Open(url, cfg.MigrationsDir)
+	if err != nil {
+		return nil, err
+	}
+	defer m.Close()
+
+	db, err := eng.Open(url)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+	defer db.Close()
+
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	applied, err := eng.Ledger().AppliedVersions(db)
+	if err != nil {
+		return nil, fmt.Errorf("target %q: %w", targetName, err)
+	}
+
+	if len(applied) == 0 {
+		return &Result{
+			Target:           targetName,
+			RevertedVersions: nil,
+			NewCursor:        0,
+			HasCursor:        false,
+		}, nil
+	}
+
+	count := steps
+	if count <= 0 || count > len(applied) {
+		count = 1
+	}
+
+	reverted := make([]uint64, 0, count)
+	for i := len(applied) - 1; i >= len(applied)-count; i-- {
+		reverted = append(reverted, applied[i])
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	for _, ver := range reverted {
+		if err := eng.Ledger().SetStatus(tx, ver, ledger.StatusReverted, "soft-reverted via rollback"); err != nil {
+			return nil, err
+		}
+	}
+
+	remaining, err := eng.Ledger().AppliedVersions(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		Target:           targetName,
+		RevertedVersions: reverted,
+	}
+
+	if len(remaining) > 0 {
+		newCursor := remaining[len(remaining)-1]
+		if err := m.Stamp(newCursor); err != nil {
+			return nil, err
+		}
+		result.NewCursor = newCursor
+		result.HasCursor = true
+	}
+
+	return result, nil
+}

--- a/internal/rollback/rollback_test.go
+++ b/internal/rollback/rollback_test.go
@@ -1,0 +1,50 @@
+package rollback
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	_ "github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+)
+
+func TestRollback_Run(t *testing.T) {
+	tmpDir := t.TempDir()
+	migDir := filepath.Join(tmpDir, "migrations")
+	if err := os.MkdirAll(migDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	os.WriteFile(filepath.Join(migDir, "20260101000000_create_users.up.sql"), []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"), 0o644)
+	os.WriteFile(filepath.Join(migDir, "20260102000000_create_orders.up.sql"), []byte("CREATE TABLE orders (id INTEGER PRIMARY KEY);"), 0o644)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	t.Setenv("DBTOOLS_TEST_ROLLBACK_URL", "sqlite://"+dbPath)
+
+	cfg := &config.Config{
+		MigrationsDir: migDir,
+		Targets: map[string]config.Target{
+			"local": {URLEnv: "DBTOOLS_TEST_ROLLBACK_URL"},
+		},
+	}
+
+	// Up both
+	if _, err := apply.Run(cfg, "local", ""); err != nil {
+		t.Fatalf("apply.Run() failed: %v", err)
+	}
+
+	// Soft-revert latest version
+	res, err := Run(cfg, "local", 1, "")
+	if err != nil {
+		t.Fatalf("Run() rollback failed: %v", err)
+	}
+
+	if len(res.RevertedVersions) != 1 || res.RevertedVersions[0] != 20260102000000 {
+		t.Errorf("RevertedVersions = %v, want [20260102000000]", res.RevertedVersions)
+	}
+	if !res.HasCursor || res.NewCursor != 20260101000000 {
+		t.Errorf("NewCursor = %d (hasCursor=%v), want 20260101000000", res.NewCursor, res.HasCursor)
+	}
+}


### PR DESCRIPTION
## Summary of Changes (v0.2 Workstream 3a)

This PR implements down migrations and ledger-level rollback:

1. **`dbtools down <target> [N]`**:
   - Reverts the last N applied migrations (defaults to 1) in reverse order using `.down.sql` files.
   - Records each reverted version in the migration ledger (`dbtools_migration_history`) with status `reverted` and its `.down.sql` content hash.
   - Protected target safety gate: on protected targets, prints preview of what will be executed and requires `--yes` (or `--preview` for dry preview).

2. **`dbtools rollback <target> [N]`**:
   - Soft-reverts the last N migrations in the ledger only (metadata-only).
   - Recomputes the migration cursor without executing `.down.sql` or dropping objects.
   - Safe production verb for clearing bad ledger states.

3. **`migrator.Dir` down file indexing & planning**:
   - In-memory indexing of `.down.sql` files, `DownPlan`, and `DownContentHash`.
   - Adds `StepDown()` and `Down()` to `migrator.Migrator`.

4. **Testing**:
   - Unit tests for `internal/down`, `internal/rollback`, and `migrator.Dir` down file planning.
   - Command tests in `cmd/down_test.go` and `cmd/rollback_test.go` (argument validation, protected target refusal).
   - Extended `cmd/sqlite_loop_test.go` full loop test to verify up -> down -> verify OK -> rollback.