### PR TITLE
feat: add @dbtools/cli npm wrapper package and release workflow publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
           install-mode: "goinstall"
       - name: Unit tests
         run: go test ./...
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - name: NPM package test
+        run: node npm/test.js
 
   integration:
     name: Integration (${{ matrix.db }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,18 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          cd npm
+          npm version "$VERSION" --no-git-tag-version
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,35 @@
+# @dbtools/cli
+
+Fast schema migrations and dev databases for MSSQL, PostgreSQL, and SQLite.
+
+## Usage with npx (zero installation)
+
+```bash
+# Run without installing
+npx @dbtools/cli status
+
+# Apply local migrations
+npx @dbtools/cli up
+
+# Preview migrations and drift with exit-code contract
+npx @dbtools/cli plan --json
+```
+
+## Global Installation
+
+```bash
+npm install -g @dbtools/cli
+
+# Now run directly
+dbtools status
+dbtools up
+dbtools verify local
+```
+
+## Supported Platforms
+
+- macOS (x86_64 and arm64 Apple Silicon)
+- Linux (x86_64 and arm64)
+- Windows (x86_64)
+
+The npm package automatically fetches and caches the matching native `dbtools` binary from official GitHub Releases.

--- a/npm/bin/dbtools.js
+++ b/npm/bin/dbtools.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { getBinaryPath } = require('../lib/binary.js');
+
+async function main() {
+  try {
+    const binPath = await getBinaryPath();
+    const child = spawn(binPath, process.argv.slice(2), {
+      stdio: 'inherit',
+      env: process.env
+    });
+
+    child.on('error', (err) => {
+      console.error(`Failed to start dbtools: ${err.message}`);
+      process.exit(1);
+    });
+
+    child.on('close', (code) => {
+      process.exit(code ?? 0);
+    });
+  } catch (err) {
+    console.error(`dbtools installer error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/npm/lib/binary.js
+++ b/npm/lib/binary.js
@@ -1,0 +1,146 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+const http = require('http');
+const zlib = require('zlib');
+const { execSync } = require('child_process');
+
+const pkg = require('../package.json');
+
+const REPO = 'seanpham99/dbtools';
+
+function getPlatformInfo() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  let osName = '';
+  if (platform === 'linux') {
+    osName = 'Linux';
+  } else if (platform === 'darwin') {
+    osName = 'Darwin';
+  } else if (platform === 'win32') {
+    osName = 'Windows';
+  } else {
+    throw new Error(`Unsupported OS: ${platform}`);
+  }
+
+  let archName = '';
+  if (arch === 'x64') {
+    archName = 'x86_64';
+  } else if (arch === 'arm64') {
+    archName = 'arm64';
+  } else {
+    throw new Error(`Unsupported architecture: ${arch}`);
+  }
+
+  const ext = platform === 'win32' ? 'zip' : 'tar.gz';
+  const binName = platform === 'win32' ? 'dbtools.exe' : 'dbtools';
+
+  return { osName, archName, ext, binName, platform };
+}
+
+function getCacheDir(version) {
+  const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  return path.join(base, 'dbtools', `v${version}`);
+}
+
+function downloadFile(url) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https') ? https : http;
+    client.get(url, { headers: { 'User-Agent': 'dbtools-npx-installer' } }, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return downloadFile(res.headers.location).then(resolve).catch(reject);
+      }
+      if (res.statusCode !== 200) {
+        return reject(new Error(`Failed to download ${url}: HTTP ${res.statusCode}`));
+      }
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve(Buffer.concat(chunks)));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+function extractTarGz(buffer, targetBinaryName) {
+  const uncompressed = zlib.gunzipSync(buffer);
+  let offset = 0;
+
+  while (offset < uncompressed.length) {
+    const header = uncompressed.subarray(offset, offset + 512);
+    if (header.every((b) => b === 0)) {
+      break;
+    }
+
+    // Name is 100 bytes null-terminated
+    let nameEnd = 0;
+    while (nameEnd < 100 && header[nameEnd] !== 0) {
+      nameEnd++;
+    }
+    const name = header.subarray(0, nameEnd).toString('utf8');
+
+    // Size is 12 bytes octal string at offset 124
+    const sizeStr = header.subarray(124, 136).toString('utf8').trim().replace(/\0/g, '');
+    const size = parseInt(sizeStr, 8) || 0;
+
+    offset += 512;
+    const fileData = uncompressed.subarray(offset, offset + size);
+
+    if (name === targetBinaryName || path.basename(name) === targetBinaryName) {
+      return fileData;
+    }
+
+    // Tar blocks are padded to 512 bytes
+    offset += Math.ceil(size / 512) * 512;
+  }
+
+  throw new Error(`Binary ${targetBinaryName} not found in archive`);
+}
+
+async function getBinaryPath() {
+  if (process.env.DBTOOLS_BINARY_PATH && fs.existsSync(process.env.DBTOOLS_BINARY_PATH)) {
+    return process.env.DBTOOLS_BINARY_PATH;
+  }
+
+  const version = process.env.DBTOOLS_VERSION || pkg.version;
+  const { osName, archName, ext, binName, platform } = getPlatformInfo();
+
+  const cacheDir = getCacheDir(version);
+  const cachedBin = path.join(cacheDir, binName);
+
+  if (fs.existsSync(cachedBin)) {
+    return cachedBin;
+  }
+
+  fs.mkdirSync(cacheDir, { recursive: true });
+
+  const archiveName = `dbtools_${version}_${osName}_${archName}.${ext}`;
+  const downloadUrl = `https://github.com/${REPO}/releases/download/v${version}/${archiveName}`;
+
+  process.stderr.write(`Downloading dbtools v${version} for ${osName}/${archName}...\n`);
+  const archiveBuf = await downloadFile(downloadUrl);
+
+  if (ext === 'tar.gz') {
+    const binData = extractTarGz(archiveBuf, binName);
+    fs.writeFileSync(cachedBin, binData);
+  } else {
+    // Windows zip handling
+    const tempZip = path.join(cacheDir, archiveName);
+    fs.writeFileSync(tempZip, archiveBuf);
+    execSync(`powershell -command "Expand-Archive -Path '${tempZip}' -DestinationPath '${cacheDir}' -Force"`);
+    try { fs.unlinkSync(tempZip); } catch (_) {}
+  }
+
+  if (platform !== 'win32') {
+    fs.chmodSync(cachedBin, 0o755);
+  }
+
+  return cachedBin;
+}
+
+module.exports = {
+  getBinaryPath,
+  getPlatformInfo,
+  extractTarGz
+};

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@dbtools/cli",
+  "version": "0.2.0",
+  "description": "Fast schema migrations and dev databases for MSSQL, Postgres, and SQLite",
+  "bin": {
+    "dbtools": "./bin/dbtools.js"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "keywords": [
+    "dbtools",
+    "migrations",
+    "mssql",
+    "postgres",
+    "sqlite",
+    "database",
+    "cli"
+  ],
+  "author": "Sean Pham",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seanpham99/dbtools.git"
+  },
+  "bugs": {
+    "url": "https://github.com/seanpham99/dbtools/issues"
+  },
+  "homepage": "https://github.com/seanpham99/dbtools#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md"
+  ]
+}

--- a/npm/test.js
+++ b/npm/test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const path = require('path');
+const zlib = require('zlib');
+const { execSync } = require('child_process');
+const { getPlatformInfo, extractTarGz } = require('./lib/binary.js');
+
+console.log('Testing @dbtools/cli installer package...');
+
+// 1. Test platform detection
+const info = getPlatformInfo();
+assert(info.osName, 'osName should be defined');
+assert(info.archName, 'archName should be defined');
+assert(info.ext, 'ext should be defined');
+assert(info.binName, 'binName should be defined');
+console.log(`✓ Platform detected: ${info.osName} (${info.archName}) -> ${info.binName}`);
+
+// 2. Test tar.gz extractor
+function createMockTarGz(filename, content) {
+  const header = Buffer.alloc(512, 0);
+  header.write(filename, 0, 100, 'utf8');
+  const sizeOctal = content.length.toString(8).padStart(11, '0') + ' ';
+  header.write(sizeOctal, 124, 12, 'utf8');
+  header[156] = 48; // '0' for normal file
+
+  const contentPadded = Buffer.alloc(Math.ceil(content.length / 512) * 512, 0);
+  Buffer.from(content).copy(contentPadded);
+
+  const endBlock = Buffer.alloc(1024, 0);
+  const tarBuf = Buffer.concat([header, contentPadded, endBlock]);
+  return zlib.gzipSync(tarBuf);
+}
+
+const mockArchive = createMockTarGz('dbtools', 'binary-content-mock');
+const extracted = extractTarGz(mockArchive, 'dbtools');
+assert.strictEqual(extracted.toString(), 'binary-content-mock');
+console.log('✓ extractTarGz successfully extracted binary from mock archive');
+
+// 3. Test CLI wrapper invocation with DBTOOLS_BINARY_PATH override
+const projectRoot = path.join(__dirname, '..');
+const localBin = path.join(projectRoot, 'bin', 'dbtools-local-test');
+execSync(`go build -o "${localBin}" .`, { cwd: projectRoot });
+
+const out = execSync(`node bin/dbtools.js --help`, {
+  cwd: __dirname,
+  env: {
+    ...process.env,
+    DBTOOLS_BINARY_PATH: localBin
+  }
+}).toString();
+
+assert(out.includes('dbtools manages MSSQL/Postgres schema migrations'), 'CLI output should match dbtools help');
+console.log('✓ bin/dbtools.js execution via DBTOOLS_BINARY_PATH passed');
+
+// Clean up
+try { require('fs').unlinkSync(localBin); } catch (_) {}
+
+console.log('All npm package tests passed!');


### PR DESCRIPTION
## Summary of Changes (v0.2 Workstream 3c)

This PR adds the npx / npm wrapper package for dbtools:

1. **`@dbtools/cli` Package (`npm/`)**:
   - Zero external npm dependencies.
   - Platform detection for Linux (`x86_64`, `arm64`), macOS (`x86_64`, `arm64` Apple Silicon), and Windows (`x86_64`).
   - Downloads and caches official GitHub Release binaries under `~/.cache/dbtools/v<version>/` on first run.
   - Native fallback/override via `DBTOOLS_BINARY_PATH` and `DBTOOLS_VERSION` environment variables.
   - Executable wrapper at `npm/bin/dbtools.js`.

2. **Workflows**:
   - `.github/workflows/ci.yml`: added Node setup and `npm/test.js` execution to CI.
   - `.github/workflows/release.yml`: added automated `npm publish` step on tag release using `NPM_TOKEN` secret.