### PR TITLE
docs: sync docs with v0.2 (README, Pages, skill, roadmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 - **Zero-Drift Migration Ledger**: Tracks applied migrations with SHA-256 content hashes in `dbtools_migration_history` alongside standard `schema_migrations` cursors.
 - **Read-Only Drift Verification**: `dbtools verify` validates that live database objects match migration definitions and alerts when files were modified after execution.
 - **Rollback & Down Migrations**: `dbtools down` applies `.down.sql` files in reverse; `dbtools rollback` is a ledger-only soft-revert — the safe prod verb. Destructive ops on protected targets require `--preview --yes`.
-- **Agent-First Ergonomics**: Terraform-style exit-code contract (`0` clean / `1` error / `2` drift), `--dry-run` previews, universal `--json`, and `DBTOOLS_NO_PROMPT=1` fail-closed mode for CI and AI agents. See [docs/exit-codes.md](docs/exit-codes.md).
-- **Environment & Target Protection**: Targets are defined in `dbtools.toml` by environment variable names (`url_env`), ensuring secrets never leak into version control. Protected targets reject destructive local operations (`up`, `reset`).
+- **Agent-First Ergonomics**: Terraform-style exit-code contract (`0` clean / `1` error / `2` pending changes or drift), `--dry-run` previews, universal `--json`, and `DBTOOLS_NO_PROMPT=1` fail-closed mode for CI and AI agents. See [docs/exit-codes.md](docs/exit-codes.md).
+- **Environment & Target Protection**: Targets are defined in `dbtools.toml` by environment variable names (`url_env`), ensuring secrets never leak into version control. Protected targets reject destructive operations (`up`, `reset`, and `down` without `--preview --yes`).
 - **Python & TypeScript Type Generation**: `dbtools generate` introspects live database schemas and emits clean, versioned `pydantic.BaseModel` classes or Supabase-style TypeScript interfaces (+ optional zod schemas) for services, ETL jobs, and data pipelines.
 - **Interactive TUI Dashboard**: Built-in terminal dashboard powered by Bubble Tea for real-time migration observability.
 
@@ -115,7 +115,7 @@ dbtools status
 | `push` | `dbtools push <target> [--yes]` | Applies pending migrations to named remote target with explicit confirmation. |
 | `status` | `dbtools status [--json]` | Displays applied/pending migration status across all configured targets. |
 | `plan` | `dbtools plan [--target X] [--json]` | Read-only preview of pending migrations + ledger drift, without applying anything. Agent/CI-friendly: exit 0 = safe to apply. |
-| `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift. |
+| `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift (content-hash mismatch or missing object). |
 | `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |
 | `rollback` | `dbtools rollback <target> [--yes]` | Ledger-only soft-revert (marks `reverted`, never data-destroying). The safe prod verb. |
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |
@@ -257,6 +257,8 @@ if dbtools plan --target prod --json; then
   dbtools push prod --yes --dry-run
 fi
 ```
+
+> Note: exit `2` from `plan` means pending migrations or drift — inspect `--json` output to distinguish before deciding to apply.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/seanpham99/dbtools.svg)](https://pkg.go.dev/github.com/seanpham99/dbtools)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**dbtools** is a lightweight, reliable database migration authority and local dev-loop tool for **MSSQL**, **PostgreSQL**, and **SQLite**. Built in Go for high performance and zero external runtime dependencies, `dbtools` guarantees version-sync migration execution, immutable ledger tracking (`content_sha256`), read-only schema drift verification, and live schema introspection to typed Pydantic Python models.
+**dbtools** is a lightweight, reliable database migration authority and local dev-loop tool for **MSSQL**, **PostgreSQL**, and **SQLite**. Built in Go for high performance and zero external runtime dependencies, `dbtools` guarantees version-sync migration execution, immutable ledger tracking (`content_sha256`), read-only schema drift verification, and live schema introspection to typed Pydantic Python or TypeScript models.
 
 ---
 
@@ -13,15 +13,29 @@
 - **Multi-Engine Support**: Native migration engines for SQL Server (MSSQL), PostgreSQL (with session reset isolation), and SQLite (file-based).
 - **Zero-Drift Migration Ledger**: Tracks applied migrations with SHA-256 content hashes in `dbtools_migration_history` alongside standard `schema_migrations` cursors.
 - **Read-Only Drift Verification**: `dbtools verify` validates that live database objects match migration definitions and alerts when files were modified after execution.
+- **Rollback & Down Migrations**: `dbtools down` applies `.down.sql` files in reverse; `dbtools rollback` is a ledger-only soft-revert — the safe prod verb. Destructive ops on protected targets require `--preview --yes`.
+- **Agent-First Ergonomics**: Terraform-style exit-code contract (`0` clean / `1` error / `2` drift), `--dry-run` previews, universal `--json`, and `DBTOOLS_NO_PROMPT=1` fail-closed mode for CI and AI agents. See [docs/exit-codes.md](docs/exit-codes.md).
 - **Environment & Target Protection**: Targets are defined in `dbtools.toml` by environment variable names (`url_env`), ensuring secrets never leak into version control. Protected targets reject destructive local operations (`up`, `reset`).
-- **Python Type Generation**: `dbtools generate` introspects live database schemas and emits clean, versioned `pydantic.BaseModel` classes for Python services, ETL jobs, and data pipelines.
+- **Python & TypeScript Type Generation**: `dbtools generate` introspects live database schemas and emits clean, versioned `pydantic.BaseModel` classes or Supabase-style TypeScript interfaces (+ optional zod schemas) for services, ETL jobs, and data pipelines.
 - **Interactive TUI Dashboard**: Built-in terminal dashboard powered by Bubble Tea for real-time migration observability.
 
 ---
 
 ## Installation
 
-### Via Go Install (Recommended)
+### Via npm (Recommended for JS/TS users)
+
+```bash
+npx dbtools-cli status
+```
+
+or install globally:
+
+```bash
+npm install -g dbtools-cli
+```
+
+### Via Go Install
 
 ```bash
 go install github.com/seanpham99/dbtools@latest
@@ -101,10 +115,12 @@ dbtools status
 | `push` | `dbtools push <target> [--yes]` | Applies pending migrations to named remote target with explicit confirmation. |
 | `status` | `dbtools status [--json]` | Displays applied/pending migration status across all configured targets. |
 | `plan` | `dbtools plan [--target X] [--json]` | Read-only preview of pending migrations + ledger drift, without applying anything. Agent/CI-friendly: exit 0 = safe to apply. |
-| `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Non-zero exit on drift. |
+| `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift. |
+| `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |
+| `rollback` | `dbtools rollback <target> [--yes]` | Ledger-only soft-revert (marks `reverted`, never data-destroying). The safe prod verb. |
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |
 | `reset` | `dbtools reset [--target local] [--yes]` | Local-only: drops database, replays all migrations from zero, and executes `seed.sql`. |
-| `generate` | `dbtools generate [target] [--out models.py]` | Introspects live schema and renders Pydantic v2 Python models. |
+| `generate` | `dbtools generate [target] [--lang python\|ts] [--zod] [--out file]` | Introspects live schema and renders Pydantic v2 models (`python`, default) or Supabase-style TypeScript interfaces (`ts`; `--zod` adds zod schemas). |
 | `lint` | `dbtools lint [--dir <path>] [--json]` | Validates filenames, duplicate versions, and empty files without database connection. |
 | `dashboard` | `dbtools dashboard` | Opens terminal UI showing live target status (`r` to refresh, `q` to quit). |
 | `start` / `stop` | `dbtools start` / `stop` | Starts or stops ephemeral tool-owned local MSSQL Docker container. |
@@ -186,6 +202,60 @@ In CI/CD, enforce that repository models stay in sync with schema migrations usi
 
 ```bash
 dbtools generate local --out models.py --check
+```
+
+---
+
+## TypeScript Generation
+
+Supabase-style type generation for JS/TS services:
+
+```bash
+# TypeScript interfaces
+dbtools generate local --lang ts --out models.ts
+
+# TypeScript interfaces + zod schemas
+dbtools generate local --lang ts --zod --out models.ts
+```
+
+Generated `models.ts`:
+
+```typescript
+// Code generated by dbtools generate. DO NOT EDIT.
+export interface Users {
+  id: number;
+  email: string;
+  created_at?: string; // nullable columns become optional
+}
+
+export const UsersSchema = z.object({
+  id: z.number(),
+  email: z.string(),
+  created_at: z.string().nullish(),
+});
+```
+
+`--check` works the same for TS output (CI drift detection).
+
+---
+
+## Agent & CI Ergonomics
+
+`dbtools` is designed to be called by AI agents and CI pipelines without interactive prompts:
+
+- **Stable exit-code contract**: `0` clean, `1` error, `2` drift/pending changes. See [docs/exit-codes.md](docs/exit-codes.md).
+- **`--dry-run`**: preview SQL without applying (`dbtools up --dry-run`).
+- **Universal `--json`**: machine-readable output on stdout for `status`, `plan`, `verify`, and friends.
+- **`DBTOOLS_NO_PROMPT=1`**: never block on stdin; destructive ops fail closed. Also auto-enabled when stdout is not a TTY.
+- **Dirty-ledger refusal**: `up` refuses to apply when the ledger is dirty (a previous apply failed partway), surfacing the failure as exit `2` rather than silently continuing.
+
+Example agent loop:
+
+```bash
+if dbtools plan --target prod --json; then
+  # exit 0: safe to apply
+  dbtools push prod --yes --dry-run
+fi
 ```
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -591,11 +591,11 @@ Target: local
             <tr>
               <td><code>plan</code></td>
               <td><code>dbtools plan [--target X] [--json]</code></td>
-              <td>Read-only preview of pending migrations + ledger drift. Exit 0 = safe to apply.</td>
+              <td>Read-only preview of pending migrations + ledger drift. Exit 0 = safe to apply, 2 = pending/drift.</td>
             </tr>
             <tr>
               <td><code>verify</code></td>
-              <td><code>dbtools verify &lt;target&gt;</code></td>
+              <td><code>dbtools verify &lt;target&gt; [--json]</code></td>
               <td>Read-only audit: checks file SHA hashes and database object existence. Exit 0 clean / 1 error / 2 drift.</td>
             </tr>
             <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -457,12 +457,12 @@
       </div>
       <h1>Multi-Engine Database <br><span class="highlight">Migration Authority</span></h1>
       <p class="hero-subtitle">
-        Eliminate schema drift and protect deployment targets across MSSQL, PostgreSQL, and SQLite with cryptographic ledger tracking, drop-aware verification, and Pydantic model generation.
+        Eliminate schema drift and protect deployment targets across MSSQL, PostgreSQL, and SQLite with cryptographic ledger tracking, drop-aware verification, rollback/down migrations, and Python + TypeScript model generation — built for CI and AI agents.
       </p>
 
       <div class="install-box">
         <span class="prompt-line">$</span>
-        <span class="install-command" id="installCmd">go install github.com/seanpham99/dbtools@latest</span>
+        <span class="install-command" id="installCmd">npx dbtools-cli status</span>
         <button class="copy-btn" id="copyBtn" onclick="copyInstall()">Copy</button>
       </div>
     </section>
@@ -500,8 +500,14 @@
 
         <div class="feature-card">
           <div class="card-icon icon-blue">🐍</div>
-          <h3>Python Type Contract Generation</h3>
-          <p><code>dbtools generate</code> renders versioned, type-safe Pydantic v2 BaseModels from live schema metadata, with <code>--check</code> for CI schema sync.</p>
+          <h3>Python & TypeScript Type Generation</h3>
+          <p><code>dbtools generate</code> renders versioned, type-safe Pydantic v2 BaseModels or Supabase-style TypeScript interfaces (+ optional zod schemas) from live schema metadata, with <code>--check</code> for CI schema sync.</p>
+        </div>
+
+        <div class="feature-card">
+          <div class="card-icon icon-emerald">🤖</div>
+          <h3>Agent-First Ergonomics</h3>
+          <p>Terraform-style exit-code contract (0 clean / 1 error / 2 drift), <code>--dry-run</code> previews, universal <code>--json</code>, and <code>DBTOOLS_NO_PROMPT=1</code> fail-closed mode — built for CI and AI agents.</p>
         </div>
 
         <div class="feature-card">
@@ -583,9 +589,24 @@ Target: local
               <td>Displays applied/pending migration status across all configured targets.</td>
             </tr>
             <tr>
+              <td><code>plan</code></td>
+              <td><code>dbtools plan [--target X] [--json]</code></td>
+              <td>Read-only preview of pending migrations + ledger drift. Exit 0 = safe to apply.</td>
+            </tr>
+            <tr>
               <td><code>verify</code></td>
               <td><code>dbtools verify &lt;target&gt;</code></td>
-              <td>Read-only audit: checks file SHA hashes and database object existence. Non-zero exit on drift.</td>
+              <td>Read-only audit: checks file SHA hashes and database object existence. Exit 0 clean / 1 error / 2 drift.</td>
+            </tr>
+            <tr>
+              <td><code>down</code></td>
+              <td><code>dbtools down &lt;target&gt; [N] [--preview] [--yes]</code></td>
+              <td>Applies <code>.down.sql</code> migrations in reverse, recorded in the ledger. Protected targets require <code>--preview --yes</code>.</td>
+            </tr>
+            <tr>
+              <td><code>rollback</code></td>
+              <td><code>dbtools rollback &lt;target&gt; [--yes]</code></td>
+              <td>Ledger-only soft-revert (never data-destroying) — the safe prod verb.</td>
             </tr>
             <tr>
               <td><code>repair</code></td>
@@ -599,8 +620,8 @@ Target: local
             </tr>
             <tr>
               <td><code>generate</code></td>
-              <td><code>dbtools generate [target] [--out models.py]</code></td>
-              <td>Introspects schema and outputs typed Pydantic Python models.</td>
+              <td><code>dbtools generate [target] [--lang python|ts] [--zod] [--out file]</code></td>
+              <td>Introspects schema and outputs typed Pydantic Python models or TypeScript interfaces (+ zod).</td>
             </tr>
             <tr>
               <td><code>lint</code></td>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,13 +26,14 @@ same core.
 | Phase | Feature | Notes |
 |-------|---------|-------|
 | v0.1.2 ✅ | `plan` preview | Read-only preview of pending migrations + ledger drift. Agent/CI-friendly: exit 0 = safe to apply. |
-| v0.2 | **Rollback & down migrations** | Biggest functional gap: down-migration support + safe ledger-level rollback, with production gates. See design below. |
-| v0.2 | **Agent ergonomics** | Universal `--json`, `--dry-run`, non-interactive mode, dirty-ledger refusal. See design below. |
-| v0.2 | **npx installer** | `@dbtools/cli` — thin npm wrapper that downloads the GoReleaser binary (5 platforms) + execs it. No Go→JS rewrite. Version-synced via release pipeline. |
+| v0.2 ✅ | **Rollback & down migrations** | `down` (reverse `.down.sql` apply) + ledger-only `rollback`, with production gates. Shipped in v0.2.0. |
+| v0.2 ✅ | **Agent ergonomics** | Universal `--json`, `--dry-run`, non-interactive mode, dirty-ledger refusal, exit-code contract. Shipped in v0.2.0. |
+| v0.2 ✅ | **TypeScript generation** | `generate --lang ts [--zod]` — Supabase-style interfaces + zod. Shipped in v0.2.0. |
+| v0.2 ✅ | **npx installer** | `dbtools-cli` npm wrapper — thin downloader of the GoReleaser binary (5 platforms). Published via OIDC trusted publishing (no token). Shipped 0.2.1. |
 | v0.3 | **`doctor`** | Read-only health/security check: connectivity, version sync, ledger integrity, drift summary, basic security flags. One-call parseable health. |
 | v0.3/4 | **Clone prod→dev** | Schema + data clone with config-driven masking. Masking on by default; raw copy requires explicit opt-out. |
 | v0.4 | **Backup** | Table-stakes backup/restore. |
-| Mongo | **C → B → A** | Starts only after SQL is stable (gate = v0.2 + npx shipped). See design below. |
+| Mongo | **C → B → A** | Starts only after SQL is stable (gate = v0.2 shipped — met). See design below. |
 | launch | — | Public launch (announcements, directories) happens only after the v0.2/v0.3 features above. |
 
 ## Rollback & down migrations
@@ -80,17 +81,18 @@ not a silent change); today the permissive license maximizes adoption.
 
 ## npx installer
 
-- Package: `@dbtools/cli` (scoped; the bare `dbtools` npm name is owned by an
-  unrelated project).
-- Shape: thin npm wrapper — `npx @dbtools/cli` downloads the GoReleaser binary for
+- Package: `dbtools-cli` (unscoped; the bare `dbtools` npm name is owned by an
+  unrelated project, and scoped names need an npm org).
+- Shape: thin npm wrapper — `npx dbtools-cli` downloads the GoReleaser binary for
   the caller's platform (`darwin`/`linux`/`windows` × `amd64`/`arm64`) from GitHub
   Releases, then execs it. **No Go→JS rewrite.**
 - Versioning: npm version tracks the Go release version, published by the same
-  release pipeline (add npm token secret + publish step).
+  release pipeline via **OIDC trusted publishing** (GitHub `npm` deployment
+  environment + `id-token: write`; no npm token secret).
 
 ## Mongo support (post-SQL-stable)
 
-Starts only after the SQL story is stable (gate = v0.2 shipped + npx installer).
+Starts only after the SQL story is stable (gate = v0.2 shipped + npx installer — **met as of 0.2.1**).
 The engine abstraction is SQL-shaped today (`Engine.Open` returns `*sql.DB`,
 `DDLDialect` parses SQL, `verify` checks SQL object existence); Mongo needs a
 non-SQL seam, so it is a semantic fork, not a new engine. Sequence:

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,6 +2,8 @@
 
 Fast schema migrations and dev databases for MSSQL, PostgreSQL, and SQLite.
 
+This is the npm distribution of [`dbtools`](https://github.com/seanpham99/dbtools) — a thin wrapper that downloads the official Go binary for your platform. Features: version-sync migrations, SHA-256 ledger, read-only drift verification, rollback/down, TypeScript + Pydantic type generation, and agent-friendly exit codes / `--json` output.
+
 ## Usage with npx (zero installation)
 
 ```bash

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -45,8 +45,18 @@ dbtools reset
 # Check status of applied/pending migrations
 dbtools status [--json]
 
+# Preview pending migrations + drift (agent/CI-safe: exit 0 = applyable)
+dbtools plan [--target X] [--json]
+
 # Verify migration ledger objects exist in target DB (drift check)
 dbtools verify <target_name> [--json]
+# Exit codes: 0 clean, 1 error, 2 drift/pending — see docs/exit-codes.md
+
+# Apply .down.sql migrations in reverse (destructive; protected targets need --preview --yes)
+dbtools down <target_name> [N] [--preview] [--yes]
+
+# Ledger-only soft-revert (marks 'reverted', never data-destroying) — safe prod verb
+dbtools rollback <target_name> [--yes]
 
 # Repair ledger status (replaces old 'stamp' command)
 dbtools repair <target_name> <version>:<status> --yes [--force]
@@ -55,6 +65,9 @@ dbtools repair <target_name> <version>:<status> --yes [--force]
 dbtools generate [target] [--out db_models.py] [--yes] [--check]
 # --yes required when target is prod. --check exits non-zero if the file on disk
 # is stale instead of writing (use in CI to catch un-regenerated db_models.py).
+
+# Generate TypeScript interfaces (+ optional zod schemas) from live DB schema
+dbtools generate [target] --lang ts [--zod] [--out db_models.ts]
 
 # Read-only TUI status dashboard ('r' to refresh, 'q' to quit)
 dbtools dashboard
@@ -98,10 +111,12 @@ url_env = "DBTOOLS_PROD_URL"
 ## Red Flags - STOP and Correct
 
 - ❌ Hardcoding connection strings or password credentials in `dbtools.toml`.
-- ❌ Using non-existent commands: `dbtools migrate`, `dbtools rollback`, `dbtools sync`, `dbtools stamp`.
+- ❌ Using non-existent commands: `dbtools migrate`, `dbtools sync`, `dbtools stamp`.
 - ❌ Expecting `dbtools push` to diff live schema (it only performs version-sync).
 - ❌ Creating multiple seed files instead of single root `seed.sql`.
 - ❌ Modifying applied migration files instead of scaffolding a new one with `dbtools new`.
+- ❌ Running `dbtools down` on a protected target without `--preview --yes` (refused).
+- ❌ Calling `dbtools plan`/`verify` and ignoring the exit code — `2` means drift/pending, not success.
 
 ## Rationalizations Table
 
@@ -109,4 +124,4 @@ url_env = "DBTOOLS_PROD_URL"
 |---|---|
 | "I can put localhost URL directly in `dbtools.toml`" | Violates security & convention. Always use `url_env` (e.g. `DBTOOLS_LOCAL_URL`). |
 | "I'll use `dbtools stamp` to fix migration state" | `stamp` command is removed. Use `dbtools repair`. |
-| "I need to run rollback on production" | `dbtools` uses forward-only migration pattern; use `repair` or write a new reverting migration. |
+| "I need to run rollback on production" | Use `dbtools rollback` (ledger-only, non-destructive) or `dbtools down` with `--preview --yes` on a protected target — never silently. |

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -45,7 +45,7 @@ dbtools reset
 # Check status of applied/pending migrations
 dbtools status [--json]
 
-# Preview pending migrations + drift (agent/CI-safe: exit 0 = applyable)
+# Preview pending migrations + drift (agent/CI-safe: exit 0 = applyable, 2 = pending/drift)
 dbtools plan [--target X] [--json]
 
 # Verify migration ledger objects exist in target DB (drift check)


### PR DESCRIPTION
Updates all user-facing surfaces to reflect v0.2 shipped features:
- Rollback & down migrations
- Agent ergonomics (exit codes, --dry-run, --json, NO_PROMPT)
- TypeScript generation (--lang ts --zod)
- npx installer (dbtools-cli, OIDC published)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented `down` and `rollback` migration commands.
  * Added TypeScript and optional Zod type-generation guidance.
  * Added CLI exit codes, JSON output, dry-run previews, and CI/agent workflow documentation.
  * Updated installation instructions to include npm and npx options.
  * Documented safeguards for destructive operations and protected targets.
  * Updated roadmap and package documentation to reflect the latest capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->