### PR TITLE
chore(release): group release notes by conventional-commit type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dbtools
+dist/ 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,9 +40,21 @@ checksum:
   algorithm: sha256
 
 changelog:
-  sort: asc
+  groups:
+    - title: "Features"
+      regexp: "^feat(\\([[:word:]]+\\))?!?:"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^(fix|perf)(\\([[:word:]]+\\))?!?:"
+      order: 1
+    - title: "Refactors"
+      regexp: "^refactor:"
+      order: 2
+    - title: "Other changes"
+      order: 999
   filters:
     exclude:
       - "^docs:"
       - "^test:"
       - "^ci:"
+      - "^chore:"


### PR DESCRIPTION
## What
Add `changelog.groups` to `.goreleaser.yaml` so GitHub release notes are grouped by conventional-commit type instead of the flat commit list.

## Changes
- `Features` (feat:), `Bug fixes` (fix:/perf:), `Refactors` (refactor:), `Other changes` (fallback)
- Kept the existing `docs/test/ci/chore` exclusion filters
- No version bump, no release

## Verified
- `goreleaser check` passes (only pre-existing `archives.format` deprecation warnings)
- `goreleaser release --snapshot --skip=publish` builds all 5 platforms cleanly
- Group regexes matched against real v0.1.2..v0.2.0 commit subjects — next release will look like:

### Features
- feat(generate): TypeScript + zod generation (#24)
- feat: add @dbtools/cli npm wrapper package and release workflow publishing (#23)
- feat: implement agent ergonomics with exit-code contract, dry-run SQL preview, and universal JSON output (#22)
- feat: add down migrations and ledger-only rollback commands with production gates (#21)

### Bug fixes
- fix(scaffold): derive migration version from max(clock, max_existing+1) (fixes #1) (#12)

### Refactors
- refactor(arch): deepen engine seams, unify migrator.Dir, dissolve render, and harden apply stepping (#19)

### Other changes
- chore(npm): publish as unscoped 'dbtools-cli' (no org needed)
- ci(release): fix npm publish when package version already matches tag