### PR TITLE
ci(release): fail release if CHANGELOG entry missing for tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check CHANGELOG entry
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          # awk string-compare (no regex) on line start; grep -F would treat ^ as literal
+          if ! awk -v v="## [$VERSION]" 'index($0, v) == 1 { found=1 } END { exit !found }' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing an entry for [$VERSION]. Add one (Keep a Changelog format) before tagging."
+            exit 1
+          fi
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## What
Add a gate to `release.yml`: before GoReleaser runs, verify the tagged version has an entry in `CHANGELOG.md` (Keep a Changelog format `## [v]`).

## Why
Prevents shipping a release with no changelog entry — the changelog is the user-facing record of what changed.

## Implementation notes
- `awk` string-compare (`index($0, v) == 1`) instead of `grep -F`: grep -F would treat `^` as a literal character, never matching.
- No regex, so `## [0.1]` cannot false-match `## [0.1.0]`.
- Tag-only trigger (`on: push: tags: v*`), so this can't block PRs.

## Verified
- Positive: `## [0.2.0]` → passes
- Negative: `## [9.9.9]` → fails
- Partial trap: `## [0.1]` → fails (doesn't match 0.1.0)
