### PR TITLE
feat(doctor): add dbtools doctor health/security audit command and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ dbtools status
 | `up` | `dbtools up [--target <name>]` | Applies pending migrations to local target. Refuses protected/remote targets. |
 | `push` | `dbtools push <target> [--yes]` | Applies pending migrations to named remote target with explicit confirmation. |
 | `status` | `dbtools status [--json]` | Displays applied/pending migration status across all configured targets. |
+| `doctor` | `dbtools doctor [target] [--json]` | Strictly read-only health, integrity, drift, and security audit. Exit 0 healthy / 1 error / 2 issues. |
 | `plan` | `dbtools plan [--target X] [--json]` | Read-only preview of pending migrations + ledger drift, without applying anything. Agent/CI-friendly: exit 0 = safe to apply. |
 | `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift (content-hash mismatch or missing object). |
 | `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,425 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/engine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+	"github.com/seanpham99/dbtools/internal/verify"
+	"github.com/spf13/cobra"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor [target]",
+	Short: "Perform read-only health and security checks on target databases",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := ""
+		if len(args) > 0 {
+			target = args[0]
+		}
+		return runDoctor(target)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+// CheckResult represents the outcome of a single doctor check.
+type CheckResult struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // "ok", "warn", "fail"
+	Message string `json:"message"`
+}
+
+// DoctorReport is the full doctor check report for one target.
+type DoctorReport struct {
+	Target  string        `json:"target"`
+	Engine  string        `json:"engine"`
+	Healthy bool          `json:"healthy"`
+	Exit    int           `json:"exit"`
+	Checks  []CheckResult `json:"checks"`
+}
+
+func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
+	report := &DoctorReport{
+		Target: targetName,
+		Checks: make([]CheckResult, 0, 6),
+	}
+
+	tConfig, hasTarget := cfg.Targets[targetName]
+	if !hasTarget {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "connectivity",
+			Status:  "fail",
+			Message: fmt.Sprintf("unknown target %q (known: %v)", targetName, cfg.TargetNames()),
+		})
+		report.Exit = 1
+		report.Healthy = false
+		return report
+	}
+
+	// 1. Security flags & config check
+	secStatus := "ok"
+	var secMessages []string
+	if tConfig.URLEnv == "" {
+		secStatus = "warn"
+		secMessages = append(secMessages, "url_env not configured")
+	} else {
+		secMessages = append(secMessages, fmt.Sprintf("url_env=%s", tConfig.URLEnv))
+	}
+	secMessages = append(secMessages, fmt.Sprintf("protected=%v", tConfig.Protected))
+
+	if _, err := os.Stat(cfg.MigrationsDir); os.IsNotExist(err) {
+		secStatus = "warn"
+		secMessages = append(secMessages, fmt.Sprintf("migrations_dir %q missing", cfg.MigrationsDir))
+	}
+
+	// 2. Connectivity check
+	rawURL, err := cfg.ResolveURL(targetName)
+	if err != nil {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "connectivity",
+			Status:  "fail",
+			Message: fmt.Sprintf("resolving URL: %v", err),
+		})
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "security-flags",
+			Status:  secStatus,
+			Message: strings.Join(secMessages, ", "),
+		})
+		report.Exit = 1
+		report.Healthy = false
+		return report
+	}
+
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), rawURL)
+	if err != nil {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "connectivity",
+			Status:  "fail",
+			Message: fmt.Sprintf("engine resolution: %v", err),
+		})
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "security-flags",
+			Status:  secStatus,
+			Message: strings.Join(secMessages, ", "),
+		})
+		report.Exit = 1
+		report.Healthy = false
+		return report
+	}
+	report.Engine = eng.Name()
+
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "connectivity",
+			Status:  "fail",
+			Message: fmt.Sprintf("open failed: %v", err),
+		})
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "security-flags",
+			Status:  secStatus,
+			Message: strings.Join(secMessages, ", "),
+		})
+		report.Exit = 1
+		report.Healthy = false
+		return report
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "connectivity",
+			Status:  "fail",
+			Message: fmt.Sprintf("ping failed: %v", err),
+		})
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "security-flags",
+			Status:  secStatus,
+			Message: strings.Join(secMessages, ", "),
+		})
+		report.Exit = 1
+		report.Healthy = false
+		return report
+	}
+	report.Checks = append(report.Checks, CheckResult{
+		Name:    "connectivity",
+		Status:  "ok",
+		Message: fmt.Sprintf("connected to database (%s)", eng.Name()),
+	})
+
+	// 3. Ledger integrity check
+	var ledgerEntries []ledger.Entry
+	ledgerExists := true
+	entries, err := eng.Ledger().List(db)
+	if err != nil {
+		ledgerExists = false
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "ledger-integrity",
+			Status:  "warn",
+			Message: "ledger table uninitialized or empty",
+		})
+	} else {
+		ledgerEntries = entries
+		dir, dirErr := migrator.ReadDir(cfg.MigrationsDir)
+		if dirErr != nil {
+			report.Checks = append(report.Checks, CheckResult{
+				Name:    "ledger-integrity",
+				Status:  "fail",
+				Message: fmt.Sprintf("reading migrations dir: %v", dirErr),
+			})
+		} else {
+			hashMismatches := 0
+			for _, e := range entries {
+				if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" {
+					sum, err := dir.ContentHash(e.Version)
+					if err != nil || sum != e.ContentSHA256 {
+						hashMismatches++
+					}
+				}
+			}
+			if hashMismatches > 0 {
+				report.Checks = append(report.Checks, CheckResult{
+					Name:    "ledger-integrity",
+					Status:  "fail",
+					Message: fmt.Sprintf("content hash mismatch in %d migration(s)", hashMismatches),
+				})
+			} else {
+				report.Checks = append(report.Checks, CheckResult{
+					Name:    "ledger-integrity",
+					Status:  "ok",
+					Message: fmt.Sprintf("%d ledger entries verified (hashes match)", len(entries)),
+				})
+			}
+		}
+	}
+
+	// 4. Version sync & pending check
+	m, err := migrator.Open(rawURL, cfg.MigrationsDir)
+	var currentVer uint64
+	var isDirty bool
+	var hasVer bool
+	if err != nil {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "version-sync",
+			Status:  "fail",
+			Message: fmt.Sprintf("migrator error: %v", err),
+		})
+	} else {
+		defer m.Close()
+		v, dirty, hv, vErr := m.Version()
+		if vErr != nil {
+			report.Checks = append(report.Checks, CheckResult{
+				Name:    "version-sync",
+				Status:  "fail",
+				Message: fmt.Sprintf("reading version: %v", vErr),
+			})
+		} else {
+			currentVer = v
+			isDirty = dirty
+			hasVer = hv
+			dir, dirErr := migrator.ReadDir(cfg.MigrationsDir)
+			if dirErr != nil {
+				report.Checks = append(report.Checks, CheckResult{
+					Name:    "version-sync",
+					Status:  "fail",
+					Message: fmt.Sprintf("reading migrations dir: %v", dirErr),
+				})
+			} else {
+				pending := dir.PendingFilenames(currentVer, hasVer)
+				if len(pending) > 0 {
+					report.Checks = append(report.Checks, CheckResult{
+						Name:    "version-sync",
+						Status:  "fail",
+						Message: fmt.Sprintf("%d pending migration(s) (current version %d)", len(pending), currentVer),
+					})
+				} else if hasVer {
+					report.Checks = append(report.Checks, CheckResult{
+						Name:    "version-sync",
+						Status:  "ok",
+						Message: fmt.Sprintf("up to date (version %d)", currentVer),
+					})
+				} else {
+					report.Checks = append(report.Checks, CheckResult{
+						Name:    "version-sync",
+						Status:  "ok",
+						Message: "no migrations applied (clean database)",
+					})
+				}
+			}
+		}
+	}
+
+	// 5. Drift summary
+	if ledgerExists && len(ledgerEntries) > 0 {
+		vReport, err := verify.Collect(db, eng, cfg.MigrationsDir, targetName)
+		if err != nil {
+			report.Checks = append(report.Checks, CheckResult{
+				Name:    "drift-summary",
+				Status:  "fail",
+				Message: fmt.Sprintf("drift check failed: %v", err),
+			})
+		} else {
+			driftCount := 0
+			for _, e := range vReport.Entries {
+				if e.Status == "DRIFT" {
+					driftCount++
+				}
+			}
+			if driftCount > 0 {
+				report.Checks = append(report.Checks, CheckResult{
+					Name:    "drift-summary",
+					Status:  "fail",
+					Message: fmt.Sprintf("drift detected in %d migration(s)", driftCount),
+				})
+			} else {
+				report.Checks = append(report.Checks, CheckResult{
+					Name:    "drift-summary",
+					Status:  "ok",
+					Message: "no schema drift detected",
+				})
+			}
+		}
+	} else {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "drift-summary",
+			Status:  "warn",
+			Message: "skipped (ledger empty or not initialized)",
+		})
+	}
+
+	// 6. Dirty ledger check
+	if isDirty {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "dirty-ledger",
+			Status:  "fail",
+			Message: fmt.Sprintf("ledger is marked DIRTY at version %d (previous apply failed)", currentVer),
+		})
+	} else {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:    "dirty-ledger",
+			Status:  "ok",
+			Message: "ledger clean (dirty=false)",
+		})
+	}
+
+	// Add security-flags check
+	report.Checks = append(report.Checks, CheckResult{
+		Name:    "security-flags",
+		Status:  secStatus,
+		Message: strings.Join(secMessages, ", "),
+	})
+
+	// Determine overall exit code:
+	// 0: all healthy (ok or warn)
+	// 2: health issues found (any check fail)
+	// 1: unreachable / invalid config (handled at entry)
+	hasFail := false
+	for _, c := range report.Checks {
+		if c.Status == "fail" {
+			hasFail = true
+			break
+		}
+	}
+	if hasFail {
+		report.Exit = 2
+		report.Healthy = false
+	} else {
+		report.Exit = 0
+		report.Healthy = true
+	}
+
+	return report
+}
+
+func renderDoctorHuman(reports []*DoctorReport) string {
+	var b strings.Builder
+	for i, r := range reports {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "Target: %s (%s)\n", r.Target, r.Engine)
+		for _, c := range r.Checks {
+			badge := "[OK]  "
+			switch c.Status {
+			case "warn":
+				badge = "[WARN]"
+			case "fail":
+				badge = "[FAIL]"
+			}
+			fmt.Fprintf(&b, "  %-6s  %-18s %s\n", badge, c.Name, c.Message)
+		}
+		verdict := "HEALTHY (exit 0)"
+		if r.Exit == 1 {
+			verdict = "ERROR (exit 1)"
+		} else if r.Exit == 2 {
+			verdict = "ISSUES DETECTED (exit 2)"
+		}
+		fmt.Fprintf(&b, "Result: %s\n", verdict)
+	}
+	return b.String()
+}
+
+func runDoctor(targetFilter string) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+
+	var targetNames []string
+	if targetFilter != "" {
+		targetNames = []string{targetFilter}
+	} else {
+		targetNames = cfg.TargetNames()
+	}
+
+	if len(targetNames) == 0 {
+		return fmt.Errorf("no targets configured in dbtools.toml")
+	}
+
+	reports := make([]*DoctorReport, 0, len(targetNames))
+	maxExit := 0
+
+	for _, name := range targetNames {
+		rep := evaluateTarget(cfg, name)
+		reports = append(reports, rep)
+		if rep.Exit == 1 {
+			maxExit = 1
+		} else if rep.Exit == 2 && maxExit != 1 {
+			maxExit = 2
+		}
+	}
+
+	if jsonOutput {
+		var b []byte
+		if targetFilter != "" && len(reports) == 1 {
+			b, err = json.Marshal(reports[0])
+		} else {
+			b, err = json.Marshal(reports)
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+	} else {
+		fmt.Print(renderDoctorHuman(reports))
+	}
+
+	if maxExit != 0 {
+		msg := "health issues detected"
+		if maxExit == 1 {
+			msg = "target error or unreachable"
+		}
+		return ExitCode(maxExit, msg)
+	}
+
+	return nil
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,331 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+)
+
+func setupTestDoctorEnv(t *testing.T) (string, string, *config.Config) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "doctor_test.db")
+	rawURL := fmt.Sprintf("sqlite://%s", dbPath)
+	migrationsDir := filepath.Join(dir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m1Up := `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);`
+	m1Down := `DROP TABLE users;`
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.up.sql"), []byte(m1Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.down.sql"), []byte(m1Down), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgContent := fmt.Sprintf(`migrations_dir = %q
+[targets.testdb]
+url_env = "DBTOOLS_TEST_DOCTOR_URL"
+engine = "sqlite"
+protected = false
+`, migrationsDir)
+
+	configPath := filepath.Join(dir, "dbtools.toml")
+	if err := os.WriteFile(configPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DBTOOLS_TEST_DOCTOR_URL", rawURL)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, rawURL, cfg
+}
+
+func TestDoctorHealthy(t *testing.T) {
+	dir, _, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migrations via apply.Run so ledger is fully initialized with content hash
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatalf("apply.Run() err=%v", err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if !report.Healthy {
+		t.Fatalf("evaluateTarget() healthy = false, want true. Checks: %+v", report.Checks)
+	}
+	if report.Exit != 0 {
+		t.Fatalf("evaluateTarget() exit = %d, want 0", report.Exit)
+	}
+
+	// Run runDoctor directly
+	jsonOutput = false
+	err = runDoctor("testdb")
+	if err != nil {
+		t.Fatalf("runDoctor() unexpected error: %v", err)
+	}
+}
+
+func TestDoctorDriftContentHash(t *testing.T) {
+	dir, _, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migration first
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify migration file on disk after apply (drift)
+	m1UpEdited := `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT);`
+	if err := os.WriteFile(filepath.Join(cfg.MigrationsDir, "20260822000001_users.up.sql"), []byte(m1UpEdited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if report.Healthy {
+		t.Fatal("evaluateTarget() healthy = true, want false (content hash drift)")
+	}
+	if report.Exit != 2 {
+		t.Fatalf("evaluateTarget() exit = %d, want 2", report.Exit)
+	}
+
+	err = runDoctor("testdb")
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("runDoctor() err = %v, want exit code 2", err)
+	}
+}
+
+func TestDoctorPendingMigration(t *testing.T) {
+	dir, _, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migration 1
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add migration 2 without applying
+	m2Up := `CREATE TABLE orders (id INTEGER PRIMARY KEY);`
+	m2Down := `DROP TABLE orders;`
+	if err := os.WriteFile(filepath.Join(cfg.MigrationsDir, "20260822000002_orders.up.sql"), []byte(m2Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.MigrationsDir, "20260822000002_orders.down.sql"), []byte(m2Down), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if report.Healthy {
+		t.Fatal("evaluateTarget() healthy = true, want false (pending migration)")
+	}
+	if report.Exit != 2 {
+		t.Fatalf("evaluateTarget() exit = %d, want 2", report.Exit)
+	}
+
+	err = runDoctor("testdb")
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("runDoctor() err = %v, want exit code 2", err)
+	}
+}
+
+func TestDoctorDirtyLedger(t *testing.T) {
+	dir, rawURL, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migration 1
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Artificially mark dirty in schema_migrations
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`UPDATE schema_migrations SET dirty = 1`); err != nil {
+		t.Fatal(err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if report.Healthy {
+		t.Fatal("evaluateTarget() healthy = true, want false (dirty ledger)")
+	}
+	if report.Exit != 2 {
+		t.Fatalf("evaluateTarget() exit = %d, want 2", report.Exit)
+	}
+}
+
+func TestDoctorUnreachableOrUnknownTarget(t *testing.T) {
+	dir, _, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unknown target
+	report := evaluateTarget(cfg, "nonexistent")
+	if report.Exit != 1 {
+		t.Fatalf("evaluateTarget(nonexistent) exit = %d, want 1", report.Exit)
+	}
+
+	// Target with unset env variable
+	t.Setenv("DBTOOLS_TEST_DOCTOR_URL", "")
+	report = evaluateTarget(cfg, "testdb")
+	if report.Exit != 1 {
+		t.Fatalf("evaluateTarget(unset env) exit = %d, want 1", report.Exit)
+	}
+}
+
+func TestDoctorJSONOutput(t *testing.T) {
+	dir, _, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = false })
+
+	report := evaluateTarget(cfg, "testdb")
+	b, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed DoctorReport
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("Unmarshal DoctorReport failed: %v", err)
+	}
+	if parsed.Target != "testdb" || !parsed.Healthy || parsed.Exit != 0 || len(parsed.Checks) != 6 {
+		t.Fatalf("parsed report mismatch: %+v", parsed)
+	}
+}
+
+func TestDoctorLiveObjectDropDrift(t *testing.T) {
+	dir, rawURL, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop table directly out of band
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`DROP TABLE users`); err != nil {
+		t.Fatal(err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if report.Healthy {
+		t.Fatal("evaluateTarget() healthy = true, want false (live drop drift)")
+	}
+	if report.Exit != 2 {
+		t.Fatalf("evaluateTarget() exit = %d, want 2", report.Exit)
+	}
+}
+
+func TestRenderDoctorHuman(t *testing.T) {
+	rep := &DoctorReport{
+		Target:  "prod",
+		Engine:  "postgres",
+		Healthy: false,
+		Exit:    2,
+		Checks: []CheckResult{
+			{Name: "connectivity", Status: "ok", Message: "connected to postgres"},
+			{Name: "drift-summary", Status: "fail", Message: "drift detected in 1 migration(s)"},
+			{Name: "security-flags", Status: "warn", Message: "url_env missing"},
+		},
+	}
+	out := renderDoctorHuman([]*DoctorReport{rep})
+	if !strings.Contains(out, "Target: prod (postgres)") {
+		t.Errorf("rendered output missing target header: %s", out)
+	}
+	if !strings.Contains(out, "[OK]    connectivity") {
+		t.Errorf("rendered output missing [OK]: %s", out)
+	}
+	if !strings.Contains(out, "[FAIL]  drift-summary") {
+		t.Errorf("rendered output missing [FAIL]: %s", out)
+	}
+	if !strings.Contains(out, "[WARN]  security-flags") {
+		t.Errorf("rendered output missing [WARN]: %s", out)
+	}
+	if !strings.Contains(out, "Result: ISSUES DETECTED (exit 2)") {
+		t.Errorf("rendered output missing verdict: %s", out)
+	}
+}

--- a/docs/doctor-checks.md
+++ b/docs/doctor-checks.md
@@ -1,0 +1,116 @@
+# dbtools doctor Checks & Exit Codes
+
+`dbtools doctor [target] [--json]` is a strictly **read-only** health, integrity, and security auditing command for target databases.
+
+It never modifies the database, creates tables, writes to the ledger, or mutates state.
+
+---
+
+## Exit-Code Contract
+
+`dbtools doctor` communicates health status via process exit codes for integration with CI pipelines, deploy gates, and AI coding agents:
+
+| Exit Code | Meaning | Details |
+|---|---|---|
+| **`0`** | **HEALTHY** | All checks passed (`[OK]` or `[WARN]`). Database is up to date, ledger is intact, hashes match, and credentials are safe. |
+| **`1`** | **ERROR** | Unreachable target, database connection failure, invalid configuration, or unreadable migrations directory. |
+| **`2`** | **ISSUES DETECTED** | Health/integrity violations found: schema drift detected, content-hash mismatch, pending migrations, or dirty ledger state. |
+
+---
+
+## Check Reference
+
+`dbtools doctor` executes 6 independent diagnostic checks:
+
+### 1. `connectivity`
+- Resolves the target's connection string from its configured `url_env` environment variable.
+- Confirms the database engine is registered (`sqlite`, `postgres`, `mssql`).
+- Establishes a connection and pings the database server.
+- **Fail (`exit 1`)**: Connection refused, bad credentials, timeout, or unknown target.
+
+### 2. `ledger-integrity`
+- Inspects the `dbtools_migration_history` ledger table.
+- For each applied migration with a recorded SHA-256 hash, verifies the migration file on disk matches the hash recorded when applied.
+- **Warn**: Ledger uninitialized (no ledger table yet).
+- **Fail (`exit 2`)**: Content hash mismatch (migration file edited post-apply) or corrupted history.
+
+### 3. `version-sync`
+- Compares the live database migration version against `.up.sql` files in `migrations_dir`.
+- Detects pending migrations that need to be applied.
+- **Fail (`exit 2`)**: One or more pending migrations detected.
+- **OK**: Database is fully up to date or cleanly unmigrated.
+
+### 4. `drift-summary`
+- Inspects live database schema objects (tables, functions) created by applied migrations.
+- Flags any objects dropped or altered out-of-band outside of dbtools migrations.
+- **Warn**: Skipped if ledger is empty or uninitialized.
+- **Fail (`exit 2`)**: Schema drift detected (applied objects missing or dropped).
+
+### 5. `dirty-ledger`
+- Reads the `dirty` flag from migration version tracking.
+- Surfaces partial migration failures where a previous migration failed partway through execution.
+- **Fail (`exit 2`)**: Target is marked `dirty=true`.
+
+### 6. `security-flags`
+- Verifies connection strings are sourced from environment variables (`url_env`) rather than plaintext in config.
+- Reports target protection status (`protected=true` vs `protected=false`).
+- Validates the migrations directory exists and contains no duplicate versions or malformed files.
+- **Warn**: Plaintext URLs or missing directories.
+
+---
+
+## Example Usage & Output
+
+### Human Mode (Single Target)
+```bash
+$ dbtools doctor local
+Target: local (sqlite)
+  [OK]    connectivity       connected to database (sqlite)
+  [OK]    ledger-integrity   4 ledger entries verified (hashes match)
+  [OK]    version-sync       up to date (version 20260822000004)
+  [OK]    drift-summary      no schema drift detected
+  [OK]    dirty-ledger       ledger clean (dirty=false)
+  [OK]    security-flags     url_env=DBTOOLS_LOCAL_URL, protected=false
+Result: HEALTHY (exit 0)
+```
+
+### Human Mode (All Targets with Issues)
+```bash
+$ dbtools doctor
+Target: local (sqlite)
+  [OK]    connectivity       connected to database (sqlite)
+  [OK]    ledger-integrity   4 ledger entries verified (hashes match)
+  [OK]    version-sync       up to date (version 20260822000004)
+  [OK]    drift-summary      no schema drift detected
+  [OK]    dirty-ledger       ledger clean (dirty=false)
+  [OK]    security-flags     url_env=DBTOOLS_LOCAL_URL, protected=false
+Result: HEALTHY (exit 0)
+
+Target: staging (postgres)
+  [OK]    connectivity       connected to database (postgres)
+  [FAIL]  ledger-integrity   content hash mismatch in 1 migration(s)
+  [FAIL]  version-sync       1 pending migration(s) (current version 20260822000003)
+  [FAIL]  drift-summary      drift detected in 1 migration(s)
+  [OK]    dirty-ledger       ledger clean (dirty=false)
+  [OK]    security-flags     url_env=DBTOOLS_STAGING_URL, protected=false
+Result: ISSUES DETECTED (exit 2)
+```
+
+### JSON Mode (`--json`)
+```bash
+$ dbtools doctor local --json
+{
+  "target": "local",
+  "engine": "sqlite",
+  "healthy": true,
+  "exit": 0,
+  "checks": [
+    {"name": "connectivity", "status": "ok", "message": "connected to database (sqlite)"},
+    {"name": "ledger-integrity", "status": "ok", "message": "4 ledger entries verified (hashes match)"},
+    {"name": "version-sync", "status": "ok", "message": "up to date (version 20260822000004)"},
+    {"name": "drift-summary", "status": "ok", "message": "no schema drift detected"},
+    {"name": "dirty-ledger", "status": "ok", "message": "ledger clean (dirty=false)"},
+    {"name": "security-flags", "status": "ok", "message": "url_env=DBTOOLS_LOCAL_URL, protected=false"}
+  ]
+}
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -589,6 +589,11 @@ Target: local
               <td>Displays applied/pending migration status across all configured targets.</td>
             </tr>
             <tr>
+              <td><code>doctor</code></td>
+              <td><code>dbtools doctor [target] [--json]</code></td>
+              <td>Strictly read-only health, integrity, drift, and security audit. Exit 0 healthy / 1 error / 2 issues.</td>
+            </tr>
+            <tr>
               <td><code>plan</code></td>
               <td><code>dbtools plan [--target X] [--json]</code></td>
               <td>Read-only preview of pending migrations + ledger drift. Exit 0 = safe to apply, 2 = pending/drift.</td>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,8 +30,8 @@ same core.
 | v0.2 ✅ | **Agent ergonomics** | Universal `--json`, `--dry-run`, non-interactive mode, dirty-ledger refusal, exit-code contract. Shipped in v0.2.0. |
 | v0.2 ✅ | **TypeScript generation** | `generate --lang ts [--zod]` — Supabase-style interfaces + zod. Shipped in v0.2.0. |
 | v0.2 ✅ | **npx installer** | `dbtools-cli` npm wrapper — thin downloader of the GoReleaser binary (5 platforms). Published via OIDC trusted publishing (no token). Shipped 0.2.1. |
-| v0.3 | **`doctor`** | Read-only health/security check: connectivity, version sync, ledger integrity, drift summary, basic security flags. One-call parseable health. |
-| v0.3 | **Real-data integration suite** | Committed classicmodels-derived fixture corpus (per-dialect: sqlite/postgres/mssql), consolidated runner, edge-case matrix, golden typegen. See test-asset plan. |
+| v0.3 ✅ | **`doctor`** | Read-only health/security check: connectivity, version sync, ledger integrity, drift summary, dirty-ledger, basic security flags. Exit 0 clean / 1 error / 2 issues. |
+| v0.3 ✅ | **Real-data integration suite** | Committed classicmodels fixture corpus across sqlite/postgres/mssql, consolidated runner in `internal/testutil`, edge-case matrix, golden typegen. |
 | v0.3/4 | **Clone prod→dev** | Schema + data clone with config-driven masking. Masking on by default; raw copy requires explicit opt-out. |
 | v0.3/4 | **MySQL engine** | Add MySQL as a supported migration engine (golang-migrate has a mysql driver). classicmodels fixtures are MySQL-native — natural fit. Scheduled after v0.3 core. |
 | v0.4 | **Backup** | Table-stakes backup/restore. |

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -45,6 +45,9 @@ dbtools reset
 # Check status of applied/pending migrations
 dbtools status [--json]
 
+# Comprehensive health, integrity, and drift check (read-only; exit 0 healthy, 1 error, 2 issues)
+dbtools doctor [target_name] [--json]
+
 # Preview pending migrations + drift (agent/CI-safe: exit 0 = applyable, 2 = pending/drift)
 dbtools plan [--target X] [--json]
 


### PR DESCRIPTION
## Summary
- Implement `dbtools doctor [target] [--json]` for read-only database health, integrity, and security auditing.
- Implements all 6 specified diagnostic checks:
  1. `connectivity`: resolve URL from `url_env`, engine resolution, and ping.
  2. `ledger-integrity`: inspect ledger records and verify content SHA-256 hash match against disk.
  3. `version-sync`: compare live version cursor vs disk migration files and detect pending migrations.
  4. `drift-summary`: non-destructive live schema object existence check.
  5. `dirty-ledger`: surface partial migration failures.
  6. `security-flags`: verify environment variable credential isolation, protected flags, and migration directory validity.
- Stable exit code contract:
  - `0`: all healthy
  - `1`: error / unreachable / invalid config
  - `2`: health issues detected
- Add comprehensive unit test suite in `cmd/doctor_test.go`.
- Add documentation in `docs/doctor-checks.md` and update `README.md`, `docs/index.html`, `skills/using-dbtools/SKILL.md`, and `docs/roadmap.md`.