### PR TITLE
fix(ci): isolate internal/container integration tests from service containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,20 @@ jobs:
       - name: NPM package test
         run: node npm/test.js
 
+  container:
+    name: Integration (container)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+      # internal/container manages its own docker lifecycle (start/stop/idempotent)
+      # with tool-owned names/ports. Runs WITHOUT service containers so its
+      # published ports (14330/54320) can't collide with anything else.
+      - name: Container integration tests
+        run: go test -tags=integration -p 1 ./internal/container/... -count=1
+
   integration:
     name: Integration (${{ matrix.db }})
     runs-on: ubuntu-latest
@@ -100,7 +114,9 @@ jobs:
         run: |
           case "${{ matrix.db }}" in
             mssql)
-              go test -tags=integration -p 1 ./... -count=1
+              # internal/container has its own docker lifecycle (container job);
+              # exclude it here to avoid colliding with the service containers.
+              go test -tags=integration -p 1 $(go list ./... | grep -v '/internal/container$') -count=1
               ;;
             postgres)
               go test -tags=integration -p 1 ./internal/engine/postgresengine/... ./internal/verify/... -count=1

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -64,6 +64,9 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 		report.Healthy = false
 		return report
 	}
+	// Set engine early so human/JSON output has it even when a later
+	// connectivity check fails before engine resolution.
+	report.Engine = tConfig.Engine
 
 	// 1. Security flags & config check
 	secStatus := "ok"


### PR DESCRIPTION
## What
Fix a flaky CI collision: the mssql integration job ran `go test -tags=integration ./...`, which included `internal/container` tests that spin up their own docker containers (`dbtools-postgres-local` on `:54320`). When the postgres service container was up on the same runner, `StartFor(postgres)` failed with `address already in use` on `0.0.0.0:54320`.

## Changes
1. **New `container` job** in `ci.yml` — no service containers, runs `go test -tags=integration -p 1 ./internal/container/... -count=1` in isolation.
2. **mssql job** now excludes `/internal/container$` from its `./...` sweep (`$(go list ./... | grep -v '/internal/container$')`) — the container package's docker-lifecycle tests no longer share a runner with the service containers.
3. **doctor.go** (found in review): `report.Engine` stayed empty on early connectivity-failure paths, rendering `Target: x ()`. Set it from the target config before the early returns.

## Root cause
`internal/container` is the only package that manages its own docker lifecycle (start/stop/idempotent via `docker run -p 14330/54320`). It was only exercised inside the mssql job's `./...` sweep — where the postgres service container was also running — so the two docker port spaces collided. It belongs in its own job, which also fixes coverage (the postgres job never ran it).

## Verified
- `go build ./... && go vet ./...` ✓
- `go test ./cmd/` ✓
- `go test -tags=integration -p 1 ./internal/container/...` ✓ (locally, docker)
- `go test -tags=integration -p 1 $(go list ./... | grep -v '/internal/container$')` ✓ (exact mssql-job command)
- `gofmt -l .` clean
