### PR TITLE
feat(devloop): readiness polling, target database auto-creation, reset target support (#34, #35, #38)

### DIFF
--- a/cmd/localenv_test.go
+++ b/cmd/localenv_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/seanpham99/dbtools/internal/config"
 	"github.com/seanpham99/dbtools/internal/localenv"
@@ -55,7 +56,7 @@ func TestRunStartWritesLocalEnv(t *testing.T) {
 	})
 
 	loadConfig = fakeLocalConfig("DBTOOLS_LOCAL_URL")
-	startContainer = func(string) (string, error) {
+	startContainer = func(string, time.Duration, bool) (string, error) {
 		return "mssql://sa:pw@localhost:14330?database=dbtools_local", nil
 	}
 	var wrote map[string]string
@@ -83,7 +84,7 @@ func TestRunStartUsesConfiguredURLEnv(t *testing.T) {
 	})
 
 	loadConfig = fakeLocalConfig("CUSTOM_LOCAL_URL")
-	startContainer = func(string) (string, error) {
+	startContainer = func(string, time.Duration, bool) (string, error) {
 		return "mssql://sa:pw@localhost:14330?database=dbtools_local", nil
 	}
 	var wrote map[string]string
@@ -154,7 +155,7 @@ func TestRunStartWritesFileRelativeToWorkingDirectory(t *testing.T) {
 		startContainer = origStartContainer
 	})
 	loadConfig = fakeLocalConfig("DBTOOLS_LOCAL_URL")
-	startContainer = func(string) (string, error) {
+	startContainer = func(string, time.Duration, bool) (string, error) {
 		return "mssql://sa:pw@localhost:14330?database=dbtools_local", nil
 	}
 

--- a/cmd/openTarget.go
+++ b/cmd/openTarget.go
@@ -27,6 +27,9 @@ func OpenTarget(cfg *config.Config, targetName, urlOverride string) (eng engine.
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
+	if t, ok := cfg.Targets[targetName]; !ok || !t.Protected {
+		_ = engine.EnsureDatabase(eng, url)
+	}
 	db, err = eng.Open(url)
 	if err != nil {
 		return nil, nil, nil, "", err

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -23,21 +23,33 @@ var seedRun = seed.Run
 
 var resetLocalDatabase = recreateLocalDatabase
 
-var resetYes bool
+var (
+	resetYes    bool
+	resetTarget string
+)
 
 var resetCmd = &cobra.Command{
-	Use:   "reset",
-	Short: "Drop, recreate, replay migrations, and run seed.sql against the local database",
+	Use:   "reset [target]",
+	Short: "Drop, recreate, replay migrations, and run seed.sql against an unprotected target",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !resetYes {
-			return fmt.Errorf("refusing to drop and recreate the local database without --yes")
+		target := resetTarget
+		if len(args) > 0 && args[0] != "" {
+			target = args[0]
 		}
-		return runReset()
+		if target == "" {
+			target = "local"
+		}
+		if !resetYes {
+			return fmt.Errorf("refusing to drop and recreate target %q database without --yes", target)
+		}
+		return runReset(target)
 	},
 }
 
 func init() {
-	resetCmd.Flags().BoolVar(&resetYes, "yes", false, "confirm the destructive drop/recreate of the local database")
+	resetCmd.Flags().StringVar(&resetTarget, "target", "local", "target database to reset (default: local)")
+	resetCmd.Flags().BoolVar(&resetYes, "yes", false, "confirm the destructive drop/recreate of the target database")
 	rootCmd.AddCommand(resetCmd)
 }
 
@@ -114,33 +126,41 @@ func recreateSQLiteFile(localURL string) error {
 	return f.Close()
 }
 
-func runReset() error {
+func runReset(targetNames ...string) error {
+	targetName := "local"
+	if len(targetNames) > 0 && targetNames[0] != "" {
+		targetName = targetNames[0]
+	}
 	cfg, err := loadConfig("dbtools.toml")
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)
 	}
 
-	// Validate the configured local target (URL resolvable, engine matches
+	if err := requireUnprotected(cfg, targetName); err != nil {
+		return err
+	}
+
+	// Validate the configured target (URL resolvable, engine matches
 	// its scheme) BEFORE the destructive drop/recreate — a misconfigured
-	// target must never leave the local database wiped and then fail.
-	localURL, err := cfg.ResolveURL("local")
+	// target must never leave the database wiped and then fail.
+	targetURL, err := cfg.ResolveURL(targetName)
 	if err != nil {
 		return err
 	}
-	eng, err := engine.ForTarget(cfg.EngineName("local"), localURL)
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), targetURL)
 	if err != nil {
 		return err
 	}
 
-	if err := resetLocalDatabase(eng, localURL); err != nil {
+	if err := resetLocalDatabase(eng, targetURL); err != nil {
 		return err
 	}
 
-	status, err := applyRun(cfg, "local", "")
+	status, err := applyRun(cfg, targetName, "")
 	if err != nil {
 		return err
 	}
-	seedErr := seedRun(eng, localURL)
+	seedErr := seedRun(eng, targetURL)
 	if seedErr != nil {
 		return fmt.Errorf("running %s: %w", seed.Filename, seedErr)
 	}
@@ -152,7 +172,7 @@ func runReset() error {
 			HasVersion      bool   `json:"has_version"`
 			SeedApplied     bool   `json:"seed_applied"`
 		}{
-			Target:          "local",
+			Target:          targetName,
 			ReplayedVersion: status.CurrentVersion,
 			HasVersion:      status.HasVersion,
 			SeedApplied:     true,
@@ -164,7 +184,7 @@ func runReset() error {
 		return nil
 	}
 
-	fmt.Printf("local: replayed to version %d\n", status.CurrentVersion)
+	fmt.Printf("%s: replayed to version %d\n", targetName, status.CurrentVersion)
 	fmt.Printf("%s applied (or skipped if absent)\n", seed.Filename)
 	return nil
 }

--- a/cmd/reset_test.go
+++ b/cmd/reset_test.go
@@ -52,8 +52,8 @@ func TestRunResetRecreatesAppliesAndSeedsLocal(t *testing.T) {
 		return nil
 	}
 
-	if err := runReset(); err != nil {
-		t.Fatalf("runReset() returned error: %v", err)
+	if err := runReset("local"); err != nil {
+		t.Fatalf("runReset(local) returned error: %v", err)
 	}
 	if !resetCalled {
 		t.Fatal("runReset() did not recreate the local database")
@@ -63,5 +63,23 @@ func TestRunResetRecreatesAppliesAndSeedsLocal(t *testing.T) {
 	}
 	if !seedCalled {
 		t.Fatal("runReset() did not run seed.sql")
+	}
+}
+
+func TestRunResetRefusesProtectedTarget(t *testing.T) {
+	origLoadConfig := loadConfig
+	t.Cleanup(func() { loadConfig = origLoadConfig })
+
+	loadConfig = func(path string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets: map[string]config.Target{
+				"prod": {URLEnv: "DBTOOLS_PROD_URL", Protected: true},
+			},
+		}, nil
+	}
+
+	if err := runReset("prod"); err == nil {
+		t.Fatal("runReset(prod) succeeded on protected target, want error")
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,15 +2,21 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/seanpham99/dbtools/internal/container"
 	"github.com/seanpham99/dbtools/internal/localenv"
 	"github.com/spf13/cobra"
 )
 
-var startContainer = container.StartFor
+var startContainer = container.StartForWithTimeout
 
 var writeLocalEnv = localenv.Write
+
+var (
+	startTimeout time.Duration
+	startNoWait  bool
+)
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -21,6 +27,8 @@ var startCmd = &cobra.Command{
 }
 
 func init() {
+	startCmd.Flags().DurationVar(&startTimeout, "timeout", 30*time.Second, "maximum time to wait for the database engine to become ready")
+	startCmd.Flags().BoolVar(&startNoWait, "no-wait", false, "return immediately after starting container without waiting for database readiness")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -40,7 +48,10 @@ func runStart() error {
 		return nil
 	}
 
-	url, err := startContainer(engineName)
+	if !startNoWait {
+		fmt.Println("waiting for database engine to accept connections...")
+	}
+	url, err := startContainer(engineName, startTimeout, !startNoWait)
 	if err != nil {
 		return err
 	}

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -27,6 +27,10 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
+	if t, ok := cfg.Targets[targetName]; !ok || !t.Protected {
+		_ = engine.EnsureDatabase(eng, url)
+	}
+
 	m, err := migrator.Open(url, cfg.MigrationsDir)
 	if err != nil {
 		return nil, err

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	_ "github.com/microsoft/go-mssqldb"
 )
 
 // DatabaseName is the local development database every engine's container
@@ -51,6 +52,16 @@ var mssqlSpec = spec{
 		}
 	},
 	readyProbe: func(s spec) error {
+		u, err := url.Parse(s.url(s, "master"))
+		if err == nil {
+			u.Scheme = "sqlserver"
+			if db, err := sql.Open("sqlserver", u.String()); err == nil {
+				defer db.Close()
+				if pingErr := db.Ping(); pingErr == nil {
+					return nil
+				}
+			}
+		}
 		return exec.Command("docker", "exec", s.name, "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", password, "-C", "-Q", "SELECT 1").Run()
 	},
 	createDBArgs: func(s spec) []string {
@@ -191,9 +202,10 @@ func inspect(containerName string) (exists bool, running bool, err error) {
 	return parseInspectOutput(out.Bytes(), runErr)
 }
 
-// StartFor starts (or reuses) engineName's tool-owned local container and
-// returns the local database's connection URL.
-func StartFor(engineName string) (string, error) {
+// StartForWithTimeout starts (or reuses) engineName's tool-owned local container,
+// waits up to timeout for readiness if wait is true, and returns the local
+// database's connection URL.
+func StartForWithTimeout(engineName string, timeout time.Duration, wait bool) (string, error) {
 	s, err := specFor(engineName)
 	if err != nil {
 		return "", err
@@ -218,8 +230,10 @@ func StartFor(engineName string) (string, error) {
 		}
 	}
 
-	if err := waitReady(s); err != nil {
-		return "", err
+	if wait {
+		if err := waitReadyWithTimeout(s, timeout); err != nil {
+			return "", err
+		}
 	}
 	if s.createDBArgs != nil {
 		if out, err := exec.Command("docker", s.createDBArgs(s)...).CombinedOutput(); err != nil {
@@ -229,15 +243,24 @@ func StartFor(engineName string) (string, error) {
 	return s.url(s, DatabaseName), nil
 }
 
-func waitReady(s spec) error {
-	deadline := time.Now().Add(60 * time.Second)
+// StartFor starts (or reuses) engineName's tool-owned local container and
+// returns the local database's connection URL.
+func StartFor(engineName string) (string, error) {
+	return StartForWithTimeout(engineName, 30*time.Second, true)
+}
+
+func waitReadyWithTimeout(s spec, timeout time.Duration) error {
+	if timeout <= 0 {
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if err := s.readyProbe(s); err == nil {
 			return nil
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
-	return fmt.Errorf("%s did not become ready within 60s", s.engine)
+	return fmt.Errorf("%s did not become ready within %v", s.engine, timeout)
 }
 
 // StopFor stops and removes engineName's tool-owned local container.

--- a/internal/engine/ensure.go
+++ b/internal/engine/ensure.go
@@ -1,0 +1,142 @@
+package engine
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "github.com/lib/pq"
+	_ "github.com/microsoft/go-mssqldb"
+)
+
+// EnsureDatabase creates the database specified in rawURL if it does not
+// already exist. It only acts when the database instance is reachable via its
+// administrative database (e.g. "postgres" on PostgreSQL or "master" on MSSQL).
+// For SQLite, it ensures the parent directory exists on disk.
+func EnsureDatabase(eng Engine, rawURL string) error {
+	if eng == nil {
+		var err error
+		eng, err = ForURL(rawURL)
+		if err != nil {
+			return err
+		}
+	}
+
+	switch eng.Name() {
+	case "sqlite":
+		return ensureSQLitePath(rawURL)
+	case "postgres":
+		return ensurePostgresDatabase(rawURL)
+	case "mssql":
+		return ensureMSSQLDatabase(rawURL)
+	default:
+		return nil
+	}
+}
+
+func ensureSQLitePath(rawURL string) error {
+	path := strings.TrimPrefix(rawURL, "sqlite://")
+	if path == "" || path == ":memory:" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("creating sqlite directory %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func ensurePostgresDatabase(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	dbName := strings.TrimPrefix(u.Path, "/")
+	if dbName == "" || dbName == "postgres" {
+		return nil
+	}
+
+	// First test if target DB already exists and is reachable
+	testDB, err := sql.Open("postgres", rawURL)
+	if err == nil {
+		if pingErr := testDB.Ping(); pingErr == nil {
+			testDB.Close()
+			return nil
+		}
+		testDB.Close()
+	}
+
+	// Connect to default maintenance database "postgres"
+	mURL := *u
+	mURL.Path = "/postgres"
+	mainDB, err := sql.Open("postgres", mURL.String())
+	if err != nil {
+		return nil
+	}
+	defer mainDB.Close()
+
+	if err := mainDB.Ping(); err != nil {
+		return nil
+	}
+
+	var exists bool
+	_ = mainDB.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", dbName).Scan(&exists)
+	if !exists {
+		safeName := strings.ReplaceAll(dbName, `"`, `""`)
+		_, _ = mainDB.Exec(fmt.Sprintf(`CREATE DATABASE "%s"`, safeName))
+	}
+	return nil
+}
+
+func ensureMSSQLDatabase(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	q := u.Query()
+	dbName := q.Get("database")
+	if dbName == "" || strings.EqualFold(dbName, "master") {
+		return nil
+	}
+
+	sqlserverURL := *u
+	sqlserverURL.Scheme = "sqlserver"
+
+	// Test if target DB is already accessible
+	testDB, err := sql.Open("sqlserver", sqlserverURL.String())
+	if err == nil {
+		if pingErr := testDB.Ping(); pingErr == nil {
+			testDB.Close()
+			return nil
+		}
+		testDB.Close()
+	}
+
+	// Connect to master database
+	mURL := *u
+	mURL.Scheme = "sqlserver"
+	mq := mURL.Query()
+	mq.Set("database", "master")
+	mURL.RawQuery = mq.Encode()
+
+	mainDB, err := sql.Open("sqlserver", mURL.String())
+	if err != nil {
+		return nil
+	}
+	defer mainDB.Close()
+
+	if err := mainDB.Ping(); err != nil {
+		return nil
+	}
+
+	safeName := strings.ReplaceAll(dbName, "]", "]]")
+	safeLiteral := strings.ReplaceAll(dbName, "'", "''")
+	query := fmt.Sprintf("IF DB_ID(N'%s') IS NULL CREATE DATABASE [%s]", safeLiteral, safeName)
+	_, _ = mainDB.Exec(query)
+	return nil
+}

--- a/internal/engine/ensure_test.go
+++ b/internal/engine/ensure_test.go
@@ -1,0 +1,30 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureDatabaseSQLite(t *testing.T) {
+	withFake(t, "sqlite")
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "nested", "sub", "test.db")
+	rawURL := "sqlite://" + dbPath
+
+	if err := EnsureDatabase(nil, rawURL); err != nil {
+		t.Fatalf("EnsureDatabase(sqlite) failed: %v", err)
+	}
+
+	dir := filepath.Dir(dbPath)
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		t.Fatalf("expected directory %s to exist, err: %v", dir, err)
+	}
+}
+
+func TestEnsureDatabaseInvalidURL(t *testing.T) {
+	err := EnsureDatabase(nil, "://invalid-url")
+	if err == nil {
+		t.Fatal("expected error for invalid URL, got nil")
+	}
+}


### PR DESCRIPTION
Closes #34, closes #35, closes #38.

### Summary
1. **Container Readiness Polling (#34)**: Adds readiness polling in `container.StartForWithTimeout` and `--timeout`/`--no-wait` flags to `dbtools start`.
2. **Missing Database Auto-Creation (#35)**: Auto-creates target database on local/unprotected targets when connecting to reachable container/database instances.
3. **Reset Target Support (#38)**: Enhances `dbtools reset` to support optional target name (`[target]` or `--target <target>`) on unprotected targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added target selection to the reset command, including target flags, confirmation requirements, and target-specific output.
  * Added configurable startup timeouts and an option to skip readiness waiting.
  * Databases are now automatically prepared when needed for supported targets.
  * Improved database container readiness checks, including MSSQL support.

* **Bug Fixes**
  * Prevented reset operations on protected targets.
  * Improved handling of database setup during application and connection startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->