### PR TITLE
feat(cli): add force command for dirty recovery and status target filtering (#36, #37)

### DIFF
--- a/cmd/force.go
+++ b/cmd/force.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	forceTarget string
+	forceYes    bool
+)
+
+var forceCmd = &cobra.Command{
+	Use:   "force <version>",
+	Short: "Force the migration tracking version and clear dirty state without running SQL",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid version %q: %w", args[0], err)
+		}
+		if !forceYes {
+			return fmt.Errorf("force modifies migration version state directly without executing SQL — pass --yes to confirm")
+		}
+		return runForce(forceTarget, version)
+	},
+}
+
+func init() {
+	forceCmd.Flags().StringVar(&forceTarget, "target", "local", "target database to force version on")
+	forceCmd.Flags().BoolVar(&forceYes, "yes", false, "confirm forcing migration version and clearing dirty state")
+	rootCmd.AddCommand(forceCmd)
+}
+
+func runForce(targetName string, version uint64) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+	if err := requireUnprotected(cfg, targetName); err != nil {
+		return err
+	}
+
+	eng, db, m, _, err := OpenTarget(cfg, targetName, "")
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	defer m.Close()
+
+	if err := m.Force(version); err != nil {
+		return err
+	}
+
+	// Also update ledger status
+	note := fmt.Sprintf("forced to version %d via force command", version)
+	_ = eng.Ledger().SetStatus(db, version, ledger.StatusApplied, note)
+
+	if jsonOutput {
+		b, err := json.Marshal(struct {
+			Target  string `json:"target"`
+			Version uint64 `json:"version"`
+			Dirty   bool   `json:"dirty"`
+		}{
+			Target:  targetName,
+			Version: version,
+			Dirty:   false,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}
+
+	fmt.Printf("%s: forced to version %d (dirty flag cleared)\n", targetName, version)
+	return nil
+}

--- a/cmd/force_test.go
+++ b/cmd/force_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/config"
+	_ "github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+)
+
+func TestRunForceRefusesWithoutYes(t *testing.T) {
+	origForceYes := forceYes
+	t.Cleanup(func() { forceYes = origForceYes })
+	forceYes = false
+
+	rootCmd.SetArgs([]string{"force", "20260101000000"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error running force without --yes, got nil")
+	}
+}
+
+func TestRunForceRefusesProtectedTarget(t *testing.T) {
+	origLoadConfig := loadConfig
+	origForceYes := forceYes
+	t.Cleanup(func() {
+		loadConfig = origLoadConfig
+		forceYes = origForceYes
+	})
+	forceYes = true
+
+	loadConfig = func(path string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets: map[string]config.Target{
+				"prod": {URLEnv: "DBTOOLS_PROD_URL", Protected: true},
+			},
+		}, nil
+	}
+
+	err := runForce("prod", 20260101000000)
+	if err == nil {
+		t.Fatal("expected error running force against protected target, got nil")
+	}
+}
+
+func TestRunForceSuccessSQLite(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "force_test.db")
+	migrationsDir := filepath.Join(tmpDir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatalf("creating migrations dir: %v", err)
+	}
+
+	migSQL := "CREATE TABLE items (id INTEGER PRIMARY KEY);"
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260101000000_init.up.sql"), []byte(migSQL), 0o644); err != nil {
+		t.Fatalf("writing migration file: %v", err)
+	}
+
+	origLoadConfig := loadConfig
+	origForceYes := forceYes
+	t.Cleanup(func() {
+		loadConfig = origLoadConfig
+		forceYes = origForceYes
+	})
+	forceYes = true
+
+	t.Setenv("DBTOOLS_TEST_FORCE_URL", "sqlite://"+dbPath)
+
+	loadConfig = func(path string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: migrationsDir,
+			Targets: map[string]config.Target{
+				"local": {URLEnv: "DBTOOLS_TEST_FORCE_URL"},
+			},
+		}, nil
+	}
+
+	if err := runForce("local", 20260101000000); err != nil {
+		t.Fatalf("runForce(local, 20260101000000) returned error: %v", err)
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,10 +11,15 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show migration status for every configured target",
+	Use:   "status [target]",
+	Short: "Show migration status for every configured target (or a single target)",
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runStatus()
+		target := statusTarget
+		if len(args) > 0 && args[0] != "" {
+			target = args[0]
+		}
+		return runStatus(target)
 	},
 }
 
@@ -33,35 +38,15 @@ type targetFailure struct {
 	Error  string
 }
 
-// statusJSONEntry is the --json shape for one target: either the fields
-// from statusinfo.Status, or just Target+Error when that target couldn't
-// be reached.
+// statusJSONEntry is the --json shape for one target.
 type statusJSONEntry struct {
 	Target         string   `json:"target"`
 	CurrentVersion uint64   `json:"current_version,omitempty"`
 	HasVersion     bool     `json:"has_version,omitempty"`
 	Dirty          bool     `json:"dirty,omitempty"`
 	Pending        []string `json:"pending,omitempty"`
+	Unconfigured   bool     `json:"unconfigured,omitempty"`
 	Error          string   `json:"error,omitempty"`
-}
-
-// buildStatusEntries merges successful and failed target results into one
-// ordered slice for --json output.
-func buildStatusEntries(statuses []statusinfo.Status, failures []targetFailure) []statusJSONEntry {
-	entries := make([]statusJSONEntry, 0, len(statuses)+len(failures))
-	for _, s := range statuses {
-		entries = append(entries, statusJSONEntry{
-			Target:         s.Target,
-			CurrentVersion: s.CurrentVersion,
-			HasVersion:     s.HasVersion,
-			Dirty:          s.Dirty,
-			Pending:        s.Pending,
-		})
-	}
-	for _, f := range failures {
-		entries = append(entries, statusJSONEntry{Target: f.Target, Error: f.Error})
-	}
-	return entries
 }
 
 func collectStatuses(cfg *config.Config) ([]statusinfo.Status, []targetFailure) {
@@ -81,6 +66,10 @@ func collectStatuses(cfg *config.Config) ([]statusinfo.Status, []targetFailure) 
 func renderStatusTable(results []statusinfo.TargetResult) string {
 	var b strings.Builder
 	for _, r := range results {
+		if r.Unconfigured {
+			fmt.Fprintf(&b, "%-10s  [unconfigured]\n", r.Target)
+			continue
+		}
 		if r.Err != nil {
 			fmt.Fprintf(&b, "%-10s  error: %s\n", r.Target, r.Err.Error())
 			continue
@@ -99,25 +88,42 @@ func renderStatusTable(results []statusinfo.TargetResult) string {
 	return b.String()
 }
 
-func runStatus() error {
+func runStatus(targetNames ...string) error {
+	target := statusTarget
+	if len(targetNames) > 0 && targetNames[0] != "" {
+		target = targetNames[0]
+	}
 	cfg, err := loadConfig("dbtools.toml")
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)
 	}
 
-	results := statusinfo.CollectAll(cfg, statusTarget, statusURL)
+	results := statusinfo.CollectAll(cfg, target, statusURL)
 
 	if jsonOutput {
-		var statuses []statusinfo.Status
-		var failures []targetFailure
+		entries := make([]statusJSONEntry, 0, len(results))
 		for _, r := range results {
-			if r.Err != nil {
-				failures = append(failures, targetFailure{Target: r.Target, Error: r.Err.Error()})
+			if r.Unconfigured {
+				entries = append(entries, statusJSONEntry{
+					Target:       r.Target,
+					Unconfigured: true,
+				})
+			} else if r.Err != nil {
+				entries = append(entries, statusJSONEntry{
+					Target: r.Target,
+					Error:  r.Err.Error(),
+				})
 			} else if r.Status != nil {
-				statuses = append(statuses, *r.Status)
+				entries = append(entries, statusJSONEntry{
+					Target:         r.Status.Target,
+					CurrentVersion: r.Status.CurrentVersion,
+					HasVersion:     r.Status.HasVersion,
+					Dirty:          r.Status.Dirty,
+					Pending:        r.Status.Pending,
+				})
 			}
 		}
-		b, err := json.Marshal(buildStatusEntries(statuses, failures))
+		b, err := json.Marshal(entries)
 		if err != nil {
 			return err
 		}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,43 +1,49 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/seanpham99/dbtools/internal/statusinfo"
 )
 
-func TestBuildStatusEntries_MixedSuccessAndFailure(t *testing.T) {
-	statuses := []statusinfo.Status{
-		{Target: "local", CurrentVersion: 20260101000000, HasVersion: true, Dirty: false, Pending: nil},
-	}
-	failures := []targetFailure{
-		{Target: "prod", Error: `environment variable DBTOOLS_PROD_URL is not set`},
+func TestRenderStatusTable(t *testing.T) {
+	results := []statusinfo.TargetResult{
+		{
+			Target: "local",
+			Status: &statusinfo.Status{
+				Target:         "local",
+				CurrentVersion: 20260101000000,
+				HasVersion:     true,
+				Dirty:          false,
+				Pending:        nil,
+			},
+		},
+		{
+			Target:       "prod",
+			Unconfigured: true,
+		},
+		{
+			Target: "staging",
+			Status: &statusinfo.Status{
+				Target:         "staging",
+				CurrentVersion: 20260101000000,
+				HasVersion:     true,
+				Dirty:          true,
+				Pending:        []string{"20260102000000_add.up.sql"},
+			},
+		},
 	}
 
-	got := buildStatusEntries(statuses, failures)
+	out := renderStatusTable(results)
 
-	if len(got) != 2 {
-		t.Fatalf("buildStatusEntries() returned %d entries, want 2", len(got))
+	if !strings.Contains(out, "local       up to date") {
+		t.Errorf("rendered output missing local status: %s", out)
 	}
-	if got[0].Target != "local" || got[0].CurrentVersion != 20260101000000 || got[0].Error != "" {
-		t.Errorf("entry[0] = %+v, want a successful local entry with no error", got[0])
+	if !strings.Contains(out, "prod        [unconfigured]") {
+		t.Errorf("rendered output missing unconfigured prod status: %s", out)
 	}
-	if got[1].Target != "prod" || got[1].Error == "" {
-		t.Errorf("entry[1] = %+v, want a failed prod entry with a non-empty error", got[1])
-	}
-}
-
-func TestBuildStatusEntries_AllFailed(t *testing.T) {
-	failures := []targetFailure{
-		{Target: "staging", Error: "boom"},
-	}
-
-	got := buildStatusEntries(nil, failures)
-
-	if len(got) != 1 {
-		t.Fatalf("buildStatusEntries() returned %d entries, want 1", len(got))
-	}
-	if got[0].Target != "staging" || got[0].Error != "boom" {
-		t.Errorf("entry[0] = %+v, want {Target: staging, Error: boom}", got[0])
+	if !strings.Contains(out, "staging     1 pending [DIRTY]") {
+		t.Errorf("rendered output missing dirty staging status: %s", out)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,29 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
+
+// UnsetEnvError indicates a target's connection URL environment variable is not defined.
+type UnsetEnvError struct {
+	Target string
+	URLEnv string
+}
+
+func (e *UnsetEnvError) Error() string {
+	return fmt.Sprintf("target %q: environment variable %s is not set", e.Target, e.URLEnv)
+}
+
+// IsUnsetEnv reports whether err is an UnsetEnvError.
+func IsUnsetEnv(err error) bool {
+	var unset *UnsetEnvError
+	return errors.As(err, &unset)
+}
 
 // Target is one named database environment declared in dbtools.toml.
 // Its connection string is never stored in the file — URLEnv names the
@@ -68,7 +85,7 @@ func (c *Config) ResolveURL(targetName string) (string, error) {
 	}
 	url := os.Getenv(t.URLEnv)
 	if url == "" {
-		return "", fmt.Errorf("target %q: environment variable %s is not set", targetName, t.URLEnv)
+		return "", &UnsetEnvError{Target: targetName, URLEnv: t.URLEnv}
 	}
 	return url, nil
 }

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -135,6 +135,15 @@ func (mg *Migrator) Stamp(version uint64) error {
 	return nil
 }
 
+// Force sets version as the current applied migration version and clears any
+// dirty flag in the version-tracking table without executing migration SQL.
+func (mg *Migrator) Force(version uint64) error {
+	if err := mg.m.Force(int(version)); err != nil {
+		return fmt.Errorf("forcing version %d: %w", version, err)
+	}
+	return nil
+}
+
 // Close releases the underlying database connection.
 func (mg *Migrator) Close() error {
 	sourceErr, dbErr := mg.m.Close()

--- a/internal/statusinfo/collect.go
+++ b/internal/statusinfo/collect.go
@@ -17,9 +17,10 @@ type Status struct {
 
 // TargetResult is the outcome of collecting status for a single named target.
 type TargetResult struct {
-	Target string
-	Status *Status
-	Err    error
+	Target       string
+	Status       *Status
+	Unconfigured bool
+	Err          error
 }
 
 // Collect opens databaseURL, reads its current migration version, and
@@ -67,6 +68,10 @@ func CollectAll(cfg *config.Config, targetFilter, urlOverride string) []TargetRe
 		}
 		url, err := cfg.ResolveURLOrFlag(name, override)
 		if err != nil {
+			if targetFilter == "" && config.IsUnsetEnv(err) {
+				results = append(results, TargetResult{Target: name, Unconfigured: true})
+				continue
+			}
 			results = append(results, TargetResult{Target: name, Err: err})
 			continue
 		}


### PR DESCRIPTION
Closes #36, closes #37.

### Summary
1. **Force Command (#36)**: Adds `dbtools force <version> [--target <target>] [--yes]` to clear dirty migration flags and set the version cursor directly.
2. **Status Positional Target & Unconfigured Handling (#37)**: Supports `dbtools status [target]` positional filtering and renders `[unconfigured]` for unset env vars rather than hard errors in general status.