### PR TITLE
docs: sync CHANGELOG v0.3.0, README, Pages site, and skill reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-08-24
+
+v0.3 — health & security doctor audit, classicmodels real-data integration corpus, dirty recovery, and dev-loop enhancements.
+
+### Added
+
+- **Health & Security Audit (`dbtools doctor`)**:
+  - `dbtools doctor [target] [--json]` — strictly read-only check across connectivity, ledger integrity (hash comparison), version sync, live object drift summary, dirty ledger detection, and security configuration (target protection and url_env usage).
+  - Exit code contract: `0` healthy, `1` error/unreachable, `2` issues detected (drift, dirty, pending migrations, security warnings). Documented in `docs/doctor-checks.md`.
+- **Classicmodels Real-Data Integration Suite**:
+  - Committed real-data fixture corpus ported across SQLite, PostgreSQL, and MSSQL with canonical schema, foreign keys, and seed data.
+  - Consolidated test runner in `internal/testutil` exercising multi-version migration sequences, content hash drift, and golden typegen regression checks.
+- **Dirty Migration Recovery (`dbtools force`)**:
+  - `dbtools force <version> [--target <target>] [--yes]` — recovers from interrupted or dirty migration states by aligning the tracking version and clearing the dirty bit.
+- **Local Dev-Loop DX Enhancements**:
+  - `dbtools start` container readiness polling — polls port and ping until database engine accepts connections (`--timeout`, `--no-wait`).
+  - Automatic target database creation — creates missing local/unprotected databases on container instances seamlessly during dev loop.
+  - `dbtools reset [target]` — allows specifying any unprotected target (defaults to `local`).
+  - `dbtools status [target]` — supports positional target filtering and displays `[unconfigured]` for unset environment variables without erroring during general status.
+
+---
+
 ## [0.2.0] - 2026-08-21
 
 v0.2 — rollback + agent ergonomics + TypeScript generation.

--- a/README.md
+++ b/README.md
@@ -113,18 +113,19 @@ dbtools status
 | `new` | `dbtools new <name>` | Scaffolds timestamped `.up.sql` migration file. |
 | `up` | `dbtools up [--target <name>]` | Applies pending migrations to local target. Refuses protected/remote targets. |
 | `push` | `dbtools push <target> [--yes]` | Applies pending migrations to named remote target with explicit confirmation. |
-| `status` | `dbtools status [--json]` | Displays applied/pending migration status across all configured targets. |
+| `status` | `dbtools status [target] [--json]` | Displays applied/pending migration status across configured targets (`[unconfigured]` for unset env vars). |
 | `doctor` | `dbtools doctor [target] [--json]` | Strictly read-only health, integrity, drift, and security audit. Exit 0 healthy / 1 error / 2 issues. |
 | `plan` | `dbtools plan [--target X] [--json]` | Read-only preview of pending migrations + ledger drift, without applying anything. Agent/CI-friendly: exit 0 = safe to apply. |
 | `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift (content-hash mismatch or missing object). |
 | `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |
 | `rollback` | `dbtools rollback <target> [--yes]` | Ledger-only soft-revert (marks `reverted`, never data-destroying). The safe prod verb. |
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |
-| `reset` | `dbtools reset [--target local] [--yes]` | Local-only: drops database, replays all migrations from zero, and executes `seed.sql`. |
+| `force` | `dbtools force <version> [--target <target>] [--yes]` | Sets tracking version cursor and clears dirty state without running migration SQL. |
+| `reset` | `dbtools reset [target] [--yes]` | Unprotected targets: drops database, replays all migrations from zero, and executes `seed.sql`. |
 | `generate` | `dbtools generate [target] [--lang python\|ts] [--zod] [--out file]` | Introspects live schema and renders Pydantic v2 models (`python`, default) or Supabase-style TypeScript interfaces (`ts`; `--zod` adds zod schemas). |
 | `lint` | `dbtools lint [--dir <path>] [--json]` | Validates filenames, duplicate versions, and empty files without database connection. |
 | `dashboard` | `dbtools dashboard` | Opens terminal UI showing live target status (`r` to refresh, `q` to quit). |
-| `start` / `stop` | `dbtools start` / `stop` | Starts or stops ephemeral tool-owned local MSSQL Docker container. |
+| `start` / `stop` | `dbtools start [--timeout 30s] [--no-wait]` / `stop` | Starts or stops ephemeral tool-owned local database Docker container with readiness polling. |
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -434,7 +434,7 @@
       <div class="nav-wrap">
         <a href="#" class="brand">
           <span class="brand-badge">dbtools</span>
-          <span class="version-tag">v0.1.0</span>
+          <span class="version-tag">v0.3.0</span>
         </a>
         <nav class="nav-links">
           <a href="#features">Features</a>
@@ -585,8 +585,8 @@ Target: local
             </tr>
             <tr>
               <td><code>status</code></td>
-              <td><code>dbtools status [--json]</code></td>
-              <td>Displays applied/pending migration status across all configured targets.</td>
+              <td><code>dbtools status [target] [--json]</code></td>
+              <td>Displays applied/pending migration status across configured targets (<code>[unconfigured]</code> for unset env vars).</td>
             </tr>
             <tr>
               <td><code>doctor</code></td>
@@ -619,9 +619,14 @@ Target: local
               <td>Corrects ledger record status and resynchronizes the version cursor safely.</td>
             </tr>
             <tr>
+              <td><code>force</code></td>
+              <td><code>dbtools force &lt;version&gt; [--target target] [--yes]</code></td>
+              <td>Sets tracking version cursor and clears dirty state directly without executing SQL.</td>
+            </tr>
+            <tr>
               <td><code>reset</code></td>
-              <td><code>dbtools reset [--yes]</code></td>
-              <td>Local-only: drops database, replays all migrations, and runs <code>seed.sql</code>.</td>
+              <td><code>dbtools reset [target] [--yes]</code></td>
+              <td>Unprotected targets: drops database, replays all migrations, and runs <code>seed.sql</code>.</td>
             </tr>
             <tr>
               <td><code>generate</code></td>
@@ -637,6 +642,11 @@ Target: local
               <td><code>dashboard</code></td>
               <td><code>dbtools dashboard</code></td>
               <td>Interactive Bubble Tea TUI monitor (<code>r</code> to refresh, <code>q</code> to quit).</td>
+            </tr>
+            <tr>
+              <td><code>start</code> / <code>stop</code></td>
+              <td><code>dbtools start [--timeout 30s] [--no-wait]</code> / <code>stop</code></td>
+              <td>Starts or stops ephemeral tool-owned local database container with readiness polling.</td>
             </tr>
           </tbody>
         </table>

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -35,15 +35,15 @@ dbtools up [--target local]
 # Apply pending migrations to named target (explicit target name)
 dbtools push <target_name>
 
-# Start/stop tool-owned ephemeral local MSSQL container
-dbtools start
+# Start/stop tool-owned ephemeral local database container (with readiness polling)
+dbtools start [--timeout 30s] [--no-wait]
 dbtools stop
 
-# Local-only reset: drop, recreate, replay migrations, run seed.sql
-dbtools reset
+# Reset unprotected target: drop, recreate, replay migrations, run seed.sql
+dbtools reset [target]
 
-# Check status of applied/pending migrations
-dbtools status [--json]
+# Check status of applied/pending migrations across targets or for a specific target
+dbtools status [target] [--json]
 
 # Comprehensive health, integrity, and drift check (read-only; exit 0 healthy, 1 error, 2 issues)
 dbtools doctor [target_name] [--json]
@@ -60,6 +60,9 @@ dbtools down <target_name> [N] [--preview] [--yes]
 
 # Ledger-only soft-revert (marks 'reverted', never data-destroying) — safe prod verb
 dbtools rollback <target_name> [--yes]
+
+# Force tracking version cursor and clear dirty state without executing SQL
+dbtools force <version> [--target target] [--yes]
 
 # Repair ledger status (replaces old 'stamp' command)
 dbtools repair <target_name> <version>:<status> --yes [--force]


### PR DESCRIPTION
### Summary
- **CHANGELOG.md**: Add `[0.3.0]` release notes for doctor health check, classicmodels real-data suite, force dirty recovery, container readiness polling, target DB auto-creation, and status/reset CLI improvements.
- **README.md**: Synchronize CLI command table and option descriptions.
- **docs/index.html**: Bump version to v0.3.0 and synchronize command table.
- **skills/using-dbtools/SKILL.md**: Update command inventory and dev-loop workflows.