### PR TITLE
ci(release): drop registry-url from setup-node for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
         run: |

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbtools-cli",
-  "version": "0.2.1",
-  "binaryVersion": "0.2.1",
+  "version": "0.3.0",
+  "binaryVersion": "0.3.0",
   "description": "Fast schema migrations and dev databases for MSSQL, Postgres, and SQLite",
   "bin": {
     "dbtools": "bin/dbtools.js"


### PR DESCRIPTION
### Problem
When `actions/setup-node` specifies `registry-url: "https://registry.npmjs.org"` without `NODE_AUTH_TOKEN`, it writes a dummy `.npmrc` file expecting a token. During `npm publish --access public --provenance`, npm sends an empty/invalid bearer token instead of performing the OIDC exchange, causing npmjs to return `404 Not Found`.

### Solution
- Remove `registry-url` from `setup-node` step so `npm publish` cleanly uses GitHub Actions ambient OIDC ID token for Trusted Publishing.
- Bump `npm/package.json` to `0.3.0`.