### PR TITLE
fix(ensure): return errors on database provisioning failure and wire NPM_TOKEN auth in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "20"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
         run: |
@@ -55,3 +56,5 @@ jobs:
             npm version "$VERSION" --no-git-tag-version
           fi
           npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cmd/openTarget.go
+++ b/cmd/openTarget.go
@@ -28,7 +28,9 @@ func OpenTarget(cfg *config.Config, targetName, urlOverride string) (eng engine.
 		return nil, nil, nil, "", err
 	}
 	if t, ok := cfg.Targets[targetName]; !ok || !t.Protected {
-		_ = engine.EnsureDatabase(eng, url)
+		if err := engine.EnsureDatabase(eng, url); err != nil {
+			return nil, nil, nil, "", fmt.Errorf("target %q: %w", targetName, err)
+		}
 	}
 	db, err = eng.Open(url)
 	if err != nil {

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -28,7 +28,9 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 	}
 
 	if t, ok := cfg.Targets[targetName]; !ok || !t.Protected {
-		_ = engine.EnsureDatabase(eng, url)
+		if err := engine.EnsureDatabase(eng, url); err != nil {
+			return nil, fmt.Errorf("target %q: %w", targetName, err)
+		}
 	}
 
 	m, err := migrator.Open(url, cfg.MigrationsDir)

--- a/internal/engine/ensure.go
+++ b/internal/engine/ensure.go
@@ -85,10 +85,14 @@ func ensurePostgresDatabase(rawURL string) error {
 	}
 
 	var exists bool
-	_ = mainDB.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", dbName).Scan(&exists)
+	if err := mainDB.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", dbName).Scan(&exists); err != nil {
+		return fmt.Errorf("checking postgres database %q existence: %w", dbName, err)
+	}
 	if !exists {
 		safeName := strings.ReplaceAll(dbName, `"`, `""`)
-		_, _ = mainDB.Exec(fmt.Sprintf(`CREATE DATABASE "%s"`, safeName))
+		if _, err := mainDB.Exec(fmt.Sprintf(`CREATE DATABASE "%s"`, safeName)); err != nil {
+			return fmt.Errorf("creating postgres database %q: %w", dbName, err)
+		}
 	}
 	return nil
 }
@@ -137,6 +141,8 @@ func ensureMSSQLDatabase(rawURL string) error {
 	safeName := strings.ReplaceAll(dbName, "]", "]]")
 	safeLiteral := strings.ReplaceAll(dbName, "'", "''")
 	query := fmt.Sprintf("IF DB_ID(N'%s') IS NULL CREATE DATABASE [%s]", safeLiteral, safeName)
-	_, _ = mainDB.Exec(query)
+	if _, err := mainDB.Exec(query); err != nil {
+		return fmt.Errorf("creating mssql database %q: %w", dbName, err)
+	}
 	return nil
 }

--- a/internal/engine/ensure_test.go
+++ b/internal/engine/ensure_test.go
@@ -28,3 +28,23 @@ func TestEnsureDatabaseInvalidURL(t *testing.T) {
 		t.Fatal("expected error for invalid URL, got nil")
 	}
 }
+
+func TestEnsureDatabasePostgresUnreachable(t *testing.T) {
+	withFake(t, "postgres")
+	// If the database host/instance is unreachable, EnsureDatabase returns nil
+	// so the actual connection error can be handled by Open.
+	err := EnsureDatabase(nil, "postgres://user:pass@127.0.0.1:54321/testdb?sslmode=disable")
+	if err != nil {
+		t.Fatalf("expected nil for unreachable postgres instance, got: %v", err)
+	}
+}
+
+func TestEnsureDatabaseMSSQLUnreachable(t *testing.T) {
+	withFake(t, "mssql")
+	// If the database host/instance is unreachable, EnsureDatabase returns nil
+	// so the actual connection error can be handled by Open.
+	err := EnsureDatabase(nil, "mssql://sa:Pass123@127.0.0.1:54321?database=testdb")
+	if err != nil {
+		t.Fatalf("expected nil for unreachable mssql instance, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Summary
1. **Database Provisioning Error Handling**: Resolves CodeRabbit review on #39 by checking and returning wrapped errors from `QueryRow(...).Scan` and `CREATE DATABASE` `Exec` operations in `EnsureDatabase`, and propagating the error through `OpenTarget` and `apply.Run`. Added test cases for Postgres and MSSQL unreachable instances.
2. **NPM Release Auth**: Configures `registry-url` and passes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` in `.github/workflows/release.yml` so `npm publish` authenticates with the configured repository npm token.