### PR TITLE
ci: fix npm trusted publishing configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "22"
 
       - name: Publish to npm
         run: |
@@ -56,5 +55,4 @@ jobs:
             npm version "$VERSION" --no-git-tag-version
           fi
           npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
Fix npm publish error `ENEEDAUTH` by removing static `registry-url` and `NODE_AUTH_TOKEN` from `release.yml` to enable tokenless OIDC Trusted Publishing with Node 22.