### PR TITLE
ci: upgrade npm to latest for tokenless OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Publish to npm
         run: |
+          npm install -g npm@latest
           VERSION="${GITHUB_REF#refs/tags/v}"
           cd npm
           if [ "$(node -p "require('./package.json').version")" != "$VERSION" ]; then


### PR DESCRIPTION
Node 22 comes with npm 10.x, but tokenless OIDC Trusted Publishing requires npm >= 11.1.0. This adds `npm install -g npm@latest` before publishing.