### PR TITLE
docs: update README and roadmap for v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/seanpham99/dbtools.svg)](https://pkg.go.dev/github.com/seanpham99/dbtools)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**dbtools** is a lightweight, reliable database migration authority and local dev-loop tool for **MSSQL**, **PostgreSQL**, and **SQLite**. Built in Go for high performance and zero external runtime dependencies, `dbtools` guarantees version-sync migration execution, immutable ledger tracking (`content_sha256`), read-only schema drift verification, and live schema introspection to typed Pydantic Python or TypeScript models.
+**dbtools** is a lightweight, reliable database migration authority and local dev-loop tool for **MSSQL**, **PostgreSQL**, **MySQL**, and **SQLite**. Built in Go for high performance and zero external runtime dependencies, `dbtools` guarantees version-sync migration execution, immutable ledger tracking (`content_sha256`), read-only schema drift verification, and live schema introspection to typed Pydantic Python or TypeScript models.
 
 ---
 
 ## Key Features
 
 - **Multi-Engine Support**: Native migration engines for SQL Server (MSSQL), PostgreSQL (with session reset isolation), MySQL, and SQLite (file-based).
+- **Project-Scoped Local Dev Containers**: `dbtools start`/`stop`/`restart`/`logs` manage a tool-owned Docker container per project (no cross-repo name/port collisions), with data persisting across `stop`/`start` by default.
 - **Zero-Drift Migration Ledger**: Tracks applied migrations with SHA-256 content hashes in `dbtools_migration_history` alongside standard `schema_migrations` cursors.
 - **Read-Only Drift Verification**: `dbtools verify` validates that live database objects match migration definitions and alerts when files were modified after execution.
 - **Rollback & Down Migrations**: `dbtools down` applies `.down.sql` files in reverse; `dbtools rollback` is a ledger-only soft-revert — the safe prod verb. Destructive ops on protected targets require `--preview --yes`.
@@ -126,7 +127,9 @@ dbtools status
 | `clone` | `dbtools clone <source> <dest> [--yes] [--no-mask] [--limit N] [--where "SQL"]` | Copies data from `source` into `dest` (same engine only), masking sensitive columns by default. `dest` must not be protected. |
 | `lint` | `dbtools lint [--dir <path>] [--json]` | Validates filenames, duplicate versions, and empty files without database connection. |
 | `dashboard` | `dbtools dashboard` | Opens terminal UI showing live target status (`r` to refresh, `q` to quit). |
-| `start` / `stop` | `dbtools start [--timeout 30s] [--no-wait]` / `stop` | Starts or stops ephemeral tool-owned local database Docker container with readiness polling. |
+| `start` / `stop` | `dbtools start [--timeout 30s] [--no-wait]` / `stop [--no-backup]` | Starts or stops the tool-owned local database Docker container (project-scoped name/volume, readiness polling). `stop` preserves data by default; `--no-backup` also wipes it. |
+| `restart` | `dbtools restart [--timeout 30s] [--no-wait]` | Restarts the local container in place; data survives. |
+| `logs` | `dbtools logs [-f]` | Streams the local container's logs; `-f`/`--follow` keeps streaming new output. |
 
 ---
 
@@ -273,6 +276,36 @@ repopulates every cloned table).
 
 ---
 
+## Local Dev Containers
+
+`dbtools start` runs a tool-owned Docker container scoped to the current
+project — its name and data volume are derived from the absolute path to
+`dbtools.toml` (or an explicit override), so two dbtools checkouts on the
+same machine never collide:
+
+```bash
+dbtools start   # dbtools-<engine>-<project-id>, port auto-assigned by Docker
+dbtools stop    # container removed, data volume kept
+dbtools restart # stop + start, data survives
+dbtools logs -f # stream container logs
+```
+
+Override the generated name or pin the host port in `dbtools.toml`:
+
+```toml
+[project]
+name = "myapp"      # optional; defaults to a hash of dbtools.toml's path
+
+[container]
+port = 55432         # optional; defaults to a Docker-assigned free port
+```
+
+`dbtools stop --no-backup` also deletes the data volume, restoring the old
+full-wipe behavior. `dbtools reset` is unaffected either way — it always
+drops and recreates the database via SQL (mssql/postgres targets only).
+
+---
+
 ## Agent & CI Ergonomics
 
 `dbtools` is designed to be called by AI agents and CI pipelines without interactive prompts:
@@ -310,7 +343,7 @@ Run integration test suite:
 # SQLite integration test (runs locally without server)
 DBTOOLS_TEST_SQLITE_URL="sqlite:///tmp/dbtools-it.db" go test -tags=integration ./internal/engine/sqliteengine/... -count=1
 
-# Full matrix test (MSSQL, PostgreSQL, SQLite)
+# Full matrix test (MSSQL, PostgreSQL, MySQL, SQLite)
 go test -tags=integration ./...
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,8 +33,9 @@ same core.
 | v0.3 ✅ | **`doctor`** | Read-only health/security check: connectivity, version sync, ledger integrity, drift summary, dirty-ledger, basic security flags. Exit 0 clean / 1 error / 2 issues. |
 | v0.3 ✅ | **Real-data integration suite** | Committed classicmodels fixture corpus across sqlite/postgres/mssql, consolidated runner in `internal/testutil`, edge-case matrix, golden typegen. |
 | v0.3/4 ✅ | **Clone prod→dev** | Shipped: `dbtools clone <source> <dest>`, `internal/clone`. Masking on by default (built-in sensitive-column list + `[clone.mask]` overrides); `--no-mask` is the explicit opt-out. Same-engine only; row-count/WHERE subsetting via `--limit`/`--where`. |
-| v0.3/4 ✅ | **MySQL engine** | Shipped: `internal/engine/mysqlengine`, mirroring the mssql/postgres/sqlite seam. classicmodels fixtures ported to MySQL with real FKs. Scope: TABLE/VIEW DDL detection only (no stored procedures — see the implementation plan for why); `internal/container` local-dev support not included. |
-| v0.4 | **Backup** | Table-stakes backup/restore. |
+| v0.3/4 ✅ | **MySQL engine** | Shipped: `internal/engine/mysqlengine`, mirroring the mssql/postgres/sqlite seam. classicmodels fixtures ported to MySQL with real FKs. Scope: TABLE/VIEW DDL detection only (no stored procedures — see the implementation plan for why). `internal/container` local-dev support shipped separately (see Docker project lifecycle, below). |
+| v0.4 ✅ | **Docker project lifecycle** | Shipped: project-scoped local container/volume naming (path-hash or `[project] name`), dynamic or pinned (`[container] port`) host ports, data persists across `stop`/`start` via a named volume (`stop --no-backup` opts back into a full wipe), new `restart`/`logs` commands, and the missing MySQL container spec. `dbtools reset` on MySQL remains unsupported (separate, deferred gap — `cmd/reset.go` has no `mysql` case yet). |
+| v0.5 | **Backup** | Table-stakes backup/restore. |
 | Mongo | **C → B → A** | Starts only after SQL is stable (gate = v0.2 shipped — met). See design below. |
 | launch | — | Public launch (announcements, directories) happens only after the v0.2/v0.3 features above. |
 


### PR DESCRIPTION
## Summary
- README tagline/features/CLI reference were stale — said MSSQL+Postgres+SQLite only, no mention of MySQL, and no `restart`/`logs`/`stop --no-backup` rows despite both shipping (#47, #50).
- Added a "Local Dev Containers" section documenting project-scoped naming, `[project]`/`[container]` config, and volume persistence.
- roadmap.md: MySQL engine row's "no local-dev support" caveat resolved by the Docker lifecycle work; added a dedicated roadmap row for it; bumped the not-yet-shipped Backup phase to v0.5 since it isn't part of this release.

## Test plan
- [x] Doc-only change, no code touched
- [x] Cross-checked against actual shipped commands (`cmd/restart.go`, `cmd/logs.go`, `cmd/stop.go`) and config fields (`internal/config/config.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)