### PR TITLE
ci: publish dbtools-cli to GitHub Packages alongside npmjs.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -56,4 +57,16 @@ jobs:
             npm version "$VERSION" --no-git-tag-version
           fi
           npm publish --access public --provenance
+
+      - name: Publish to GitHub Packages
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          rm -rf /tmp/gh-pkg && cp -r npm /tmp/gh-pkg
+          cd /tmp/gh-pkg
+          npm pkg set name="@${GITHUB_REPOSITORY_OWNER,,}/dbtools-cli"
+          npm pkg set version="$VERSION"
+          npm pkg set publishConfig.registry="https://npm.pkg.github.com"
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Adds `packages: write` permission to the release workflow
- Adds a "Publish to GitHub Packages" step that copies `npm/`, renames the package to the scoped `@seanpham99/dbtools-cli`, points `publishConfig.registry` at `npm.pkg.github.com`, and publishes using `GITHUB_TOKEN`
- Public npmjs.com package name/publish is untouched — this is additive, for org members/CI who want to install via GitHub Packages

## Test plan
- [ ] Tag a release, confirm both npmjs.com and GitHub Packages publish steps succeed
- [ ] `npm install @seanpham99/dbtools-cli --registry=https://npm.pkg.github.com` resolves after release