### PR TITLE
Fix 5 bugs found integrating v0.4.0 into a real Postgres project

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -18,6 +18,10 @@ import (
 var planCmd = &cobra.Command{
 	Use:   "plan",
 	Short: "Preview pending migrations and drift without applying anything (read-only)",
+	// Exit 2 (pending/drift) is a documented, expected outcome of a
+	// correct run, not a usage mistake — cobra's default usage-block dump
+	// on any non-nil error trains agents and CI logs to ignore stderr.
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runPlan()
 	},
@@ -35,7 +39,7 @@ func init() {
 // planJSONEntry is one target's plan row.
 type planJSONEntry struct {
 	Target         string   `json:"target"`
-	CurrentVersion uint64   `json:"current_version,omitempty"`
+	CurrentVersion uint64   `json:"current_version"`
 	HasVersion     bool     `json:"has_version,omitempty"`
 	Dirty          bool     `json:"dirty,omitempty"`
 	Pending        []string `json:"pending,omitempty"`

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/seanpham99/dbtools/internal/config"
@@ -18,12 +19,22 @@ import (
 var planCmd = &cobra.Command{
 	Use:   "plan",
 	Short: "Preview pending migrations and drift without applying anything (read-only)",
-	// Exit 2 (pending/drift) is a documented, expected outcome of a
-	// correct run, not a usage mistake — cobra's default usage-block dump
-	// on any non-nil error trains agents and CI logs to ignore stderr.
-	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runPlan()
+		// Reset explicitly: cmd is a package-level singleton, so a prior
+		// invocation's exit-2 outcome (which sets this true, below) would
+		// otherwise leak into every later invocation in the same process
+		// — including, notably, every other test in this package's suite.
+		cmd.SilenceUsage = false
+		err := runPlan()
+		// Exit 2 (pending/drift) is a documented, expected outcome of a
+		// correct run, not a usage mistake — only silence usage for that
+		// specific case, so an actual invalid-flag/argument error (which
+		// cobra also routes through this same error path) still shows it.
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			cmd.SilenceUsage = true
+		}
+		return err
 	},
 }
 

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -209,3 +209,33 @@ func TestPlanCommand_SilencesUsageOnExit2(t *testing.T) {
 		t.Fatalf("plan's exit-2 outcome printed the cobra usage block: %s", stderr.String())
 	}
 }
+
+// TestPlanCommand_UnknownFlagStillPrintsUsage guards against RunE's
+// exit-2 usage-silencing bleeding into cobra's own flag-parsing errors —
+// SilenceUsage must only be set for the documented ExitCodeError case,
+// not unconditionally on the command.
+func TestPlanCommand_UnknownFlagStillPrintsUsage(t *testing.T) {
+	// planCmd is a package-level singleton: an earlier test's exit-2 case
+	// may have left SilenceUsage set from a prior invocation. A flag-parse
+	// error never reaches RunE (where that flag gets reset per-invocation),
+	// so this test must restore known state itself.
+	origSilenceUsage := planCmd.SilenceUsage
+	planCmd.SilenceUsage = false
+	t.Cleanup(func() { planCmd.SilenceUsage = origSilenceUsage })
+
+	// Cobra writes the error via PrintErrln (stderr) but the usage block
+	// via Println (stdout) — capture both into one buffer so the
+	// assertion doesn't depend on which stream cobra picks.
+	var out strings.Builder
+	rootCmd.SetErr(&out)
+	rootCmd.SetOut(&out)
+	t.Cleanup(func() { rootCmd.SetErr(nil); rootCmd.SetOut(nil) })
+
+	rootCmd.SetArgs([]string{"plan", "--no-such-flag"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("plan --no-such-flag returned nil error, want a flag-parsing error")
+	}
+	if !strings.Contains(out.String(), "Usage:") {
+		t.Fatalf("plan with an invalid flag did not print usage: %s", out.String())
+	}
+}

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,5 +100,112 @@ func TestPlanJSONPreview(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("plan drift = %v, want an entry mentioning the edited migration 20260817000001", entries[0].Drift)
+	}
+}
+
+// TestPlanJSON_CurrentVersionZeroIsSerialized guards against `omitempty`
+// dropping a legitimately-applied version 0 from the JSON contract (a
+// squash-to-baseline migration named e.g. 00000000000000_baseline.up.sql
+// applies at version 0 — not a contrived input). A consumer must be able
+// to see current_version:0 in the output, not have the key vanish.
+func TestPlanJSON_CurrentVersionZeroIsSerialized(t *testing.T) {
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "00000000000000_baseline.up.sql"), []byte(`CREATE TABLE baseline (id INTEGER PRIMARY KEY);`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dbURL := "sqlite://" + filepath.Join(dir, "local.db")
+	t.Setenv("DBTOOLS_LOCAL_URL", dbURL)
+	cfg := &config.Config{
+		MigrationsDir: "migrations",
+		Targets:       map[string]config.Target{"local": {URLEnv: "DBTOOLS_LOCAL_URL"}},
+	}
+	loadConfig = func(string) (*config.Config, error) { return cfg, nil }
+	t.Cleanup(func() { loadConfig = config.Load })
+
+	if _, err := apply.Run(cfg, "local", ""); err != nil {
+		t.Fatalf("apply.Run() returned error: %v", err)
+	}
+
+	planTarget = "local"
+	defer func() { planTarget = "" }()
+
+	entries := buildPlanEntries(cfg)
+	if len(entries) != 1 {
+		t.Fatalf("plan entries = %d, want 1", len(entries))
+	}
+	if !entries[0].HasVersion {
+		t.Fatalf("plan has_version = false after applying version 0, want true")
+	}
+	if entries[0].CurrentVersion != 0 {
+		t.Fatalf("plan current_version = %d, want 0", entries[0].CurrentVersion)
+	}
+
+	b, err := json.Marshal(entries[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() returned error: %v", err)
+	}
+	if !strings.Contains(string(b), `"current_version":0`) {
+		t.Fatalf("marshaled plan entry = %s, want it to contain \"current_version\":0 (omitempty must not drop a real version-0 result)", b)
+	}
+}
+
+// TestPlanCommand_SilencesUsageOnExit2 guards against cobra's default
+// usage-block dump when plan's RunE returns its documented exit-2 error
+// for pending migrations — that outcome is a correct, expected result of
+// a read-only preview, not a flag/argument mistake, and printing the full
+// flags block trains agents/CI logs to ignore stderr.
+func TestPlanCommand_SilencesUsageOnExit2(t *testing.T) {
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "20260817000001_users.up.sql"), []byte(`CREATE TABLE users (id INTEGER PRIMARY KEY);`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dbURL := "sqlite://" + filepath.Join(dir, "local.db")
+	t.Setenv("DBTOOLS_LOCAL_URL", dbURL)
+	cfg := &config.Config{
+		MigrationsDir: "migrations",
+		Targets:       map[string]config.Target{"local": {URLEnv: "DBTOOLS_LOCAL_URL"}},
+	}
+	loadConfig = func(string) (*config.Config, error) { return cfg, nil }
+	t.Cleanup(func() { loadConfig = config.Load })
+	t.Cleanup(func() { planTarget = "" })
+
+	var stderr strings.Builder
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetOut(&strings.Builder{})
+	t.Cleanup(func() { rootCmd.SetErr(nil); rootCmd.SetOut(nil) })
+
+	rootCmd.SetArgs([]string{"plan", "--target", "local"})
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("plan with a pending migration returned nil error, want the documented exit-2 error")
+	}
+	if strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("plan's exit-2 outcome printed the cobra usage block: %s", stderr.String())
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -41,7 +41,7 @@ type targetFailure struct {
 // statusJSONEntry is the --json shape for one target.
 type statusJSONEntry struct {
 	Target         string   `json:"target"`
-	CurrentVersion uint64   `json:"current_version,omitempty"`
+	CurrentVersion uint64   `json:"current_version"`
 	HasVersion     bool     `json:"has_version,omitempty"`
 	Dirty          bool     `json:"dirty,omitempty"`
 	Pending        []string `json:"pending,omitempty"`
@@ -100,6 +100,14 @@ func runStatus(targetNames ...string) error {
 
 	results := statusinfo.CollectAll(cfg, target, statusURL)
 
+	var connErr error
+	for _, r := range results {
+		if r.Err != nil {
+			connErr = r.Err
+			break
+		}
+	}
+
 	if jsonOutput {
 		entries := make([]statusJSONEntry, 0, len(results))
 		for _, r := range results {
@@ -128,9 +136,15 @@ func runStatus(targetNames ...string) error {
 			return err
 		}
 		fmt.Println(string(b))
+		if connErr != nil {
+			return ExitCode(1, "")
+		}
 		return nil
 	}
 
 	fmt.Print(renderStatusTable(results))
+	if connErr != nil {
+		return ExitCode(1, "")
+	}
 	return nil
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,11 +16,20 @@ var statusCmd = &cobra.Command{
 	Short: "Show migration status for every configured target (or a single target)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// See plan's identical rationale for this explicit reset.
+		cmd.SilenceUsage = false
 		target := statusTarget
 		if len(args) > 0 && args[0] != "" {
 			target = args[0]
 		}
-		return runStatus(target)
+		err := runStatus(target)
+		// A target connection failure is a documented exit-1 outcome
+		// (see #55), not a usage mistake — same rationale as plan/verify.
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			cmd.SilenceUsage = true
+		}
+		return err
 	},
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/seanpham99/dbtools/internal/config"
 	"github.com/seanpham99/dbtools/internal/statusinfo"
 )
 
@@ -45,5 +47,34 @@ func TestRenderStatusTable(t *testing.T) {
 	}
 	if !strings.Contains(out, "staging     1 pending [DIRTY]") {
 		t.Errorf("rendered output missing dirty staging status: %s", out)
+	}
+}
+
+// TestRunStatus_ExitsNonZeroOnConnectionFailure guards the exit-code
+// contract: a target status can't be collected (here: an unregistered
+// engine scheme, which fails before any network call) must exit 1, not
+// print "error:" on stdout while returning success.
+func TestRunStatus_ExitsNonZeroOnConnectionFailure(t *testing.T) {
+	origLoadConfig := loadConfig
+	t.Cleanup(func() { loadConfig = origLoadConfig })
+
+	loadConfig = func(string) (*config.Config, error) {
+		return &config.Config{
+			MigrationsDir: "migrations",
+			Targets:       map[string]config.Target{"local": {URLEnv: "DBTOOLS_STATUS_TEST_URL"}},
+		}, nil
+	}
+	t.Setenv("DBTOOLS_STATUS_TEST_URL", "nosuchengine://host/db")
+
+	err := runStatus()
+	if err == nil {
+		t.Fatal("runStatus() with an unreachable target returned nil error, want a non-zero exit")
+	}
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("runStatus() error = %v (%T), want *ExitCodeError", err, err)
+	}
+	if exitErr.Code != 1 {
+		t.Fatalf("runStatus() exit code = %d, want 1", exitErr.Code)
 	}
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -14,6 +14,9 @@ var verifyCmd = &cobra.Command{
 	Use:   "verify [target]",
 	Short: "Check for drift between the migration ledger and the live database",
 	Args:  cobra.ExactArgs(1),
+	// Exit 2 (drift) is a documented, expected outcome, not a usage
+	// mistake — see plan's identical rationale.
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runVerify(args[0])
 	},

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/seanpham99/dbtools/internal/engine"
@@ -14,11 +15,17 @@ var verifyCmd = &cobra.Command{
 	Use:   "verify [target]",
 	Short: "Check for drift between the migration ledger and the live database",
 	Args:  cobra.ExactArgs(1),
-	// Exit 2 (drift) is a documented, expected outcome, not a usage
-	// mistake — see plan's identical rationale.
-	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runVerify(args[0])
+		// See plan's identical rationale for this explicit reset.
+		cmd.SilenceUsage = false
+		err := runVerify(args[0])
+		// See plan's identical rationale: only silence usage for the
+		// documented exit-2 outcome, not for a real invalid-argument error.
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			cmd.SilenceUsage = true
+		}
+		return err
 	},
 }
 

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVerifyCommand_MissingTargetStillPrintsUsage guards against RunE's
+// exit-2 usage-silencing bleeding into cobra's own argument-count
+// validation (Args: cobra.ExactArgs(1)) — that error must still show
+// usage, since RunE's SilenceUsage toggle only applies to the documented
+// ExitCodeError case and never runs for an argument-count failure.
+func TestVerifyCommand_MissingTargetStillPrintsUsage(t *testing.T) {
+	// See plan's identical test for why this reset is needed: verifyCmd
+	// is a package-level singleton, and an argument-count error never
+	// reaches RunE (where SilenceUsage otherwise gets reset per-invocation).
+	origSilenceUsage := verifyCmd.SilenceUsage
+	verifyCmd.SilenceUsage = false
+	t.Cleanup(func() { verifyCmd.SilenceUsage = origSilenceUsage })
+
+	// Cobra writes the error via PrintErrln (stderr) but the usage block
+	// via Println (stdout) — capture both into one buffer so the
+	// assertion doesn't depend on which stream cobra picks.
+	var out strings.Builder
+	rootCmd.SetErr(&out)
+	rootCmd.SetOut(&out)
+	t.Cleanup(func() { rootCmd.SetErr(nil); rootCmd.SetOut(nil) })
+
+	rootCmd.SetArgs([]string{"verify"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("verify with no target returned nil error, want an argument-count error")
+	}
+	if !strings.Contains(out.String(), "Usage:") {
+		t.Fatalf("verify with a missing required argument did not print usage: %s", out.String())
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -109,13 +109,33 @@ func ForName(name string) (Engine, error) {
 	return e, nil
 }
 
+// schemeAliases maps a connection-string scheme onto the engine name it
+// should resolve to, for schemes that name the same engine as a
+// registered one but don't match it literally. "postgresql://" is the
+// canonical libpq URI scheme (accepted by pg_dump, Azure Database for
+// PostgreSQL, Prisma, and Docker's own POSTGRES_* examples) and is at
+// least as common in the wild as "postgres://", which is the only form
+// dbtools registers its engine under.
+var schemeAliases = map[string]string{
+	"postgresql": "postgres",
+}
+
+// normalizeScheme maps scheme onto its canonical registered engine name,
+// or returns it unchanged when it isn't an alias.
+func normalizeScheme(scheme string) string {
+	if canonical, ok := schemeAliases[scheme]; ok {
+		return canonical
+	}
+	return scheme
+}
+
 // ForURL resolves the engine for rawURL by its scheme.
 func ForURL(rawURL string) (Engine, error) {
 	scheme := migrator.SchemeOf(rawURL)
 	if scheme == "" {
 		return nil, fmt.Errorf("connection URL has no scheme (want one of %v, e.g. mssql://...)", Names())
 	}
-	return ForName(scheme)
+	return ForName(normalizeScheme(scheme))
 }
 
 // ForTarget resolves the engine for a target, cross-checking the

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -46,6 +46,26 @@ func TestForURL(t *testing.T) {
 	}
 }
 
+func TestForURL_PostgresqlSchemeAliasesToPostgres(t *testing.T) {
+	withFake(t, "postgres")
+
+	e, err := ForURL("postgresql://user:pass@host:5432/db?sslmode=disable")
+	if err != nil {
+		t.Fatalf("ForURL(postgresql://...) returned error: %v", err)
+	}
+	if e.Name() != "postgres" {
+		t.Fatalf("ForURL(postgresql://...) resolved %q, want postgres", e.Name())
+	}
+}
+
+func TestForTarget_PostgresqlSchemeMatchesConfiguredPostgresEngine(t *testing.T) {
+	withFake(t, "postgres")
+
+	if _, err := ForTarget("postgres", "postgresql://user:pass@host:5432/db"); err != nil {
+		t.Fatalf("ForTarget(postgres, postgresql://...) returned error: %v, want nil (postgresql is an alias for postgres)", err)
+	}
+}
+
 func TestForTarget(t *testing.T) {
 	withFake(t, "fakedb")
 

--- a/internal/localenv/localenv.go
+++ b/internal/localenv/localenv.go
@@ -1,6 +1,7 @@
 package localenv
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,13 +23,21 @@ func Path() string {
 // accidentally commit the generated local database password Write puts
 // in local.env on the next `git add -A`. Self-ignoring — no edit to the
 // project's own root .gitignore needed. Never overwrites an existing
-// file, in case a user has customized it.
+// file, in case a user has customized it — created with O_EXCL so a
+// concurrent dbtools process racing to create the same file loses the
+// write cleanly (ErrExist) rather than one process's WriteFile silently
+// truncating the other's already-written content.
 func ensureGitignored() error {
 	path := filepath.Join(Dir, ".gitignore")
-	if _, err := os.Stat(path); err == nil {
-		return nil
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
-	if err := os.WriteFile(path, []byte(gitignoreContents), 0o644); err != nil {
+	defer f.Close()
+	if _, err := f.WriteString(gitignoreContents); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	return nil

--- a/internal/localenv/localenv.go
+++ b/internal/localenv/localenv.go
@@ -11,13 +11,35 @@ const Dir = ".dbtools"
 
 const filename = "local.env"
 
+const gitignoreContents = "*\n"
+
 func Path() string {
 	return filepath.Join(Dir, filename)
+}
+
+// ensureGitignored writes Dir/.gitignore (contents: "*") if it doesn't
+// already exist, so a project that hasn't already ignored Dir doesn't
+// accidentally commit the generated local database password Write puts
+// in local.env on the next `git add -A`. Self-ignoring — no edit to the
+// project's own root .gitignore needed. Never overwrites an existing
+// file, in case a user has customized it.
+func ensureGitignored() error {
+	path := filepath.Join(Dir, ".gitignore")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(gitignoreContents), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
 }
 
 func Write(vars map[string]string) error {
 	if err := os.MkdirAll(Dir, 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", Dir, err)
+	}
+	if err := ensureGitignored(); err != nil {
+		return err
 	}
 
 	var builder strings.Builder

--- a/internal/localenv/localenv_test.go
+++ b/internal/localenv/localenv_test.go
@@ -2,6 +2,7 @@ package localenv
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -33,6 +34,46 @@ func TestWriteAndLoad(t *testing.T) {
 	}
 	if got["DBTOOLS_LOCAL_URL"] != "mssql://sa:pw@localhost:14330?database=dbtools_local" {
 		t.Fatalf("Load()[DBTOOLS_LOCAL_URL] = %q, want %q", got["DBTOOLS_LOCAL_URL"], "mssql://sa:pw@localhost:14330?database=dbtools_local")
+	}
+}
+
+func TestWrite_CreatesSelfIgnoringGitignore(t *testing.T) {
+	chdirTemp(t)
+
+	if err := Write(map[string]string{"DBTOOLS_LOCAL_URL": "postgres://postgres:pw@localhost:5432/dbtools_local"}); err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(Dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading %s/.gitignore returned error: %v (Write must create it so local.env's generated password is never committed)", Dir, err)
+	}
+	if string(got) != "*\n" {
+		t.Fatalf("%s/.gitignore contents = %q, want %q", Dir, got, "*\n")
+	}
+}
+
+func TestWrite_NeverOverwritesExistingGitignore(t *testing.T) {
+	chdirTemp(t)
+
+	if err := os.MkdirAll(Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := "# custom, do not touch\n"
+	if err := os.WriteFile(filepath.Join(Dir, ".gitignore"), []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Write(map[string]string{"DBTOOLS_LOCAL_URL": "postgres://postgres:pw@localhost:5432/dbtools_local"}); err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(Dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != custom {
+		t.Fatalf("%s/.gitignore contents = %q, want unchanged %q", Dir, got, custom)
 	}
 }
 

--- a/skills/using-dbtools/container.md
+++ b/skills/using-dbtools/container.md
@@ -47,6 +47,12 @@ supports** (currently mssql and postgres only — `dbtools reset` on a MySQL
 target errors with "reset does not support engine \"mysql\"", a known,
 separate gap from container lifecycle).
 
+`dbtools start`/`restart` write the resolved connection URL — including
+the local container's generated password — to `.dbtools/local.env`.
+`.dbtools/.gitignore` (contents: `*`) is created automatically the first
+time that happens, so the directory is self-ignoring even in a project
+that hasn't already excluded it. Never overwritten if it already exists.
+
 ## Commands
 
 - `dbtools restart [--timeout] [--no-wait]` — `stop` then `start`, same


### PR DESCRIPTION
## Summary

All 5 bugs filed from an integration spike against v0.4.0 (see the linked issues for full repro/rationale):

- Fixes #54 — `postgresql://` scheme rejected as "unknown engine". `postgresql` is now an alias for the registered `postgres` engine in `ForURL`/`ForTarget`.
- Fixes #55 — `dbtools status` exited 0 on a connection failure. Now aggregates per-target errors into exit 1, same as `plan`.
- Fixes #56 — `current_version` dropped from `plan`/`status --json` when the applied version is 0 (`omitempty` on a `uint64`). Removed; matches `internal/statusinfo.Status`'s existing shape.
- Fixes #57 — `plan`/`verify` printed the full cobra usage block on their documented exit-2 outcome. `SilenceUsage: true` on both.
- Fixes #58 — `.dbtools/local.env` (holds a generated local DB password) had nothing gitignoring it. `localenv.Write` now creates `.dbtools/.gitignore` (`*`) on first write, never overwriting a customized one.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` — new regression test per bug:
  - `TestForURL_PostgresqlSchemeAliasesToPostgres` / `TestForTarget_PostgresqlSchemeMatchesConfiguredPostgresEngine`
  - `TestRunStatus_ExitsNonZeroOnConnectionFailure`
  - `TestPlanJSON_CurrentVersionZeroIsSerialized`
  - `TestPlanCommand_SilencesUsageOnExit2`
  - `TestWrite_CreatesSelfIgnoringGitignore` / `TestWrite_NeverOverwritesExistingGitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plan and verify commands now suppress usage text for expected pending-migration and drift outcomes.
  - Status reports return a failure exit code when any target cannot be reached.
  - JSON output consistently includes `current_version`, including version `0`.
  - PostgreSQL connection URLs using either common scheme are recognized correctly.

- **Improvements**
  - Local environment files now include resolved connection details and are protected from accidental version control commits.
  - Existing custom `.gitignore` files are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->