### PR TITLE
ci: lint pr titles for conventional commits format

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,37 @@
+name: PR title lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            ci
+            test
+            refactor
+            chore
+            style
+            perf
+          requireScope: false
+          # GitHub's squash-merge uses the PR title verbatim as the commit
+          # subject unless someone edits it in the merge box — this check
+          # exists so that default path still parses as a conventional
+          # commit for release-please, instead of silently dropping out of
+          # the next CHANGELOG.md (as happened with #47, #50, #59).
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The PR title's description must not start with an uppercase letter — release-please reads it verbatim as the commit subject.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,5 +88,6 @@ GitHub Actions automatically runs integration tests against live MSSQL Server 20
 
 1. **Keep Changes Focused**: Make small, incremental PRs that address a single concern.
 2. **Ensure Clean History**: Write clear, descriptive commit messages following the Conventional Commits format (`feat:`, `fix:`, `docs:`, `ci:`, `test:`, `refactor:`). This matters beyond style: `release-please` reads these prefixes off `main` to compute version bumps and generate `CHANGELOG.md` (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` footer → major).
+   - **This repo merges PRs by squash**, which uses the **PR title** as the commit subject unless it's edited in the merge box — so the PR title itself needs the `type: description` prefix, not just the individual commits inside it. A CI check (`pr-title-lint.yml`) enforces this on every PR; a plain-English title like "Fix the thing" will fail it.
 3. **Verify Locally**: Confirm all tests pass locally before pushing.
 4. **Open PR**: Submit your PR targeting `main`. Describe what changes were made and how they were tested.


### PR DESCRIPTION
## Summary

Guard against the exact failure mode from this run: https://github.com/seanpham99/dbtools/actions/runs/32823125037 — release-please couldn't parse `#59`'s squash-merge commit subject (`Fix 5 bugs found integrating...`) as a conventional commit, so it'll silently drop out of the next `CHANGELOG.md`. Same thing already happened with `#47` and `#50`, each needing a manual backfill after the fact.

Since this repo's ruleset only allows squash-merge, and squash-merge defaults to using the **PR title** as the commit subject, the fix is a PR-title check, not a commit-message one:

- New `.github/workflows/pr-title-lint.yml` using `amannn/action-semantic-pull-request`, requiring `type: description` (types: feat/fix/docs/ci/test/refactor/chore/style/perf) with a lowercase description.
- `CONTRIBUTING.md` note explaining *why* the PR title specifically matters here, not just the individual commits inside it.

Doesn't retroactively fix `#47`/`#50`/`#59` (already merged, not worth a history rewrite for a changelog line) — just stops it recurring.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] This PR's own title (`ci: lint pr titles for conventional commits format`) should pass the new check once it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)