### PR TITLE
feat: add official multi-arch docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,29 @@ jobs:
               go test -tags=integration ./internal/engine/mysqlengine/... -count=1
               ;;
           esac
+
+  docker-smoke:
+    name: Docker image smoke build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+      - name: Install GoReleaser
+        run: go install github.com/goreleaser/goreleaser/v2@latest
+      - name: Build a local snapshot binary
+        run: goreleaser build --single-target --snapshot --clean
+      - name: Stage the binary where the Dockerfile expects it
+        run: |
+          bin=$(find dist -maxdepth 2 -name dbtools -type f | head -1)
+          if [ -z "$bin" ]; then
+            echo "::error::no dbtools binary found under dist/ after goreleaser build"
+            exit 1
+          fi
+          cp "$bin" ./dbtools
+      - name: Build the image
+        run: docker build -t dbtools-smoke .
+      - name: Run it
+        run: docker run --rm dbtools-smoke --help
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,19 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,34 @@ archives:
       - LICENSE
       - CHANGELOG.md
 
+dockers:
+  - image_templates:
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/seanpham99/dbtools:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-amd64"
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/seanpham99/dbtools:latest"
+    image_templates:
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-amd64"
+      - "ghcr.io/seanpham99/dbtools:{{ .Version }}-arm64"
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Dockerfile
+FROM gcr.io/distroless/static
+COPY dbtools /usr/local/bin/dbtools
+WORKDIR /workspace
+ENTRYPOINT ["dbtools"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ or install globally:
 npm install -g dbtools-cli
 ```
 
+### Via Docker (for private-network / job-container use)
+
+```bash
+docker run --rm -v "$(pwd)":/workspace ghcr.io/seanpham99/dbtools:0.4.0 status
+```
+
+`linux/amd64`/`linux/arm64`, ships on `gcr.io/distroless/static` (CA
+certs included). See [skills/using-dbtools/docker-image.md](skills/using-dbtools/docker-image.md)
+for the build-`FROM` pattern used by private-network job runners.
+
 ### Via Go Install
 
 ```bash

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -21,6 +21,7 @@ nuance than a table row can hold, read the matching file before using them:
 | `dbtools generate` — Pydantic/TS codegen, `--check` CI drift gate | `codegen.md` |
 | MySQL `url_env` connection-string format and gotchas | `mysql.md` |
 | Container lifecycle project scoping, ports, volume persistence | `container.md` |
+| Docker image — base, tags, mount vs. build-`FROM` consumption patterns | `docker-image.md` |
 
 ## Terminology & Key Concepts
 

--- a/skills/using-dbtools/docker-image.md
+++ b/skills/using-dbtools/docker-image.md
@@ -1,0 +1,52 @@
+# dbtools Docker image reference
+
+`ghcr.io/seanpham99/dbtools:<version>` (also tagged `:latest`) ships the
+`dbtools` binary on `gcr.io/distroless/static` — CA certificates and
+tzdata included (needed for TLS to cloud databases like Azure Database
+for PostgreSQL or RDS), no shell. `linux/amd64` and `linux/arm64`.
+
+The image ships the binary only — never a project's `dbtools.toml` or
+`migrations/`. Two ways to supply them:
+
+## Mount (default)
+
+```bash
+docker run --rm -v "$(pwd)":/workspace \
+  -e DBTOOLS_LOCAL_URL \
+  ghcr.io/seanpham99/dbtools:0.4.0 up
+```
+
+`WORKDIR` inside the image is `/workspace` — `dbtools.toml` and
+`migrations_dir` (default `migrations/`) are expected relative to it,
+same as running the binary locally from your project root.
+
+## Build `FROM` it
+
+For a private-network job runner (Azure Container Apps job, ECS
+RunTask, Kubernetes Job, Cloud Run job) where the database has no public
+endpoint and migrations must run from inside the network, teams
+typically reuse a single image for the whole job rather than adopting a
+second one:
+
+```dockerfile
+FROM ghcr.io/seanpham99/dbtools:0.4.0
+COPY dbtools.toml ./
+COPY migrations/ ./migrations/
+```
+
+Then point the job's entrypoint/command at the same `dbtools` binary
+(`up`, `plan --json`, `doctor --json`, etc.) with `DATABASE_URL`/
+`DBTOOLS_*_URL` injected the same way the job already injects secrets
+(Key Vault → container secret → env var, AWS Secrets Manager → task
+definition secret → env var — `url_env` composes with either
+unchanged).
+
+## Red flags
+
+- ❌ Baking `dbtools.toml`/`migrations/` into a *published, shared*
+  image — the mount pattern exists so one dbtools image serves every
+  project; only a project's own job/app image should bake its own files
+  in via the build-`FROM` pattern.
+- ❌ Expecting a shell inside the image for debugging — `distroless/static`
+  has none. Use `docker cp`/multi-stage builds if you need one during
+  development.


### PR DESCRIPTION
## Summary
- `Dockerfile` (`gcr.io/distroless/static` base — CA certs included, no shell) + GoReleaser `dockers:`/`docker_manifests:` config for `ghcr.io/seanpham99/dbtools:<version>`/`:latest`, linux/amd64 + linux/arm64.
- `release.yml`: QEMU + buildx + ghcr.io login (existing `GITHUB_TOKEN`, no new secret) ahead of the existing GoReleaser step.
- `ci.yml`: new `docker-smoke` job — builds a local snapshot binary, builds the image, runs `--help` — on every PR, never pushes.
- Docs: `skills/using-dbtools/docker-image.md` (mount vs. build-`FROM` patterns) + README + SKILL.md links.

Sub-project 1 of 4 for #60 (private-network/job-container support). The other 3 (Postgres error diagnostics, `--log-format=json`, job-pattern docs) are separate, not started here.

## Known limitation
The actual multi-arch **publish** (`dockers:`/`docker_manifests:` running for real against ghcr.io) can only be verified by cutting a real release tag — out of scope for this PR. Whoever merges the next version tag should watch the `goreleaser` job in `release.yml` on that push.

## Test plan
- [x] YAML validated for `.goreleaser.yaml`, `release.yml`, `ci.yml`
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` clean
- [ ] **`Docker image smoke build` CI check on this PR must pass** — this is the only real proof the Dockerfile/GoReleaser config work; local scripts don't exercise the actual GitHub Actions job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker image support for `dbtools`.
  * Published multi-architecture images for Linux amd64 and arm64.
  * Added Docker-based installation and usage options.

* **Documentation**
  * Added guidance for mounting project files or using the image in private-network job runners.
  * Documented supported architectures, included certificates and timezone data, and the image’s shell-free environment.

* **Tests**
  * Added a CI smoke test that builds the image and verifies the command runs successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->