### PR TITLE
feat: add postgres error diagnostics and notice forwarding

### DIFF
--- a/internal/migrator/pgdiagnostic.go
+++ b/internal/migrator/pgdiagnostic.go
@@ -1,0 +1,109 @@
+package migrator
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+)
+
+// PermissionReport holds diagnostic information collected when a PostgreSQL
+// migration fails with SQLSTATE 42501 (insufficient_privilege).
+type PermissionReport struct {
+	CurrentUser       string
+	SessionUser       string
+	Database          string
+	Schema            string
+	SchemaOwner       string
+	HasUsage          bool
+	HasCreate         bool
+	IsAzureAdmin      bool
+	HasAzureAdminRole bool
+	Table             string
+	Remediation       string
+}
+
+// FormatPermissionReport renders a structured diagnostic text block from a PermissionReport.
+func FormatPermissionReport(report PermissionReport) string {
+	var b strings.Builder
+	b.WriteString("[permission diagnostic (SQLSTATE 42501)]\n")
+	fmt.Fprintf(&b, "  current_user: %s\n", report.CurrentUser)
+	fmt.Fprintf(&b, "  session_user: %s\n", report.SessionUser)
+	fmt.Fprintf(&b, "  database: %s\n", report.Database)
+	fmt.Fprintf(&b, "  schema: %s (owner: %s)\n", report.Schema, report.SchemaOwner)
+	fmt.Fprintf(&b, "  schema privileges: USAGE=%t, CREATE=%t\n", report.HasUsage, report.HasCreate)
+	hasAdmin := report.HasAzureAdminRole || report.IsAzureAdmin
+	fmt.Fprintf(&b, "  azure_pg_admin member: %t\n", hasAdmin)
+	fmt.Fprintf(&b, "  remediation: %s", report.Remediation)
+	return b.String()
+}
+
+// RunPermissionDiagnostic inspects the database connection and queries permission
+// metadata if the given error is a PostgreSQL SQLSTATE 42501 error.
+// It safely recovers from any query failures so diagnostic collection never panics or masks the original failure.
+func RunPermissionDiagnostic(ctx context.Context, db *sql.DB, pqErr *pq.Error) string {
+	if db == nil || pqErr == nil || pqErr.Code != "42501" {
+		return ""
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	report := PermissionReport{
+		Table: pqErr.Table,
+	}
+
+	// 1. Query current user, session user, current database, and current schema
+	var currentUser, sessionUser, currentDB, currentSchema sql.NullString
+	row := db.QueryRowContext(ctx, "SELECT current_user, session_user, current_database(), coalesce(current_schema(), 'public')")
+	if err := row.Scan(&currentUser, &sessionUser, &currentDB, &currentSchema); err != nil {
+		return ""
+	}
+
+	report.CurrentUser = currentUser.String
+	report.SessionUser = sessionUser.String
+	report.Database = currentDB.String
+
+	if pqErr.Schema != "" {
+		report.Schema = pqErr.Schema
+	} else if currentSchema.Valid && currentSchema.String != "" {
+		report.Schema = currentSchema.String
+	} else {
+		report.Schema = "public"
+	}
+
+	// 2. Query schema owner
+	var schemaOwner sql.NullString
+	_ = db.QueryRowContext(ctx, "SELECT coalesce(pg_get_userbyid(nspowner), 'unknown') FROM pg_namespace WHERE nspname = $1", report.Schema).Scan(&schemaOwner)
+	if schemaOwner.Valid && schemaOwner.String != "" {
+		report.SchemaOwner = schemaOwner.String
+	} else {
+		report.SchemaOwner = "unknown"
+	}
+
+	// 3. Query schema privileges
+	var hasUsage, hasCreate sql.NullBool
+	_ = db.QueryRowContext(ctx, "SELECT has_schema_privilege(current_user, $1, 'USAGE'), has_schema_privilege(current_user, $1, 'CREATE')", report.Schema).Scan(&hasUsage, &hasCreate)
+	report.HasUsage = hasUsage.Bool
+	report.HasCreate = hasCreate.Bool
+
+	// 4. Query azure_pg_admin role membership
+	var isAzureAdmin sql.NullBool
+	_ = db.QueryRowContext(ctx, "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'azure_pg_admin' AND pg_has_role(current_user, 'azure_pg_admin', 'MEMBER'))").Scan(&isAzureAdmin)
+	report.IsAzureAdmin = isAzureAdmin.Bool
+	report.HasAzureAdminRole = isAzureAdmin.Bool
+
+	// 5. Build remediation advice
+	if !report.HasUsage || !report.HasCreate {
+		report.Remediation = fmt.Sprintf("User %q lacks CREATE/USAGE privilege on schema %q. Run: GRANT USAGE, CREATE ON SCHEMA %q TO %q;", report.CurrentUser, report.Schema, report.Schema, report.CurrentUser)
+	} else if report.Table != "" {
+		report.Remediation = fmt.Sprintf("User %q lacks permissions on table %q. Run: GRANT ALL ON TABLE %q TO %q;", report.CurrentUser, report.Table, report.Table, report.CurrentUser)
+	} else {
+		report.Remediation = fmt.Sprintf("User %q lacks required privileges on schema %q. Run: GRANT ALL ON SCHEMA %q TO %q;", report.CurrentUser, report.Schema, report.Schema, report.CurrentUser)
+	}
+
+	return FormatPermissionReport(report)
+}

--- a/internal/migrator/pgdiagnostic_test.go
+++ b/internal/migrator/pgdiagnostic_test.go
@@ -1,0 +1,352 @@
+package migrator
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/lib/pq"
+)
+
+func TestFormatPermissionReport(t *testing.T) {
+	t.Run("missing create permission", func(t *testing.T) {
+		report := PermissionReport{
+			CurrentUser:       "app_user",
+			SessionUser:       "app_user",
+			Database:          "mydb",
+			Schema:            "public",
+			SchemaOwner:       "postgres",
+			HasUsage:          true,
+			HasCreate:         false,
+			IsAzureAdmin:      false,
+			HasAzureAdminRole: false,
+			Remediation:       `User "app_user" lacks CREATE/USAGE privilege on schema "public". Run: GRANT USAGE, CREATE ON SCHEMA "public" TO "app_user";`,
+		}
+
+		got := FormatPermissionReport(report)
+		want := `[permission diagnostic (SQLSTATE 42501)]
+  current_user: app_user
+  session_user: app_user
+  database: mydb
+  schema: public (owner: postgres)
+  schema privileges: USAGE=true, CREATE=false
+  azure_pg_admin member: false
+  remediation: User "app_user" lacks CREATE/USAGE privilege on schema "public". Run: GRANT USAGE, CREATE ON SCHEMA "public" TO "app_user";`
+
+		if got != want {
+			t.Errorf("FormatPermissionReport got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("missing usage and azure admin true", func(t *testing.T) {
+		report := PermissionReport{
+			CurrentUser:       "service_role",
+			SessionUser:       "azure_admin",
+			Database:          "prod_db",
+			Schema:            "app_schema",
+			SchemaOwner:       "db_owner",
+			HasUsage:          false,
+			HasCreate:         false,
+			IsAzureAdmin:      true,
+			HasAzureAdminRole: true,
+			Remediation:       `User "service_role" lacks CREATE/USAGE privilege on schema "app_schema". Run: GRANT USAGE, CREATE ON SCHEMA "app_schema" TO "service_role";`,
+		}
+
+		got := FormatPermissionReport(report)
+		if !strings.Contains(got, "azure_pg_admin member: true") {
+			t.Errorf("expected azure_pg_admin member: true in:\n%s", got)
+		}
+		if !strings.Contains(got, "schema privileges: USAGE=false, CREATE=false") {
+			t.Errorf("expected schema privileges in:\n%s", got)
+		}
+	})
+
+	t.Run("table permission remediation", func(t *testing.T) {
+		report := PermissionReport{
+			CurrentUser: "read_user",
+			SessionUser: "read_user",
+			Database:    "mydb",
+			Schema:      "public",
+			SchemaOwner: "postgres",
+			HasUsage:    true,
+			HasCreate:   true,
+			Table:       "schema_migrations",
+			Remediation: `User "read_user" lacks permissions on table "schema_migrations". Run: GRANT ALL ON TABLE "schema_migrations" TO "read_user";`,
+		}
+
+		got := FormatPermissionReport(report)
+		if !strings.Contains(got, `remediation: User "read_user" lacks permissions on table "schema_migrations". Run: GRANT ALL ON TABLE "schema_migrations" TO "read_user";`) {
+			t.Errorf("expected table remediation in:\n%s", got)
+		}
+	})
+}
+
+// mockDriver implements a lightweight driver.Driver for testing RunPermissionDiagnostic.
+type mockDriver struct {
+	mu       sync.Mutex
+	handlers map[string]func(args []driver.Value) (driver.Rows, error)
+}
+
+func (m *mockDriver) Open(name string) (driver.Conn, error) {
+	return &mockConn{driver: m}, nil
+}
+
+type mockConn struct {
+	driver *mockDriver
+}
+
+func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
+	return &mockStmt{conn: c, query: query}, nil
+}
+
+func (c *mockConn) Close() error              { return nil }
+func (c *mockConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+
+type mockStmt struct {
+	conn  *mockConn
+	query string
+}
+
+func (s *mockStmt) Close() error { return nil }
+func (s *mockStmt) NumInput() int {
+	return -1
+}
+
+func (s *mockStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *mockStmt) Query(args []driver.Value) (driver.Rows, error) {
+	s.conn.driver.mu.Lock()
+	defer s.conn.driver.mu.Unlock()
+
+	for q, h := range s.conn.driver.handlers {
+		if strings.Contains(s.query, q) {
+			return h(args)
+		}
+	}
+	return nil, errors.New("no mock handler for query: " + s.query)
+}
+
+type mockRows struct {
+	cols   []string
+	values [][]driver.Value
+	pos    int
+}
+
+func (r *mockRows) Columns() []string { return r.cols }
+func (r *mockRows) Close() error      { return nil }
+func (r *mockRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.values) {
+		return io.EOF
+	}
+	for i, v := range r.values[r.pos] {
+		dest[i] = v
+	}
+	r.pos++
+	return nil
+}
+
+var (
+	mockDriverInstance = &mockDriver{
+		handlers: make(map[string]func(args []driver.Value) (driver.Rows, error)),
+	}
+	mockInitOnce sync.Once
+)
+
+func getMockDB(t *testing.T) *sql.DB {
+	mockInitOnce.Do(func() {
+		sql.Register("pgdiagnostic_mock", mockDriverInstance)
+	})
+	db, err := sql.Open("pgdiagnostic_mock", "")
+	if err != nil {
+		t.Fatalf("failed to open mock db: %v", err)
+	}
+	return db
+}
+
+func TestRunPermissionDiagnostic(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil db", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "42501"}
+		got := RunPermissionDiagnostic(ctx, nil, pqErr)
+		if got != "" {
+			t.Errorf("expected empty string for nil db, got %q", got)
+		}
+	})
+
+	t.Run("nil pqErr", func(t *testing.T) {
+		db := getMockDB(t)
+		got := RunPermissionDiagnostic(ctx, db, nil)
+		if got != "" {
+			t.Errorf("expected empty string for nil pqErr, got %q", got)
+		}
+	})
+
+	t.Run("non-42501 error code", func(t *testing.T) {
+		db := getMockDB(t)
+		pqErr := &pq.Error{Code: "42P01", Message: "table not found"}
+		got := RunPermissionDiagnostic(ctx, db, pqErr)
+		if got != "" {
+			t.Errorf("expected empty string for 42P01 error, got %q", got)
+		}
+	})
+
+	t.Run("successful diagnostic run with schema permission failure", func(t *testing.T) {
+		db := getMockDB(t)
+
+		mockDriverInstance.mu.Lock()
+		mockDriverInstance.handlers = map[string]func(args []driver.Value) (driver.Rows, error){
+			"SELECT current_user": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"current_user", "session_user", "current_database", "current_schema"},
+					values: [][]driver.Value{
+						{"app_user", "app_user", "testdb", "custom_schema"},
+					},
+				}, nil
+			},
+			"nspowner": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"coalesce"},
+					values: [][]driver.Value{
+						{"admin_role"},
+					},
+				}, nil
+			},
+			"has_schema_privilege": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"has_usage", "has_create"},
+					values: [][]driver.Value{
+						{true, false},
+					},
+				}, nil
+			},
+			"azure_pg_admin": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"exists"},
+					values: [][]driver.Value{
+						{false},
+					},
+				}, nil
+			},
+		}
+		mockDriverInstance.mu.Unlock()
+
+		pqErr := &pq.Error{
+			Code:    "42501",
+			Message: "permission denied for schema custom_schema",
+		}
+
+		got := RunPermissionDiagnostic(ctx, db, pqErr)
+		if got == "" {
+			t.Fatal("expected non-empty diagnostic output, got empty")
+		}
+
+		if !strings.Contains(got, "[permission diagnostic (SQLSTATE 42501)]") {
+			t.Errorf("missing header in: %s", got)
+		}
+		if !strings.Contains(got, "current_user: app_user") {
+			t.Errorf("missing current_user in: %s", got)
+		}
+		if !strings.Contains(got, "schema: custom_schema (owner: admin_role)") {
+			t.Errorf("missing schema/owner in: %s", got)
+		}
+		if !strings.Contains(got, "schema privileges: USAGE=true, CREATE=false") {
+			t.Errorf("missing privileges in: %s", got)
+		}
+		if !strings.Contains(got, "azure_pg_admin member: false") {
+			t.Errorf("missing azure_pg_admin in: %s", got)
+		}
+		if !strings.Contains(got, `remediation: User "app_user" lacks CREATE/USAGE privilege on schema "custom_schema". Run: GRANT USAGE, CREATE ON SCHEMA "custom_schema" TO "app_user";`) {
+			t.Errorf("missing remediation in: %s", got)
+		}
+	})
+
+	t.Run("table permission remediation when schema privileges are present", func(t *testing.T) {
+		db := getMockDB(t)
+
+		mockDriverInstance.mu.Lock()
+		mockDriverInstance.handlers = map[string]func(args []driver.Value) (driver.Rows, error){
+			"SELECT current_user": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"current_user", "session_user", "current_database", "current_schema"},
+					values: [][]driver.Value{
+						{"readonly_user", "readonly_user", "testdb", "public"},
+					},
+				}, nil
+			},
+			"nspowner": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"coalesce"},
+					values: [][]driver.Value{
+						{"postgres"},
+					},
+				}, nil
+			},
+			"has_schema_privilege": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"has_usage", "has_create"},
+					values: [][]driver.Value{
+						{true, true},
+					},
+				}, nil
+			},
+			"azure_pg_admin": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols: []string{"exists"},
+					values: [][]driver.Value{
+						{true},
+					},
+				}, nil
+			},
+		}
+		mockDriverInstance.mu.Unlock()
+
+		pqErr := &pq.Error{
+			Code:    "42501",
+			Message: "permission denied for table schema_migrations",
+			Table:   "schema_migrations",
+			Schema:  "public",
+		}
+
+		got := RunPermissionDiagnostic(ctx, db, pqErr)
+		if got == "" {
+			t.Fatal("expected non-empty diagnostic output, got empty")
+		}
+
+		if !strings.Contains(got, "azure_pg_admin member: true") {
+			t.Errorf("missing azure_pg_admin member: true in: %s", got)
+		}
+		if !strings.Contains(got, `remediation: User "readonly_user" lacks permissions on table "schema_migrations". Run: GRANT ALL ON TABLE "schema_migrations" TO "readonly_user";`) {
+			t.Errorf("missing table remediation in: %s", got)
+		}
+	})
+
+	t.Run("query failure gracefully handled", func(t *testing.T) {
+		db := getMockDB(t)
+
+		mockDriverInstance.mu.Lock()
+		mockDriverInstance.handlers = map[string]func(args []driver.Value) (driver.Rows, error){
+			"SELECT current_user": func(args []driver.Value) (driver.Rows, error) {
+				return nil, errors.New("db disconnected")
+			},
+		}
+		mockDriverInstance.mu.Unlock()
+
+		pqErr := &pq.Error{
+			Code:    "42501",
+			Message: "permission denied",
+		}
+
+		got := RunPermissionDiagnostic(ctx, db, pqErr)
+		if got != "" {
+			t.Errorf("expected empty string on connection failure, got %q", got)
+		}
+	})
+}

--- a/internal/migrator/pgdiagnostic_test.go
+++ b/internal/migrator/pgdiagnostic_test.go
@@ -145,9 +145,7 @@ func (r *mockRows) Next(dest []driver.Value) error {
 	if r.pos >= len(r.values) {
 		return io.EOF
 	}
-	for i, v := range r.values[r.pos] {
-		dest[i] = v
-	}
+	copy(dest, r.values[r.pos])
 	r.pos++
 	return nil
 }

--- a/internal/migrator/pgerror.go
+++ b/internal/migrator/pgerror.go
@@ -1,0 +1,101 @@
+package migrator
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lib/pq"
+)
+
+// TranslatePosition converts a 1-based character (rune) offset into 1-based line
+// and column coordinates, returning the line text (without trailing newline) and
+// a caret string pointing to the column.
+func TranslatePosition(sqlText string, charOffset int) (line int, col int, lineText string, caret string) {
+	runes := []rune(sqlText)
+	if charOffset < 1 || charOffset > len(runes) {
+		return 0, 0, "", ""
+	}
+
+	curLine := 1
+	curCol := 1
+	lineStartIdx := 0
+
+	for i := 0; i < charOffset-1; i++ {
+		if runes[i] == '\n' {
+			curLine++
+			curCol = 1
+			lineStartIdx = i + 1
+		} else {
+			curCol++
+		}
+	}
+
+	lineEndIdx := lineStartIdx
+	for lineEndIdx < len(runes) && runes[lineEndIdx] != '\n' {
+		lineEndIdx++
+	}
+
+	lineRunes := runes[lineStartIdx:lineEndIdx]
+	if len(lineRunes) > 0 && lineRunes[len(lineRunes)-1] == '\r' {
+		lineRunes = lineRunes[:len(lineRunes)-1]
+	}
+
+	lineText = string(lineRunes)
+	caret = strings.Repeat(" ", curCol-1) + "^"
+	return curLine, curCol, lineText, caret
+}
+
+// FormatPostgresError formats a PostgreSQL error, translating character-offset
+// position information into line and column numbers and rendering a code snippet
+// with a caret pointer. If prefixLen is > 0, the position offset is adjusted
+// to account for any preamble prepended before sqlText.
+func FormatPostgresError(err error, sqlText string, prefixLen int) error {
+	if err == nil {
+		return nil
+	}
+
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) || pqErr == nil {
+		return err
+	}
+
+	var line, col int
+	var lineText, caret string
+
+	if pqErr.Position != "" {
+		if pos, convErr := strconv.Atoi(pqErr.Position); convErr == nil {
+			adjustedOffset := pos - prefixLen
+			if adjustedOffset > 0 {
+				line, col, lineText, caret = TranslatePosition(sqlText, adjustedOffset)
+			}
+		}
+	}
+
+	var b strings.Builder
+	if line > 0 {
+		fmt.Fprintf(&b, "migration error at line %d, column %d:\n", line, col)
+		lineNumStr := strconv.Itoa(line)
+		fmt.Fprintf(&b, "  %s | %s\n", lineNumStr, lineText)
+		fmt.Fprintf(&b, "  %s | %s\n", strings.Repeat(" ", len(lineNumStr)), caret)
+	}
+
+	if pqErr.Code != "" {
+		fmt.Fprintf(&b, "pq: %s (SQLSTATE %s)", pqErr.Message, pqErr.Code)
+	} else {
+		fmt.Fprintf(&b, "pq: %s", pqErr.Message)
+	}
+
+	if pqErr.Detail != "" {
+		fmt.Fprintf(&b, "\nDetail: %s", pqErr.Detail)
+	}
+	if pqErr.Hint != "" {
+		fmt.Fprintf(&b, "\nHint: %s", pqErr.Hint)
+	}
+	if pqErr.Where != "" {
+		fmt.Fprintf(&b, "\nWhere: %s", pqErr.Where)
+	}
+
+	return errors.New(b.String())
+}

--- a/internal/migrator/pgerror_test.go
+++ b/internal/migrator/pgerror_test.go
@@ -1,0 +1,286 @@
+package migrator
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+)
+
+func TestTranslatePosition(t *testing.T) {
+	tests := []struct {
+		name        string
+		sqlText     string
+		charOffset  int
+		wantLine    int
+		wantCol     int
+		wantLineTxt string
+		wantCaret   string
+	}{
+		{
+			name:        "empty string",
+			sqlText:     "",
+			charOffset:  1,
+			wantLine:    0,
+			wantCol:     0,
+			wantLineTxt: "",
+			wantCaret:   "",
+		},
+		{
+			name:        "offset zero",
+			sqlText:     "SELECT 1;",
+			charOffset:  0,
+			wantLine:    0,
+			wantCol:     0,
+			wantLineTxt: "",
+			wantCaret:   "",
+		},
+		{
+			name:        "negative offset",
+			sqlText:     "SELECT 1;",
+			charOffset:  -5,
+			wantLine:    0,
+			wantCol:     0,
+			wantLineTxt: "",
+			wantCaret:   "",
+		},
+		{
+			name:        "out of range offset",
+			sqlText:     "SELECT 1;",
+			charOffset:  20,
+			wantLine:    0,
+			wantCol:     0,
+			wantLineTxt: "",
+			wantCaret:   "",
+		},
+		{
+			name:        "single line first char",
+			sqlText:     "SELECT 1;",
+			charOffset:  1,
+			wantLine:    1,
+			wantCol:     1,
+			wantLineTxt: "SELECT 1;",
+			wantCaret:   "^",
+		},
+		{
+			name:        "single line middle char",
+			sqlText:     "SELECT * FROM users;",
+			charOffset:  8,
+			wantLine:    1,
+			wantCol:     8,
+			wantLineTxt: "SELECT * FROM users;",
+			wantCaret:   "       ^",
+		},
+		{
+			name:        "single line last char",
+			sqlText:     "SELECT 1;",
+			charOffset:  9,
+			wantLine:    1,
+			wantCol:     9,
+			wantLineTxt: "SELECT 1;",
+			wantCaret:   "        ^",
+		},
+		{
+			name: "multiline line 2 start",
+			sqlText: "CREATE TABLE users (\n" +
+				"    id INT PRIMARY KEY\n" +
+				");",
+			charOffset:  22, // '    id' starts at offset 22 ('C'...'\n' is 21 runes)
+			wantLine:    2,
+			wantCol:     1,
+			wantLineTxt: "    id INT PRIMARY KEY",
+			wantCaret:   "^",
+		},
+		{
+			name: "multiline line 2 column 5",
+			sqlText: "CREATE TABLE users (\n" +
+				"    id INT PRIMARY KEY\n" +
+				");",
+			charOffset:  26, // 'i' is col 5
+			wantLine:    2,
+			wantCol:     5,
+			wantLineTxt: "    id INT PRIMARY KEY",
+			wantCaret:   "    ^",
+		},
+		{
+			name: "multiline line 3 col 2",
+			sqlText: "LINE 1\n" +
+				"LINE 2\n" +
+				"LINE 3",
+			charOffset:  16, // 'I' in 'LINE 3' (line 1 is 7 runes, line 2 is 7 runes, 'L' is 15, 'I' is 16)
+			wantLine:    3,
+			wantCol:     2,
+			wantLineTxt: "LINE 3",
+			wantCaret:   " ^",
+		},
+		{
+			name: "crlf line endings",
+			sqlText: "SELECT 1;\r\n" +
+				"SELECT 2;\r\n",
+			charOffset:  12, // 'S' of second line (SELECT 1;\r\n is 11 runes)
+			wantLine:    2,
+			wantCol:     1,
+			wantLineTxt: "SELECT 2;",
+			wantCaret:   "^",
+		},
+		{
+			name: "unicode multibyte characters in comments",
+			sqlText: "-- 🚀 Initial migration with unicode 数据库\n" +
+				"CREATE TABLE test (id INT);",
+			// Rune count on line 1: 3 + 1 + 32 + 3 + 1 = 40 runes
+			charOffset:  41, // 'C' on line 2
+			wantLine:    2,
+			wantCol:     1,
+			wantLineTxt: "CREATE TABLE test (id INT);",
+			wantCaret:   "^",
+		},
+		{
+			name: "unicode position pointing to multibyte char",
+			sqlText: "-- 🚀\n" +
+				"SELECT '你好世界';",
+			// Line 1: "-- 🚀\n" -> 5 runes
+			// Line 2: "SELECT '" -> 8 runes -> total 13 runes before '你'
+			// CharOffset 14 -> '好' (col 9 on line 2: S(1)E(2)L(3)E(4)C(5)T(6) (7)'(8)你(9) -> wait, '你' is col 9, '好' is col 10!)
+			// At offset 14: col is 9 ('你')
+			charOffset:  14,
+			wantLine:    2,
+			wantCol:     9,
+			wantLineTxt: "SELECT '你好世界';",
+			wantCaret:   "        ^",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line, col, lineTxt, caret := TranslatePosition(tt.sqlText, tt.charOffset)
+			if line != tt.wantLine || col != tt.wantCol {
+				t.Errorf("TranslatePosition() line=%d, col=%d; want line=%d, col=%d", line, col, tt.wantLine, tt.wantCol)
+			}
+			if lineTxt != tt.wantLineTxt {
+				t.Errorf("TranslatePosition() lineTxt=%q; want %q", lineTxt, tt.wantLineTxt)
+			}
+			if caret != tt.wantCaret {
+				t.Errorf("TranslatePosition() caret=%q; want %q", caret, tt.wantCaret)
+			}
+		})
+	}
+}
+
+func TestFormatPostgresError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		got := FormatPostgresError(nil, "SELECT 1;", 0)
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("non-pq error", func(t *testing.T) {
+		orig := errors.New("some io error")
+		got := FormatPostgresError(orig, "SELECT 1;", 0)
+		if got != orig {
+			t.Errorf("expected original error %v, got %v", orig, got)
+		}
+	})
+
+	t.Run("pq error without position", func(t *testing.T) {
+		pqErr := &pq.Error{
+			Severity: "ERROR",
+			Code:     "42P01",
+			Message:  `relation "nonexistent" does not exist`,
+		}
+		got := FormatPostgresError(pqErr, "SELECT * FROM nonexistent;", 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		want := `pq: relation "nonexistent" does not exist (SQLSTATE 42P01)`
+		if got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+	})
+
+	t.Run("pq error with position and snippet", func(t *testing.T) {
+		sqlText := "CREATE TABLE users (\n    id INT,\n    invalid syntax\n);"
+		// "CREATE TABLE users (\n    id INT,\n    " is 21 + 12 + 4 = 37 runes.
+		// "i" of "invalid" is rune 38.
+		pqErr := &pq.Error{
+			Severity: "ERROR",
+			Code:     "42601",
+			Message:  `syntax error at or near "invalid"`,
+			Position: "38",
+		}
+		got := FormatPostgresError(pqErr, sqlText, 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		errMsg := got.Error()
+		if !strings.Contains(errMsg, "migration error at line 3, column 5:") {
+			t.Errorf("missing header in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "  3 |     invalid syntax") {
+			t.Errorf("missing code line in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "    |     ^") {
+			t.Errorf("missing caret in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, `pq: syntax error at or near "invalid" (SQLSTATE 42601)`) {
+			t.Errorf("missing pq summary in: %s", errMsg)
+		}
+	})
+
+	t.Run("pq error with prefix length adjustment", func(t *testing.T) {
+		prefix := "SET search_path TO public; RESET client_min_messages;\n"
+		prefixLen := len([]rune(prefix)) // 54 runes
+		sqlText := "SELECT * FROM nonexistent_table;"
+
+		pqErr := &pq.Error{
+			Severity: "ERROR",
+			Code:     "42P01",
+			Message:  `relation "nonexistent_table" does not exist`,
+			Position: "69", // 54 prefix + 15 ("SELECT * FROM n")
+		}
+
+		got := FormatPostgresError(pqErr, sqlText, prefixLen)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		errMsg := got.Error()
+		if !strings.Contains(errMsg, "migration error at line 1, column 15:") {
+			t.Errorf("expected line 1, column 15 in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "  1 | SELECT * FROM nonexistent_table;") {
+			t.Errorf("expected code line in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "    |               ^") {
+			t.Errorf("expected caret at col 15 in: %s", errMsg)
+		}
+	})
+
+	t.Run("pq error with detail hint and where", func(t *testing.T) {
+		pqErr := &pq.Error{
+			Severity: "ERROR",
+			Code:     "42703",
+			Message:  `column "foo" does not exist`,
+			Detail:   `Column "foo" was not found in table "bar".`,
+			Hint:     `Perhaps you meant to reference the column "bar.baz".`,
+			Where:    `PL/pgSQL function update_bar() line 4 at SQL statement`,
+		}
+		got := FormatPostgresError(pqErr, "SELECT foo FROM bar;", 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		errMsg := got.Error()
+		if !strings.Contains(errMsg, `Detail: Column "foo" was not found in table "bar".`) {
+			t.Errorf("missing Detail in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, `Hint: Perhaps you meant to reference the column "bar.baz".`) {
+			t.Errorf("missing Hint in: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, `Where: PL/pgSQL function update_bar() line 4 at SQL statement`) {
+			t.Errorf("missing Where in: %s", errMsg)
+		}
+	})
+}

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/lib/pq"
 )
 
 // openPostgresResetDriver builds the postgres driver for rawURL and wraps
@@ -20,19 +21,21 @@ func openPostgresResetDriver(rawURL string) (database.Driver, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %w", rawURL, err)
 	}
-	// WithInstance needs the *sql.DB the driver will use; build it the
-	// same way the postgres package does (strip custom query params).
 	cleanURL := migrate.FilterCustomQuery(purl).String()
-	db, err := sql.Open("postgres", cleanURL)
+	connector, err := pq.NewConnector(cleanURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating postgres connector: %w", err)
 	}
+	nhConnector := pq.ConnectorWithNoticeHandler(connector, func(n *pq.Error) {
+		fmt.Printf("postgres: %s: %s\n", n.Severity, n.Message)
+	})
+	db := sql.OpenDB(nhConnector)
 	inner, err := postgres.WithInstance(db, &postgres.Config{})
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("opening postgres driver: %w", err)
 	}
-	return &pgResetDriver{inner: inner}, nil
+	return &pgResetDriver{inner: inner, db: db}, nil
 }
 
 // pgResetDriver wraps golang-migrate's postgres driver and resets
@@ -49,6 +52,7 @@ func openPostgresResetDriver(rawURL string) (database.Driver, error) {
 // fresh session without paying for a new connection per file.
 type pgResetDriver struct {
 	inner database.Driver
+	db    *sql.DB
 }
 
 func (d *pgResetDriver) Close() error  { return d.inner.Close() }

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -1,7 +1,10 @@
 package migrator
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -77,11 +80,27 @@ func (d *pgResetDriver) Drop() error                 { return d.inner.Drop() }
 // file. The version-table bookkeeping (SetVersion) runs on the same
 // connection but outside Run, so it still sees the default schema.
 func (d *pgResetDriver) Run(migration io.Reader) error {
+	migrationBytes, err := io.ReadAll(migration)
+	if err != nil {
+		return fmt.Errorf("reading migration: %w", err)
+	}
+
+	prefix := "SET search_path TO public; RESET client_min_messages;\n"
+	prefixRunes := len([]rune(prefix))
+
 	if err := d.inner.Run(io.MultiReader(
-		strings.NewReader("SET search_path TO public; RESET client_min_messages;"),
-		migration,
+		strings.NewReader(prefix),
+		bytes.NewReader(migrationBytes),
 	)); err != nil {
-		return fmt.Errorf("running migration: %w", err)
+		formattedErr := FormatPostgresError(err, string(migrationBytes), prefixRunes)
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr != nil && pqErr.Code == "42501" {
+			diag := RunPermissionDiagnostic(context.Background(), d.db, pqErr)
+			if diag != "" {
+				formattedErr = fmt.Errorf("%w\n\n%s", formattedErr, diag)
+			}
+		}
+		return fmt.Errorf("running migration: %w", formattedErr)
 	}
 	return nil
 }

--- a/internal/migrator/pgreset_test.go
+++ b/internal/migrator/pgreset_test.go
@@ -1,17 +1,21 @@
 package migrator
 
 import (
+	"database/sql/driver"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/lib/pq"
 )
 
 // fakeResetInner records what Run received so the wrapper's prepend
 // behaviour is testable without a live postgres.
 type fakeResetInner struct {
 	lastMigration string
+	runErr        error
 }
 
 func (f *fakeResetInner) Open(string) (database.Driver, error) { return f, nil }
@@ -24,7 +28,13 @@ func (f *fakeResetInner) Drop() error                          { return nil }
 func (f *fakeResetInner) Run(r io.Reader) error {
 	raw, _ := io.ReadAll(r)
 	f.lastMigration = string(raw)
-	return nil
+	return f.runErr
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }
 
 // TestPgResetDriver_PrependsSessionReset is the R6/C5 regression: every
@@ -76,5 +86,154 @@ func TestOpenPostgresResetDriver_BadURL(t *testing.T) {
 	_, err := openPostgresResetDriver("postgres://invalid:port:is:bad")
 	if err == nil {
 		t.Fatalf("openPostgresResetDriver() expected error for invalid URL, got nil")
+	}
+}
+
+func TestPgResetDriver_Run_ReadError(t *testing.T) {
+	inner := &fakeResetInner{}
+	d := &pgResetDriver{inner: inner}
+
+	err := d.Run(errReader{})
+	if err == nil {
+		t.Fatal("expected error for failing reader, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading migration: read failed") {
+		t.Errorf("expected reading migration error, got %v", err)
+	}
+}
+
+func TestPgResetDriver_Run_SyntaxErrorFormatting(t *testing.T) {
+	// Prefix is "SET search_path TO public; RESET client_min_messages;\n" (54 runes)
+	// Position 62 in total stream = 62 - 54 = 8 in migration text
+	// Migration: "CREATE TABEL foo (id int);"
+	// Line 1, Col 8 is "T" of TABEL
+	inner := &fakeResetInner{
+		runErr: &pq.Error{
+			Code:     "42601",
+			Message:  `syntax error at or near "TABEL"`,
+			Position: "62",
+		},
+	}
+	d := &pgResetDriver{inner: inner}
+
+	sqlText := "CREATE TABEL foo (id int);"
+	err := d.Run(strings.NewReader(sqlText))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "migration error at line 1, column 8:") {
+		t.Errorf("expected position line/col in error, got:\n%s", errMsg)
+	}
+	if !strings.Contains(errMsg, "CREATE TABEL foo (id int);") {
+		t.Errorf("expected snippet in error, got:\n%s", errMsg)
+	}
+	if !strings.Contains(errMsg, "pq: syntax error at or near \"TABEL\" (SQLSTATE 42601)") {
+		t.Errorf("expected SQLSTATE 42601 in error, got:\n%s", errMsg)
+	}
+}
+
+func TestPgResetDriver_Run_PermissionDiagnosticAttached(t *testing.T) {
+	db := getMockDB(t)
+
+	mockDriverInstance.mu.Lock()
+	mockDriverInstance.handlers = map[string]func(args []driver.Value) (driver.Rows, error){
+		"SELECT current_user": func(args []driver.Value) (driver.Rows, error) {
+			return &mockRows{
+				cols: []string{"current_user", "session_user", "current_database", "current_schema"},
+				values: [][]driver.Value{
+					{"app_user", "app_user", "testdb", "public"},
+				},
+			}, nil
+		},
+		"nspowner": func(args []driver.Value) (driver.Rows, error) {
+			return &mockRows{
+				cols: []string{"coalesce"},
+				values: [][]driver.Value{
+					{"postgres"},
+				},
+			}, nil
+		},
+		"has_schema_privilege": func(args []driver.Value) (driver.Rows, error) {
+			return &mockRows{
+				cols: []string{"has_usage", "has_create"},
+				values: [][]driver.Value{
+					{true, false},
+				},
+			}, nil
+		},
+		"azure_pg_admin": func(args []driver.Value) (driver.Rows, error) {
+			return &mockRows{
+				cols: []string{"exists"},
+				values: [][]driver.Value{
+					{false},
+				},
+			}, nil
+		},
+	}
+	mockDriverInstance.mu.Unlock()
+
+	inner := &fakeResetInner{
+		runErr: &pq.Error{
+			Code:    "42501",
+			Message: "permission denied for schema public",
+		},
+	}
+	d := &pgResetDriver{inner: inner, db: db}
+
+	err := d.Run(strings.NewReader("CREATE TABLE foo (id int);"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "[permission diagnostic (SQLSTATE 42501)]") {
+		t.Errorf("expected permission diagnostic header in error, got:\n%s", errMsg)
+	}
+	if !strings.Contains(errMsg, "schema privileges: USAGE=true, CREATE=false") {
+		t.Errorf("expected schema privileges in error, got:\n%s", errMsg)
+	}
+	if !strings.Contains(errMsg, `remediation: User "app_user" lacks CREATE/USAGE privilege on schema "public". Run: GRANT USAGE, CREATE ON SCHEMA "public" TO "app_user";`) {
+		t.Errorf("expected remediation in error, got:\n%s", errMsg)
+	}
+}
+
+func TestPgResetDriver_Run_PermissionDiagnosticNoDB(t *testing.T) {
+	inner := &fakeResetInner{
+		runErr: &pq.Error{
+			Code:    "42501",
+			Message: "permission denied for schema public",
+		},
+	}
+	d := &pgResetDriver{inner: inner, db: nil}
+
+	err := d.Run(strings.NewReader("CREATE TABLE foo (id int);"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "pq: permission denied for schema public (SQLSTATE 42501)") {
+		t.Errorf("expected pq error in message, got:\n%s", errMsg)
+	}
+	// With nil DB, diagnostic block is empty so no diagnostic header should be attached
+	if strings.Contains(errMsg, "[permission diagnostic") {
+		t.Errorf("did not expect diagnostic block when db is nil, got:\n%s", errMsg)
+	}
+}
+
+func TestPgResetDriver_Run_GenericError(t *testing.T) {
+	inner := &fakeResetInner{
+		runErr: errors.New("connection reset by peer"),
+	}
+	d := &pgResetDriver{inner: inner}
+
+	err := d.Run(strings.NewReader("CREATE TABLE foo (id int);"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "running migration: connection reset by peer") {
+		t.Errorf("expected generic error wrapped, got %v", err)
 	}
 }

--- a/internal/migrator/pgreset_test.go
+++ b/internal/migrator/pgreset_test.go
@@ -71,3 +71,10 @@ func TestPgResetDriver_DelegatesTheRest(t *testing.T) {
 		t.Errorf("Drop() returned error: %v", err)
 	}
 }
+
+func TestOpenPostgresResetDriver_BadURL(t *testing.T) {
+	_, err := openPostgresResetDriver("postgres://invalid:port:is:bad")
+	if err == nil {
+		t.Fatalf("openPostgresResetDriver() expected error for invalid URL, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Closes part of #60 (sub-project 2 of 4: Postgres error diagnostics).

- Forward PostgreSQL server `NOTICE`s to stdout during migration execution using `pq.ConnectorWithNoticeHandler`.
- Translate character-offset error positions (`pq.Error.Position`) into 1-based line/col numbers and render code snippets with caret pointers.
- Added automated permission self-diagnostic on `SQLSTATE 42501` (`insufficient_privilege`) inspecting `current_user`, schema ownership, `has_schema_privilege`, and `azure_pg_admin` role membership with actionable remediation output.

## Test plan
- [x] Unit tests in `internal/migrator/pgerror_test.go` and `internal/migrator/pgdiagnostic_test.go`
- [x] Driver integration in `internal/migrator/pgreset_test.go`
- [x] Full local test suite `scripts/dev-local.sh all` passed
- [ ] Verify GitHub Actions CI checks