### PR TITLE
feat: add log-format flag for structured json logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dbtools
 dist/ 
+.superpowers/sdd/

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/seanpham99/dbtools/internal/down"
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/migrator"
 	"github.com/spf13/cobra"
 )
@@ -77,12 +78,12 @@ func runDown(targetName string, steps int) error {
 			return nil
 		}
 		if len(plan) == 0 {
-			fmt.Printf("%s: no applied migrations to revert (preview)\n", targetName)
+			logger.Infof("%s: no applied migrations to revert (preview)", targetName)
 			return nil
 		}
-		fmt.Printf("%s: %d down migration(s) would be executed:\n", targetName, len(plan))
+		logger.Infof("%s: %d down migration(s) would be executed:", targetName, len(plan))
 		for _, f := range plan {
-			fmt.Printf("  %s\n", f.Filename)
+			logger.Infof("  %s", f.Filename)
 		}
 		return nil
 	}
@@ -101,15 +102,15 @@ func runDown(targetName string, steps int) error {
 			fmt.Println(string(b))
 			return nil
 		}
-		fmt.Printf("%s: no applied migrations to revert\n", targetName)
+		logger.Infof("%s: no applied migrations to revert", targetName)
 		return nil
 	}
 
 	if target.Protected {
 		if !jsonOutput {
-			fmt.Printf("%s: [PROTECTED TARGET] %d down migration(s) will be executed:\n", targetName, len(plan))
+			logger.Infof("%s: [PROTECTED TARGET] %d down migration(s) will be executed:", targetName, len(plan))
 			for _, f := range plan {
-				fmt.Printf("  %s\n", f.Filename)
+				logger.Infof("  %s", f.Filename)
 			}
 		}
 		if !downYes {
@@ -131,14 +132,14 @@ func runDown(targetName string, steps int) error {
 		return nil
 	}
 
-	fmt.Printf("%s: reverted %d migration(s)\n", targetName, len(res.RevertedVersions))
+	logger.Infof("%s: reverted %d migration(s)", targetName, len(res.RevertedVersions))
 	for _, v := range res.RevertedVersions {
-		fmt.Printf("  reverted v%d\n", v)
+		logger.Infof("  reverted v%d", v)
 	}
 	if res.HasVersion {
-		fmt.Printf("%s: now at version %d\n", targetName, res.CurrentVersion)
+		logger.Infof("%s: now at version %d", targetName, res.CurrentVersion)
 	} else {
-		fmt.Printf("%s: no migrations remaining (version 0)\n", targetName)
+		logger.Infof("%s: no migrations remaining (version 0)", targetName)
 	}
 	return nil
 }

--- a/cmd/log_format_integration_test.go
+++ b/cmd/log_format_integration_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/logger"
+)
+
+func TestLogFormatIntegration_JSON(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+		upTarget = "local"
+		upURL = ""
+		upDryRun = false
+		pushYes = false
+		pushURL = ""
+		pushDryRun = false
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "20260825000001_test.up.sql"), []byte("CREATE TABLE log_test (id INT);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "20260825000001_test.down.sql"), []byte("DROP TABLE log_test;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dbURL := "sqlite://" + filepath.Join(dir, "log_test.db")
+	t.Setenv("DBTOOLS_TEST_LOG_URL", dbURL)
+
+	configContent := `migrations_dir = "migrations"
+
+[targets.local]
+url_env = "DBTOOLS_TEST_LOG_URL"
+
+[targets.remote]
+url_env = "DBTOOLS_TEST_LOG_URL"
+`
+	if err := os.WriteFile("dbtools.toml", []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	rootCmd.SetArgs([]string{"--log-format=json", "up"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() up failed: %v", err)
+	}
+
+	logOutput := strings.TrimSpace(buf.String())
+	if logOutput == "" {
+		t.Fatal("expected log output, got empty")
+	}
+
+	lines := strings.Split(logOutput, "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record logger.LogRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("failed to unmarshal log record as JSON: %v, raw line: %q", err, line)
+		}
+		if record.Timestamp == "" {
+			t.Errorf("expected non-empty timestamp, got %q in %s", record.Timestamp, line)
+		}
+		if record.Level != "INFO" {
+			t.Errorf("expected level INFO, got %q in %s", record.Level, line)
+		}
+		if !strings.Contains(record.Message, "local: now at version") {
+			t.Errorf("expected message containing 'local: now at version', got %q", record.Message)
+		}
+	}
+}
+
+func TestLogFormatIntegration_Text(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+		upTarget = "local"
+		upURL = ""
+		upDryRun = false
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "20260825000001_test.up.sql"), []byte("CREATE TABLE log_test_text (id INT);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dbURL := "sqlite://" + filepath.Join(dir, "log_test_text.db")
+	t.Setenv("DBTOOLS_TEST_LOG_TEXT_URL", dbURL)
+
+	configContent := `migrations_dir = "migrations"
+
+[targets.local]
+url_env = "DBTOOLS_TEST_LOG_TEXT_URL"
+`
+	if err := os.WriteFile("dbtools.toml", []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	rootCmd.SetArgs([]string{"--log-format=text", "up"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() up failed: %v", err)
+	}
+
+	logOutput := strings.TrimSpace(buf.String())
+	if logOutput == "" {
+		t.Fatal("expected log output, got empty")
+	}
+
+	if strings.HasPrefix(logOutput, "{") {
+		t.Fatalf("expected plain text log, but got JSON-like output: %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "local: now at version") {
+		t.Fatalf("expected message containing 'local: now at version', got %q", logOutput)
+	}
+}
+
+func TestLogFormatIntegration_PushJSON(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	dir := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+		pushYes = false
+		pushURL = ""
+		pushDryRun = false
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll("migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("migrations", "20260825000001_test.up.sql"), []byte("CREATE TABLE log_test_push (id INT);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dbURL := "sqlite://" + filepath.Join(dir, "log_test_push.db")
+	t.Setenv("DBTOOLS_TEST_PUSH_LOG_URL", dbURL)
+
+	configContent := `migrations_dir = "migrations"
+
+[targets.remote]
+url_env = "DBTOOLS_TEST_PUSH_LOG_URL"
+`
+	if err := os.WriteFile("dbtools.toml", []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	rootCmd.SetArgs([]string{"--log-format=json", "push", "remote", "--yes"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() push failed: %v", err)
+	}
+
+	logOutput := strings.TrimSpace(buf.String())
+	if logOutput == "" {
+		t.Fatal("expected log output, got empty")
+	}
+
+	var record logger.LogRecord
+	if err := json.Unmarshal([]byte(logOutput), &record); err != nil {
+		t.Fatalf("failed to unmarshal log record as JSON: %v, raw line: %q", err, logOutput)
+	}
+	if record.Timestamp == "" || record.Level != "INFO" || !strings.Contains(record.Message, "remote: now at version") {
+		t.Fatalf("unexpected record: %+v", record)
+	}
+}

--- a/cmd/log_format_test.go
+++ b/cmd/log_format_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/logger"
+)
+
+func resetRootFlags() {
+	jsonOutput = false
+	logFormat = "text"
+	if f := rootCmd.PersistentFlags().Lookup("log-format"); f != nil {
+		f.Changed = false
+		_ = f.Value.Set("text")
+	}
+	if f := rootCmd.PersistentFlags().Lookup("json"); f != nil {
+		f.Changed = false
+		_ = f.Value.Set("false")
+	}
+	logger.SetFormat("text")
+	logger.SetOutput(os.Stderr)
+}
+
+func TestLogFormat_JSONFlag(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	rootCmd.SetArgs([]string{"--log-format=json", "version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected rootCmd.Execute() to succeed, got: %v", err)
+	}
+
+	if got := logger.GetFormat(); got != "json" {
+		t.Fatalf("logger.GetFormat() = %q, want %q", got, "json")
+	}
+}
+
+func TestLogFormat_TextFlag(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	rootCmd.SetArgs([]string{"--log-format=text", "version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected rootCmd.Execute() to succeed, got: %v", err)
+	}
+
+	if got := logger.GetFormat(); got != "text" {
+		t.Fatalf("logger.GetFormat() = %q, want %q", got, "text")
+	}
+}
+
+func TestLogFormat_InvalidFlag(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	rootCmd.SetArgs([]string{"--log-format=invalid", "version"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error for invalid --log-format, got nil")
+	}
+
+	expected := `invalid --log-format "invalid" (must be 'text' or 'json')`
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected error containing %q, got %q", expected, err.Error())
+	}
+}
+
+func TestLogFormat_EnvVarFallback(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	t.Setenv("DBTOOLS_LOG_FORMAT", "json")
+
+	rootCmd.SetArgs([]string{"version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected rootCmd.Execute() to succeed, got: %v", err)
+	}
+
+	if got := logger.GetFormat(); got != "json" {
+		t.Fatalf("logger.GetFormat() = %q, want %q", got, "json")
+	}
+}
+
+func TestLogFormat_FlagOverridesEnvVar(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	t.Setenv("DBTOOLS_LOG_FORMAT", "json")
+
+	rootCmd.SetArgs([]string{"--log-format=text", "version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected rootCmd.Execute() to succeed, got: %v", err)
+	}
+
+	if got := logger.GetFormat(); got != "text" {
+		t.Fatalf("logger.GetFormat() = %q, want %q", got, "text")
+	}
+}
+
+func TestLogFormat_JSONOutputStderr(t *testing.T) {
+	t.Cleanup(resetRootFlags)
+	resetRootFlags()
+
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	rootCmd.SetArgs([]string{"--json", "version"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected rootCmd.Execute() to succeed, got: %v", err)
+	}
+
+	// Logging after pre-run with --json must not write to custom buf because output was reset to os.Stderr
+	logger.Info("should go to stderr")
+	if buf.Len() != 0 {
+		t.Fatalf("expected buf to be empty after --json redirected output to os.Stderr, got %q", buf.String())
+	}
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/seanpham99/dbtools/internal/apply"
 	"github.com/seanpham99/dbtools/internal/engine"
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/statusinfo"
 	"github.com/spf13/cobra"
 )
@@ -66,15 +67,15 @@ func runPush(targetName string) error {
 			fmt.Println(string(b))
 			return nil
 		}
-		fmt.Printf("%s: already up to date, nothing to push\n", targetName)
+		logger.Infof("%s: already up to date, nothing to push", targetName)
 		return nil
 	}
 
 	if !pushYes {
 		if !jsonOutput {
-			fmt.Printf("%s: %d pending migration(s):\n", targetName, len(preview.Pending))
+			logger.Infof("%s: %d pending migration(s):", targetName, len(preview.Pending))
 			for _, f := range preview.Pending {
-				fmt.Printf("  %s\n", f)
+				logger.Infof("  %s", f)
 			}
 		}
 		return fmt.Errorf("refusing to push migrations to %q without --yes", targetName)
@@ -94,7 +95,7 @@ func runPush(targetName string) error {
 		return nil
 	}
 
-	fmt.Printf("%s: now at version %d (%d pending)\n", status.Target, status.CurrentVersion, len(status.Pending))
+	logger.Infof("%s: now at version %d (%d pending)", status.Target, status.CurrentVersion, len(status.Pending))
 	return nil
 }
 

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/migrator"
 	"github.com/seanpham99/dbtools/internal/repair"
 	"github.com/spf13/cobra"
@@ -118,9 +119,9 @@ func runRepair(targetName string, pairs []repair.Pair) error {
 	}
 
 	if !result.HasCursor {
-		fmt.Printf("%s: repaired %d version(s), no applied versions remain (cursor untouched)\n", targetName, len(result.Repaired))
+		logger.Infof("%s: repaired %d version(s), no applied versions remain (cursor untouched)", targetName, len(result.Repaired))
 		return nil
 	}
-	fmt.Printf("%s: repaired %d version(s), cursor now at %d\n", targetName, len(result.Repaired), result.NewCursor)
+	logger.Infof("%s: repaired %d version(s), cursor now at %d", targetName, len(result.Repaired), result.NewCursor)
 	return nil
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seanpham99/dbtools/internal/container"
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/seed"
 	"github.com/spf13/cobra"
 )
@@ -184,7 +185,7 @@ func runReset(targetNames ...string) error {
 		return nil
 	}
 
-	fmt.Printf("%s: replayed to version %d\n", targetName, status.CurrentVersion)
-	fmt.Printf("%s applied (or skipped if absent)\n", seed.Filename)
+	logger.Infof("%s: replayed to version %d", targetName, status.CurrentVersion)
+	logger.Infof("%s applied (or skipped if absent)", seed.Filename)
 	return nil
 }

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/rollback"
 	"github.com/spf13/cobra"
 )
@@ -68,18 +69,18 @@ func runRollback(targetName string, steps int) error {
 	}
 
 	if len(res.RevertedVersions) == 0 {
-		fmt.Printf("%s: no applied migrations to soft-revert\n", targetName)
+		logger.Infof("%s: no applied migrations to soft-revert", targetName)
 		return nil
 	}
 
-	fmt.Printf("%s: soft-reverted %d migration(s) in ledger (no tables dropped)\n", targetName, len(res.RevertedVersions))
+	logger.Infof("%s: soft-reverted %d migration(s) in ledger (no tables dropped)", targetName, len(res.RevertedVersions))
 	for _, v := range res.RevertedVersions {
-		fmt.Printf("  marked v%d reverted\n", v)
+		logger.Infof("  marked v%d reverted", v)
 	}
 	if res.HasCursor {
-		fmt.Printf("%s: cursor recomputed to version %d\n", targetName, res.NewCursor)
+		logger.Infof("%s: cursor recomputed to version %d", targetName, res.NewCursor)
 	} else {
-		fmt.Printf("%s: no applied migrations remaining\n", targetName)
+		logger.Infof("%s: no applied migrations remaining", targetName)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/seanpham99/dbtools/internal/engine/postgresengine"
 	_ "github.com/seanpham99/dbtools/internal/engine/sqliteengine"
 	"github.com/seanpham99/dbtools/internal/localenv"
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,10 @@ var rootCmd = &cobra.Command{
 	Short: "dbtools manages MSSQL/Postgres schema migrations and local dev databases",
 }
 
-var jsonOutput bool
+var (
+	jsonOutput bool
+	logFormat  string
+)
 
 func loadLocalEnv() error {
 	vars, err := localenv.Load()
@@ -36,7 +40,23 @@ func loadLocalEnv() error {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "emit machine-readable JSON output")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "log format (text, json)")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		fmtVal := logFormat
+		if !cmd.Flags().Changed("log-format") {
+			if env := os.Getenv("DBTOOLS_LOG_FORMAT"); env != "" {
+				fmtVal = env
+			}
+		}
+		switch fmtVal {
+		case "text", "json":
+		default:
+			return fmt.Errorf("invalid --log-format %q (must be 'text' or 'json')", fmtVal)
+		}
+		logger.SetFormat(fmtVal)
+		if jsonOutput {
+			logger.SetOutput(os.Stderr)
+		}
 		return loadLocalEnv()
 	}
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,7 @@ var upCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Printf("%s: now at version %d (%d pending)\n", status.Target, status.CurrentVersion, len(status.Pending))
+		logger.Infof("%s: now at version %d (%d pending)", status.Target, status.CurrentVersion, len(status.Pending))
 		return nil
 	},
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,233 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Level represents the severity level of a log message.
+type Level string
+
+const (
+	LevelDebug Level = "DEBUG"
+	LevelInfo  Level = "INFO"
+	LevelWarn  Level = "WARN"
+	LevelError Level = "ERROR"
+)
+
+// String returns the string representation of the level.
+func (l Level) String() string {
+	return string(l)
+}
+
+// Supported log format types.
+const (
+	FormatText = "text"
+	FormatJSON = "json"
+)
+
+// LogRecord represents a single structured log entry for JSON output.
+type LogRecord struct {
+	Timestamp string         `json:"timestamp"`
+	Level     string         `json:"level"`
+	Message   string         `json:"message"`
+	Fields    map[string]any `json:"fields,omitempty"`
+}
+
+// Logger provides synchronized structured logging to an io.Writer.
+type Logger struct {
+	mu     sync.Mutex
+	out    io.Writer
+	format string
+}
+
+// New creates a new Logger writing to w with default text format.
+func New(w io.Writer) *Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	return &Logger{
+		out:    w,
+		format: FormatText,
+	}
+}
+
+var defaultLogger = func() *Logger {
+	l := New(os.Stderr)
+	if env := os.Getenv("DBTOOLS_LOG_FORMAT"); env != "" {
+		l.SetFormat(env)
+	}
+	return l
+}()
+
+// Default returns the package-level default logger instance.
+func Default() *Logger {
+	return defaultLogger
+}
+
+// SetFormat configures the log format ("text" or "json").
+func (l *Logger) SetFormat(format string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case FormatJSON:
+		l.format = FormatJSON
+	default:
+		l.format = FormatText
+	}
+}
+
+// GetFormat returns the current log format.
+func (l *Logger) GetFormat() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.format
+}
+
+// SetOutput sets the output writer for the logger.
+func (l *Logger) SetOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if w == nil {
+		w = os.Stderr
+	}
+	l.out = w
+}
+
+func (l *Logger) writeRecord(level Level, msg string, fields map[string]any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.format == FormatJSON {
+		rec := LogRecord{
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Level:     string(level),
+			Message:   msg,
+			Fields:    fields,
+		}
+		data, err := json.Marshal(rec)
+		if err != nil {
+			fallback := fmt.Sprintf(`{"timestamp":%q,"level":"ERROR","message":%q}`+"\n",
+				time.Now().UTC().Format(time.RFC3339), "failed to marshal log record: "+err.Error())
+			_, _ = io.WriteString(l.out, fallback)
+			return
+		}
+		data = append(data, '\n')
+		_, _ = l.out.Write(data)
+		return
+	}
+
+	_, _ = fmt.Fprintln(l.out, msg)
+}
+
+// Log writes a message with a custom level and optional fields.
+func (l *Logger) Log(level Level, msg string, fields map[string]any) {
+	l.writeRecord(level, msg, fields)
+}
+
+// Debug logs a message at LevelDebug.
+func (l *Logger) Debug(msg string) {
+	l.writeRecord(LevelDebug, msg, nil)
+}
+
+// Debugf logs a formatted message at LevelDebug.
+func (l *Logger) Debugf(format string, args ...any) {
+	l.writeRecord(LevelDebug, fmt.Sprintf(format, args...), nil)
+}
+
+// Info logs a message at LevelInfo.
+func (l *Logger) Info(msg string) {
+	l.writeRecord(LevelInfo, msg, nil)
+}
+
+// Infof logs a formatted message at LevelInfo.
+func (l *Logger) Infof(format string, args ...any) {
+	l.writeRecord(LevelInfo, fmt.Sprintf(format, args...), nil)
+}
+
+// Warn logs a message at LevelWarn.
+func (l *Logger) Warn(msg string) {
+	l.writeRecord(LevelWarn, msg, nil)
+}
+
+// Warnf logs a formatted message at LevelWarn.
+func (l *Logger) Warnf(format string, args ...any) {
+	l.writeRecord(LevelWarn, fmt.Sprintf(format, args...), nil)
+}
+
+// Error logs a message at LevelError.
+func (l *Logger) Error(msg string) {
+	l.writeRecord(LevelError, msg, nil)
+}
+
+// Errorf logs a formatted message at LevelError.
+func (l *Logger) Errorf(format string, args ...any) {
+	l.writeRecord(LevelError, fmt.Sprintf(format, args...), nil)
+}
+
+// Package-level functions delegating to defaultLogger:
+
+// SetFormat configures the default logger's format ("text" or "json").
+func SetFormat(format string) {
+	defaultLogger.SetFormat(format)
+}
+
+// GetFormat returns the default logger's format.
+func GetFormat() string {
+	return defaultLogger.GetFormat()
+}
+
+// SetOutput sets the default logger's output writer.
+func SetOutput(w io.Writer) {
+	defaultLogger.SetOutput(w)
+}
+
+// Info logs a message at LevelInfo using the default logger.
+func Info(msg string) {
+	defaultLogger.Info(msg)
+}
+
+// Infof logs a formatted message at LevelInfo using the default logger.
+func Infof(format string, args ...any) {
+	defaultLogger.Infof(format, args...)
+}
+
+// Warn logs a message at LevelWarn using the default logger.
+func Warn(msg string) {
+	defaultLogger.Warn(msg)
+}
+
+// Warnf logs a formatted message at LevelWarn using the default logger.
+func Warnf(format string, args ...any) {
+	defaultLogger.Warnf(format, args...)
+}
+
+// Error logs a message at LevelError using the default logger.
+func Error(msg string) {
+	defaultLogger.Error(msg)
+}
+
+// Errorf logs a formatted message at LevelError using the default logger.
+func Errorf(format string, args ...any) {
+	defaultLogger.Errorf(format, args...)
+}
+
+// Debug logs a message at LevelDebug using the default logger.
+func Debug(msg string) {
+	defaultLogger.Debug(msg)
+}
+
+// Debugf logs a formatted message at LevelDebug using the default logger.
+func Debugf(format string, args ...any) {
+	defaultLogger.Debugf(format, args...)
+}
+
+// Log writes a message with a custom level and optional fields using the default logger.
+func Log(level Level, msg string, fields map[string]any) {
+	defaultLogger.Log(level, msg, fields)
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,255 @@
+package logger_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/seanpham99/dbtools/internal/logger"
+)
+
+func TestTextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(&buf)
+	l.SetFormat("text")
+
+	if got := l.GetFormat(); got != logger.FormatText {
+		t.Fatalf("expected format %q, got %q", logger.FormatText, got)
+	}
+
+	l.Info("info message")
+	l.Infof("info formatted %d", 42)
+	l.Warn("warn message")
+	l.Warnf("warn formatted %s", "foo")
+	l.Error("error message")
+	l.Errorf("error formatted %s", "bar")
+	l.Debug("debug message")
+	l.Debugf("debug formatted %s", "baz")
+	l.Log(logger.LevelInfo, "custom level message", map[string]any{"key": "value"})
+
+	expected := "info message\n" +
+		"info formatted 42\n" +
+		"warn message\n" +
+		"warn formatted foo\n" +
+		"error message\n" +
+		"error formatted bar\n" +
+		"debug message\n" +
+		"debug formatted baz\n" +
+		"custom level message\n"
+
+	if buf.String() != expected {
+		t.Errorf("unexpected output:\ngot:\n%s\nwant:\n%s", buf.String(), expected)
+	}
+}
+
+func TestJSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(&buf)
+	l.SetFormat("json")
+
+	if got := l.GetFormat(); got != logger.FormatJSON {
+		t.Fatalf("expected format %q, got %q", logger.FormatJSON, got)
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+
+	l.Info("starting process")
+	l.Infof("item count: %d", 10)
+	l.Warn("resource warning")
+	l.Warnf("threshold reached: %v", true)
+	l.Error("operation failed")
+	l.Errorf("code: %d", 500)
+	l.Debug("verbose details")
+	l.Debugf("step: %s", "init")
+	l.Log(logger.LevelWarn, "with fields", map[string]any{
+		"target":  "postgres",
+		"version": 16,
+	})
+
+	after := time.Now().UTC().Add(time.Second)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 9 {
+		t.Fatalf("expected 9 lines, got %d:\n%s", len(lines), buf.String())
+	}
+
+	expectedLevels := []string{
+		"INFO", "INFO", "WARN", "WARN", "ERROR", "ERROR", "DEBUG", "DEBUG", "WARN",
+	}
+	expectedMessages := []string{
+		"starting process",
+		"item count: 10",
+		"resource warning",
+		"threshold reached: true",
+		"operation failed",
+		"code: 500",
+		"verbose details",
+		"step: init",
+		"with fields",
+	}
+
+	for i, line := range lines {
+		var rec logger.LogRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v (raw: %s)", i, err, line)
+		}
+
+		if rec.Level != expectedLevels[i] {
+			t.Errorf("line %d: expected level %s, got %s", i, expectedLevels[i], rec.Level)
+		}
+		if rec.Message != expectedMessages[i] {
+			t.Errorf("line %d: expected message %q, got %q", i, expectedMessages[i], rec.Message)
+		}
+
+		ts, err := time.Parse(time.RFC3339, rec.Timestamp)
+		if err != nil {
+			t.Errorf("line %d: invalid RFC3339 timestamp %q: %v", i, rec.Timestamp, err)
+		}
+		if ts.Before(before) || ts.After(after) {
+			t.Errorf("line %d: timestamp %v out of range [%v, %v]", i, ts, before, after)
+		}
+
+		if i == 8 {
+			if rec.Fields == nil {
+				t.Fatalf("line 8: expected fields, got nil")
+			}
+			if rec.Fields["target"] != "postgres" {
+				t.Errorf("line 8: expected target=postgres, got %v", rec.Fields["target"])
+			}
+			if rec.Fields["version"] != float64(16) { // json unmarshals numbers to float64
+				t.Errorf("line 8: expected version=16, got %v", rec.Fields["version"])
+			}
+		} else {
+			if len(rec.Fields) != 0 {
+				t.Errorf("line %d: expected empty fields, got %v", i, rec.Fields)
+			}
+		}
+	}
+}
+
+func TestSetFormatValidationFallback(t *testing.T) {
+	l := logger.New(nil)
+
+	invalidFormats := []string{"", "xml", "yaml", "JSON_PRETTY", "123"}
+	for _, fmtStr := range invalidFormats {
+		l.SetFormat(fmtStr)
+		if got := l.GetFormat(); got != logger.FormatText {
+			t.Errorf("SetFormat(%q): expected fallback to %q, got %q", fmtStr, logger.FormatText, got)
+		}
+	}
+
+	validJSONFormats := []string{"json", "JSON", " Json ", "  json  "}
+	for _, fmtStr := range validJSONFormats {
+		l.SetFormat(fmtStr)
+		if got := l.GetFormat(); got != logger.FormatJSON {
+			t.Errorf("SetFormat(%q): expected %q, got %q", fmtStr, logger.FormatJSON, got)
+		}
+	}
+}
+
+func TestPackageLevelDelegation(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.SetFormat("text")
+	defer func() {
+		logger.SetOutput(nil)
+		logger.SetFormat("text")
+	}()
+
+	logger.Info("pkg info")
+	logger.Infof("pkg infof %d", 1)
+	logger.Warn("pkg warn")
+	logger.Warnf("pkg warnf %d", 2)
+	logger.Error("pkg error")
+	logger.Errorf("pkg errorf %d", 3)
+	logger.Debug("pkg debug")
+	logger.Debugf("pkg debugf %d", 4)
+	logger.Log(logger.LevelInfo, "pkg log", map[string]any{"k": "v"})
+
+	expected := "pkg info\n" +
+		"pkg infof 1\n" +
+		"pkg warn\n" +
+		"pkg warnf 2\n" +
+		"pkg error\n" +
+		"pkg errorf 3\n" +
+		"pkg debug\n" +
+		"pkg debugf 4\n" +
+		"pkg log\n"
+
+	if buf.String() != expected {
+		t.Errorf("unexpected output from package-level functions:\ngot:\n%s\nwant:\n%s", buf.String(), expected)
+	}
+
+	buf.Reset()
+	logger.SetFormat("json")
+	if got := logger.GetFormat(); got != logger.FormatJSON {
+		t.Fatalf("expected format %q, got %q", logger.FormatJSON, got)
+	}
+
+	logger.Info("pkg json info")
+	var rec logger.LogRecord
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("failed to parse json log: %v", err)
+	}
+	if rec.Level != "INFO" || rec.Message != "pkg json info" {
+		t.Errorf("unexpected record: %+v", rec)
+	}
+}
+
+func TestConcurrentLogging(t *testing.T) {
+	var buf bytes.Buffer
+	l := logger.New(&buf)
+	l.SetFormat("json")
+
+	const goroutines = 20
+	const messagesPerGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				l.Log(logger.LevelInfo, fmt.Sprintf("worker-%d message-%d", id, j), map[string]any{
+					"worker": id,
+					"iter":   j,
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	expectedCount := goroutines * messagesPerGoroutine
+	if len(lines) != expectedCount {
+		t.Fatalf("expected %d log lines, got %d", expectedCount, len(lines))
+	}
+
+	for i, line := range lines {
+		var rec logger.LogRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("line %d invalid JSON under concurrency: %v\nline: %s", i, err, line)
+		}
+	}
+}
+
+func TestLevelString(t *testing.T) {
+	if logger.LevelDebug.String() != "DEBUG" {
+		t.Errorf("expected DEBUG, got %s", logger.LevelDebug.String())
+	}
+	if logger.LevelInfo.String() != "INFO" {
+		t.Errorf("expected INFO, got %s", logger.LevelInfo.String())
+	}
+	if logger.LevelWarn.String() != "WARN" {
+		t.Errorf("expected WARN, got %s", logger.LevelWarn.String())
+	}
+	if logger.LevelError.String() != "ERROR" {
+		t.Errorf("expected ERROR, got %s", logger.LevelError.String())
+	}
+}

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/lib/pq"
+	"github.com/seanpham99/dbtools/internal/logger"
 )
 
 // openPostgresResetDriver builds the postgres driver for rawURL and wraps
@@ -30,7 +31,7 @@ func openPostgresResetDriver(rawURL string) (database.Driver, error) {
 		return nil, fmt.Errorf("creating postgres connector: %w", err)
 	}
 	nhConnector := pq.ConnectorWithNoticeHandler(connector, func(n *pq.Error) {
-		fmt.Printf("postgres: %s: %s\n", n.Severity, n.Message)
+		logger.Infof("postgres: %s: %s", n.Severity, n.Message)
 	})
 	db := sql.OpenDB(nhConnector)
 	inner, err := postgres.WithInstance(db, &postgres.Config{})


### PR DESCRIPTION
## Summary
Closes part of #60 (sub-project 3 of 4: `--log-format=json`).

- Added `internal/logger` package with zero external dependencies supporting text and structured JSON logging.
- Added persistent flag `--log-format=text|json` on `rootCmd` and `DBTOOLS_LOG_FORMAT` env var support.
- Routed PostgreSQL server notices and progress output in mutating commands (`up`, `push`, `down`, `reset`, `repair`, `rollback`) through the structured logger.
- When `--json` is active, human logs route cleanly to `os.Stderr` preserving `os.Stdout` for result payloads.

## Test plan
- [x] Unit tests in `internal/logger/logger_test.go`
- [x] CLI flag and env var tests in `cmd/log_format_test.go`
- [x] CLI execution tests in `cmd/log_format_integration_test.go`
- [x] `scripts/dev-local.sh all` clean pass
- [ ] Verify GitHub Actions CI checks