### PR TITLE
docs: document private-network container jobs and retry semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **Rollback & Down Migrations**: `dbtools down` applies `.down.sql` files in reverse; `dbtools rollback` is a ledger-only soft-revert — the safe prod verb. Destructive ops on protected targets require `--preview --yes`.
 - **Agent-First Ergonomics**: Terraform-style exit-code contract (`0` clean / `1` error / `2` pending changes or drift), `--dry-run` previews, universal `--json`, and `DBTOOLS_NO_PROMPT=1` fail-closed mode for CI and AI agents. See [docs/exit-codes.md](docs/exit-codes.md).
 - **Environment & Target Protection**: Targets are defined in `dbtools.toml` by environment variable names (`url_env`), ensuring secrets never leak into version control. Protected targets reject destructive operations (`up`, `reset`, and `down` without `--preview --yes`).
+- **Private-Network Job Execution & Structured Logging**: `--log-format=json` (or `DBTOOLS_LOG_FORMAT=json`), PostgreSQL server `NOTICE` forwarding, character-offset error position translation with carets, and `SQLSTATE 42501` permission self-diagnostics for headless jobs. See [skills/using-dbtools/private-network-jobs.md](skills/using-dbtools/private-network-jobs.md).
 - **Python & TypeScript Type Generation**: `dbtools generate` introspects live database schemas and emits clean, versioned `pydantic.BaseModel` classes or Supabase-style TypeScript interfaces (+ optional zod schemas) for services, ETL jobs, and data pipelines.
 - **Interactive TUI Dashboard**: Built-in terminal dashboard powered by Bubble Tea for real-time migration observability.
 
@@ -44,7 +45,9 @@ docker run --rm -v "$(pwd)":/workspace ghcr.io/seanpham99/dbtools:0.4.0 status
 
 `linux/amd64`/`linux/arm64`, ships on `gcr.io/distroless/static` (CA
 certs included). See [skills/using-dbtools/docker-image.md](skills/using-dbtools/docker-image.md)
-for the build-`FROM` pattern used by private-network job runners.
+for the build-`FROM` pattern used by private-network job runners, and
+[skills/using-dbtools/private-network-jobs.md](skills/using-dbtools/private-network-jobs.md)
+for running in container jobs.
 
 ### Via Go Install
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -63,6 +63,21 @@ else
 fi
 ```
 
+## Container Jobs & Retry Semantics
+
+When running `dbtools` in headless container job orchestrators (Azure Container Apps Jobs, AWS ECS RunTask, Kubernetes Jobs, GCP Cloud Run):
+
+1. **Job Completion Assessment**:
+   - Exit `0`: Platform considers job completed successfully.
+   - Exit `1`: Platform marks job execution failed.
+   - Exit `2`: Inspection detected pending migrations or schema drift (used by audit/gate jobs).
+
+2. **Platform Retry Hazard vs. Dirty Cursor Refusal**:
+   - Cloud platforms often allow automatic task retries (e.g. Azure `replica_retry_limit > 0`, Kubernetes `backoffLimit > 0`).
+   - If a migration fails midway through execution, `dbtools` flags the migration cursor `dirty=true` in the ledger.
+   - On subsequent automatic container retries, `dbtools` inspects the ledger before running any SQL, detects the dirty cursor, and **fails closed immediately with exit code 1**.
+   - This ensures retries will not execute out-of-order DDL or replay partial migrations until an operator explicitly repairs the ledger (`dbtools repair <target> <version>:<status> --yes`).
+
 ---
 
 ## Non-Interactive Mode

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -22,6 +22,7 @@ nuance than a table row can hold, read the matching file before using them:
 | MySQL `url_env` connection-string format and gotchas | `mysql.md` |
 | Container lifecycle project scoping, ports, volume persistence | `container.md` |
 | Docker image — base, tags, mount vs. build-`FROM` consumption patterns | `docker-image.md` |
+| Private-network job execution — read-only observation, container retry policies, structured logging, diagnostics | `private-network-jobs.md` |
 
 ## Terminology & Key Concepts
 

--- a/skills/using-dbtools/private-network-jobs.md
+++ b/skills/using-dbtools/private-network-jobs.md
@@ -1,0 +1,127 @@
+# Private-Network Job Execution & Observability Reference
+
+When databases reside in private subnets with no public ingress or direct developer access, database migrations and schema inspections run as container jobs inside the private network (e.g., Azure Container Apps Jobs, AWS ECS RunTask, Kubernetes Jobs, GCP Cloud Run Jobs).
+
+`dbtools` is designed for headless, automated execution in these environments.
+
+---
+
+## 1. The Read-Only Observation Pattern (Low-Risk On-Ramp)
+
+Before authorizing mutating migration jobs in production, run read-only observation jobs to inspect database state, preview pending migrations, or audit schema health without risking schema mutations or locks:
+
+```bash
+# Check applied and pending migration status across targets
+dbtools status prod --json
+
+# Preview pending migrations and drift without executing SQL
+dbtools plan --target prod --json
+
+# Run comprehensive health and integrity checks (connectivity, hash integrity, dirty state)
+dbtools doctor prod --json
+```
+
+### Safety Guarantee
+Read-only commands (`status`, `plan`, `doctor`, `verify`) never acquire DDL locks, never mutate ledger history, and never require `--yes`. They are safe to run periodically as scheduled audit jobs or pre-deployment inspection steps.
+
+---
+
+## 2. Mutating Migration Execution
+
+To apply pending migrations inside a private network job:
+
+```bash
+# Push pending migrations to a named protected target
+dbtools push prod --yes
+
+# Or apply pending migrations in single-target container environments
+dbtools up --yes
+```
+
+### Protection Gates
+- Protected targets require `--yes` (or `DBTOOLS_NO_PROMPT=1` / `CI=1` alongside `--yes`).
+- If `--yes` is omitted in automated/non-interactive jobs, `dbtools` fails closed immediately with exit code `1` rather than hanging on standard input.
+
+---
+
+## 3. Exit Codes & Container Retry Semantics
+
+`dbtools` adheres strictly to Terraform-style exit codes:
+
+| Exit Code | Meaning | Container Platform Action |
+|:---:|---|---|
+| `0` | **Success / Clean** | Job succeeded; no pending changes or drift. |
+| `1` | **Fatal Error** | Job failed (network failure, syntax error, missing `--yes`, migration error). |
+| `2` | **Pending Changes / Drift** | Inspection found unapplied migrations, schema drift, or dirty ledger. |
+
+### Dirty Ledger Cursor Safety Under Orchestrator Retries
+
+Container orchestrators often configure retry policies:
+- **Azure Container Apps Jobs**: `replica_retry_limit > 0`
+- **Kubernetes Jobs**: `backoffLimit > 0`
+- **AWS ECS / Step Functions**: Retry on task failure
+
+When a migration script fails partway through execution:
+1. `dbtools` records `dirty = true` at the failed migration version in the database ledger (`dbtools_migration_history`).
+2. The container exits with code `1`.
+3. If the orchestrator automatically restarts or spawns a retry replica, `dbtools` inspects the ledger on startup, detects `dirty = true`, and **fails closed immediately** with exit code `1`.
+
+This prevents catastrophic partial-state replay or double-execution of non-idempotent DDL statements. The cursor remains locked until an operator inspects the failure and runs `dbtools repair <target> <version>:<status> --yes` or `dbtools force <version> --yes`.
+
+---
+
+## 4. Structured Logging & Log Scraping
+
+For ingestion into centralized log analytics (Azure Log Analytics / Container Insights, AWS CloudWatch, Datadog, Grafana Loki):
+
+```bash
+# Enable JSON structured logging via flag
+dbtools push prod --yes --log-format=json
+
+# Or enable JSON structured logging via environment variable
+export DBTOOLS_LOG_FORMAT=json
+dbtools push prod --yes
+```
+
+### Standard Output vs. Standard Error Separation
+When combining `--json` (machine output) and `--log-format=json` (structured logs):
+- **`stdout`**: Contains exclusively the machine-readable command result payload (JSON object).
+- **`stderr`**: Contains structured operational logs, timestamped progress messages, and server notices.
+
+This allows CI/CD orchestrators to parse `$STDOUT` with `jq` while log scrapers ingest `$STDERR` into log analytics.
+
+---
+
+## 5. PostgreSQL Diagnostics in Detached Jobs
+
+Debugging migration failures in headless container jobs requires detailed diagnostic context without interactive database access. `dbtools` includes built-in diagnostics for PostgreSQL:
+
+### Server `NOTICE` Forwarding
+PostgreSQL server notices (`RAISE NOTICE`, informational messages during `CREATE INDEX CONCURRENTLY`, table existence warnings) are forwarded in real time to stderr/logs instead of being silently swallowed by the driver.
+
+### Character-Offset Error Translation
+When a PostgreSQL migration fails with a syntax or semantic error, PostgreSQL returns a raw 1-based character position. `dbtools` automatically translates this character offset into:
+- 1-based line and column coordinates
+- The source line of SQL from the migration file
+- A visual caret pointer (`^`) pinpointing the exact offending token
+
+```
+migration error at line 4, column 15:
+  4 | CREATE TABEL invalid_syntax (id int);
+    |               ^
+pq: syntax error at or near "TABEL" (SQLSTATE 42601)
+```
+
+### Automated Permission Diagnostics (`SQLSTATE 42501`)
+If a migration fails with `SQLSTATE 42501` (`insufficient_privilege`), `dbtools` queries database metadata to diagnose permission mismatches and emits an actionable diagnostic report:
+
+```
+[permission diagnostic (SQLSTATE 42501)]
+  current_user: app_migrator
+  session_user: app_migrator
+  database: my_production_db
+  schema: public (owner: postgres)
+  schema privileges: USAGE=true, CREATE=false
+  azure_pg_admin member: false
+  remediation: User "app_migrator" lacks CREATE/USAGE privilege on schema "public". Run: GRANT USAGE, CREATE ON SCHEMA "public" TO "app_migrator";
+```


### PR DESCRIPTION
## Summary
Closes #60 (sub-project 4 of 4: Documentation).

- Added `skills/using-dbtools/private-network-jobs.md` documenting headless container job execution (Azure Container Apps, AWS ECS, K8s, Cloud Run).
- Documented the Read-Only Observation pattern (`status`, `plan`, `doctor --json`) as a low-risk on-ramp for private network DBs.
- Detailed orchestrator retry policies (`replica_retry_limit`, `backoffLimit`) and `dbtools` dirty-cursor refusal protection in `docs/exit-codes.md`.
- Documented `--log-format=json`, output separation, and PostgreSQL error diagnostics.
- Linked new guide in `skills/using-dbtools/SKILL.md` and `README.md`.

## Test plan
- [x] Links and markdown format verified
- [x] `scripts/dev-local.sh all` clean pass
- [ ] Verify GitHub Actions CI checks