### PR TITLE
fix: address issue #60 code-review findings

### DIFF
--- a/cmd/jobsummary.go
+++ b/cmd/jobsummary.go
@@ -17,9 +17,19 @@ import (
 // Call as `defer emitJobSummary(&err)` from a function with a named
 // `err error` return value, so it fires on every return path: success,
 // a documented non-zero exit (ExitCodeError), or a genuine runtime
-// error alike. Only a hard crash (panic that unwinds past the deferred
-// call, or a killed process) skips it — which is the point.
+// error alike. A killed process skips it entirely, which is the point —
+// but a Go panic does not immediately kill the process, it unwinds
+// through deferred calls first, and `err` is still its nil zero value
+// mid-unwind. Without the recover() below, a panic would print a false
+// "ok":true record moments before the process actually crashes — exactly
+// the signal this function exists to prevent. recover()ing here, then
+// re-panicking, lets the crash still propagate to the caller (so exit
+// status and any top-level panic log are unaffected) while suppressing
+// the misleading summary line.
 func emitJobSummary(err *error) {
+	if r := recover(); r != nil {
+		panic(r)
+	}
 	if !jsonOutput {
 		return
 	}

--- a/cmd/jobsummary.go
+++ b/cmd/jobsummary.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// emitJobSummary prints one final JSON-lines record to stdout when --json
+// is set, marking that this process reached the end of its own control
+// flow and is now exiting deliberately — as opposed to being killed or
+// crashing mid-write, which never reaches this line at all. Job
+// platforms scraping container logs (Azure Container Apps, ECS,
+// Kubernetes Jobs) use this to distinguish "the job finished and
+// reported" from "the job died mid-write" — see
+// skills/using-dbtools/private-network-jobs.md.
+//
+// Call as `defer emitJobSummary(&err)` from a function with a named
+// `err error` return value, so it fires on every return path: success,
+// a documented non-zero exit (ExitCodeError), or a genuine runtime
+// error alike. Only a hard crash (panic that unwinds past the deferred
+// call, or a killed process) skips it — which is the point.
+func emitJobSummary(err *error) {
+	if !jsonOutput {
+		return
+	}
+	summary := struct {
+		Event string `json:"event"`
+		OK    bool   `json:"ok"`
+		Error string `json:"error,omitempty"`
+	}{Event: "job_complete", OK: *err == nil}
+	if *err != nil {
+		summary.Error = (*err).Error()
+	}
+	b, marshalErr := json.Marshal(summary)
+	if marshalErr != nil {
+		return
+	}
+	fmt.Println(string(b))
+}

--- a/cmd/jobsummary_test.go
+++ b/cmd/jobsummary_test.go
@@ -99,3 +99,33 @@ func TestUpCommand_EmitsJobSummaryOnRefusal(t *testing.T) {
 		t.Fatalf("up --target prod --json output = %q, want ok:false since up refuses non-local targets", out)
 	}
 }
+
+// TestEmitJobSummary_PanicSkipsSummaryAndRepropagates guards against a
+// panic mid-RunE printing a false "ok":true record right before the
+// process actually crashes — err is still nil during panic unwinding,
+// which would otherwise look identical to a real success.
+func TestEmitJobSummary_PanicSkipsSummaryAndRepropagates(t *testing.T) {
+	origJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	var out string
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		out = captureStdout(t, func() {
+			runWithSummary := func() (err error) {
+				defer emitJobSummary(&err)
+				panic("simulated crash mid-write")
+			}
+			_ = runWithSummary()
+		})
+	}()
+
+	if recovered != "simulated crash mid-write" {
+		t.Fatalf("panic was not repropagated, recovered = %v", recovered)
+	}
+	if strings.Contains(out, "job_complete") {
+		t.Fatalf("emitJobSummary printed a summary during a panic: %q, want nothing", out)
+	}
+}

--- a/cmd/jobsummary_test.go
+++ b/cmd/jobsummary_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() returned error: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer returned error: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading pipe returned error: %v", err)
+	}
+	return string(out)
+}
+
+func TestEmitJobSummary_NoOpWithoutJSON(t *testing.T) {
+	origJSON := jsonOutput
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	var err error
+	out := captureStdout(t, func() { emitJobSummary(&err) })
+	if out != "" {
+		t.Fatalf("emitJobSummary() without --json printed %q, want nothing", out)
+	}
+}
+
+func TestEmitJobSummary_SuccessRecordWithJSON(t *testing.T) {
+	origJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	var err error
+	out := captureStdout(t, func() { emitJobSummary(&err) })
+	if !strings.Contains(out, `"event":"job_complete"`) {
+		t.Fatalf("emitJobSummary() output = %q, want it to contain the job_complete event", out)
+	}
+	if !strings.Contains(out, `"ok":true`) {
+		t.Fatalf("emitJobSummary() output = %q, want ok:true for a nil error", out)
+	}
+	if strings.Contains(out, `"error"`) {
+		t.Fatalf("emitJobSummary() output = %q, want no error field for a nil error", out)
+	}
+}
+
+func TestEmitJobSummary_ErrorRecordWithJSON(t *testing.T) {
+	origJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	err := errors.New("connection refused")
+	out := captureStdout(t, func() { emitJobSummary(&err) })
+	if !strings.Contains(out, `"ok":false`) {
+		t.Fatalf("emitJobSummary() output = %q, want ok:false for a non-nil error", out)
+	}
+	if !strings.Contains(out, `"error":"connection refused"`) {
+		t.Fatalf("emitJobSummary() output = %q, want the error message included", out)
+	}
+}
+
+// TestUpCommand_EmitsJobSummaryOnRefusal proves the defer fires even on
+// an early-return error path (not just the success path) — up refuses a
+// non-local target before doing anything else.
+func TestUpCommand_EmitsJobSummaryOnRefusal(t *testing.T) {
+	origTarget := upTarget
+	origJSON := jsonOutput
+	t.Cleanup(func() {
+		upTarget = origTarget
+		jsonOutput = origJSON
+	})
+
+	rootCmd.SetArgs([]string{"up", "--target", "prod", "--json"})
+	out := captureStdout(t, func() {
+		_ = rootCmd.Execute()
+	})
+	if !strings.Contains(out, `"event":"job_complete"`) {
+		t.Fatalf("up --target prod --json output = %q, want a job_complete summary even on refusal", out)
+	}
+	if !strings.Contains(out, `"ok":false`) {
+		t.Fatalf("up --target prod --json output = %q, want ok:false since up refuses non-local targets", out)
+	}
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -26,7 +26,8 @@ var pushCmd = &cobra.Command{
 	},
 }
 
-func runPush(targetName string) error {
+func runPush(targetName string) (err error) {
+	defer emitJobSummary(&err)
 	cfg, err := loadConfig("dbtools.toml")
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,16 @@ var rootCmd = &cobra.Command{
 	Short: "dbtools manages MSSQL/Postgres schema migrations and local dev databases",
 }
 
+// jsonOutput and logFormat are intentionally separate, orthogonal flags
+// governing two different streams, not one output-mode concept split in
+// two: jsonOutput controls the shape of a command's data RESULT (the
+// payload written to stdout — a status/plan object, a generated model,
+// etc.), while logFormat controls the shape of the human-readable
+// progress/diagnostic LOG stream (written to stderr via the logger
+// package — see docs/using-dbtools/private-network-jobs.md's log-scraping
+// section). A job can run `--log-format=json` alone to get structured
+// logs without changing what a command's own result payload looks like,
+// or `--json` alone to get a structured result with plain-text logs.
 var (
 	jsonOutput bool
 	logFormat  string
@@ -55,6 +65,11 @@ func init() {
 		}
 		logger.SetFormat(fmtVal)
 		if jsonOutput {
+			// Force logs to stderr regardless of any prior redirection —
+			// --json's contract is that stdout carries only the data
+			// payload; this guarantees that even if something upstream
+			// redirected the logger elsewhere, --json still separates the
+			// two streams (see TestLogFormat_JSONOutputStderr).
 			logger.SetOutput(os.Stderr)
 		}
 		return loadLocalEnv()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -17,7 +17,8 @@ var (
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Apply pending migrations to the local target",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		defer emitJobSummary(&err)
 		// up is the fast local dev loop. It deliberately refuses any
 		// non-local target: reaching a remote database requires the
 		// explicit `push <target> --yes` path with its preview + guard.

--- a/internal/migrator/pgdiagnostic.go
+++ b/internal/migrator/pgdiagnostic.go
@@ -40,6 +40,27 @@ func FormatPermissionReport(report PermissionReport) string {
 	return b.String()
 }
 
+// queryOptionalString runs a single-column query and returns its value,
+// or fallback if the query fails or returns NULL/empty. Diagnostic
+// queries must never let a failure here mask the original migration
+// error, so errors are swallowed rather than propagated.
+func queryOptionalString(ctx context.Context, db *sql.DB, fallback, query string, args ...any) string {
+	var s sql.NullString
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&s); err != nil || !s.Valid || s.String == "" {
+		return fallback
+	}
+	return s.String
+}
+
+// queryOptionalBool runs a single-column boolean query and returns its
+// value, or false if the query fails. Same swallow-errors rationale as
+// queryOptionalString.
+func queryOptionalBool(ctx context.Context, db *sql.DB, query string, args ...any) bool {
+	var b sql.NullBool
+	_ = db.QueryRowContext(ctx, query, args...).Scan(&b)
+	return b.Bool
+}
+
 // RunPermissionDiagnostic inspects the database connection and queries permission
 // metadata if the given error is a PostgreSQL SQLSTATE 42501 error.
 // It safely recovers from any query failures so diagnostic collection never panics or masks the original failure.
@@ -76,25 +97,22 @@ func RunPermissionDiagnostic(ctx context.Context, db *sql.DB, pqErr *pq.Error) s
 	}
 
 	// 2. Query schema owner
-	var schemaOwner sql.NullString
-	_ = db.QueryRowContext(ctx, "SELECT coalesce(pg_get_userbyid(nspowner), 'unknown') FROM pg_namespace WHERE nspname = $1", report.Schema).Scan(&schemaOwner)
-	if schemaOwner.Valid && schemaOwner.String != "" {
-		report.SchemaOwner = schemaOwner.String
-	} else {
-		report.SchemaOwner = "unknown"
-	}
+	report.SchemaOwner = queryOptionalString(ctx, db, "unknown",
+		"SELECT coalesce(pg_get_userbyid(nspowner), 'unknown') FROM pg_namespace WHERE nspname = $1", report.Schema)
 
-	// 3. Query schema privileges
+	// 3. Query schema privileges (one row, two columns — not the same
+	// single-value shape as 2 and 4, so it stays a direct query rather
+	// than going through queryOptionalBool).
 	var hasUsage, hasCreate sql.NullBool
 	_ = db.QueryRowContext(ctx, "SELECT has_schema_privilege(current_user, $1, 'USAGE'), has_schema_privilege(current_user, $1, 'CREATE')", report.Schema).Scan(&hasUsage, &hasCreate)
 	report.HasUsage = hasUsage.Bool
 	report.HasCreate = hasCreate.Bool
 
 	// 4. Query azure_pg_admin role membership
-	var isAzureAdmin sql.NullBool
-	_ = db.QueryRowContext(ctx, "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'azure_pg_admin' AND pg_has_role(current_user, 'azure_pg_admin', 'MEMBER'))").Scan(&isAzureAdmin)
-	report.IsAzureAdmin = isAzureAdmin.Bool
-	report.HasAzureAdminRole = isAzureAdmin.Bool
+	isAzureAdmin := queryOptionalBool(ctx, db,
+		"SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'azure_pg_admin' AND pg_has_role(current_user, 'azure_pg_admin', 'MEMBER'))")
+	report.IsAzureAdmin = isAzureAdmin
+	report.HasAzureAdminRole = isAzureAdmin
 
 	// 5. Build remediation advice
 	if !report.HasUsage || !report.HasCreate {

--- a/internal/migrator/pgerror.go
+++ b/internal/migrator/pgerror.go
@@ -1,6 +1,8 @@
 package migrator
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strconv"
@@ -98,4 +100,28 @@ func FormatPostgresError(err error, sqlText string, prefixLen int) error {
 	}
 
 	return errors.New(b.String())
+}
+
+// DiagnosePostgresError is the single entry point callers use to turn a
+// raw Postgres error into the fullest diagnostic available: line/column
+// context via FormatPostgresError always, plus — for SQLSTATE 42501
+// (insufficient_privilege), the one error class where a live connection
+// can add actionable context — a permission report from
+// RunPermissionDiagnostic. Callers that just need line/column formatting
+// with no live connection to probe further should call
+// FormatPostgresError directly instead; this exists so a caller like
+// pgResetDriver.Run doesn't need to know pq.Error internals or SQLSTATE
+// codes itself, only that a migration failed.
+func DiagnosePostgresError(ctx context.Context, db *sql.DB, err error, sqlText string, prefixLen int) error {
+	formatted := FormatPostgresError(err, sqlText, prefixLen)
+
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) || pqErr == nil || pqErr.Code != "42501" {
+		return formatted
+	}
+	diag := RunPermissionDiagnostic(ctx, db, pqErr)
+	if diag == "" {
+		return formatted
+	}
+	return fmt.Errorf("%w\n\n%s", formatted, diag)
 }

--- a/internal/migrator/pgerror_test.go
+++ b/internal/migrator/pgerror_test.go
@@ -1,6 +1,8 @@
 package migrator
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"strings"
 	"testing"
@@ -281,6 +283,69 @@ func TestFormatPostgresError(t *testing.T) {
 		}
 		if !strings.Contains(errMsg, `Where: PL/pgSQL function update_bar() line 4 at SQL statement`) {
 			t.Errorf("missing Where in: %s", errMsg)
+		}
+	})
+}
+
+func TestDiagnosePostgresError(t *testing.T) {
+	t.Run("non-42501 error: no diagnostic appended", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "42P01", Message: `relation "x" does not exist`}
+		got := DiagnosePostgresError(context.Background(), nil, pqErr, "SELECT * FROM x;", 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if strings.Contains(got.Error(), "permission diagnostic") {
+			t.Errorf("expected no permission diagnostic for a non-42501 error, got: %s", got.Error())
+		}
+	})
+
+	t.Run("42501 error with nil db: formats without a diagnostic instead of panicking", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "42501", Message: "permission denied for schema x"}
+		got := DiagnosePostgresError(context.Background(), nil, pqErr, "CREATE TABLE x (id INT);", 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(got.Error(), "permission denied for schema x") {
+			t.Errorf("expected the original message preserved, got: %s", got.Error())
+		}
+		if strings.Contains(got.Error(), "permission diagnostic") {
+			t.Errorf("expected no permission diagnostic with a nil db, got: %s", got.Error())
+		}
+	})
+
+	t.Run("42501 error with a live db: diagnostic appended after the formatted error", func(t *testing.T) {
+		db := getMockDB(t)
+		mockDriverInstance.mu.Lock()
+		mockDriverInstance.handlers = map[string]func(args []driver.Value) (driver.Rows, error){
+			"SELECT current_user": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{
+					cols:   []string{"current_user", "session_user", "current_database", "current_schema"},
+					values: [][]driver.Value{{"app_user", "app_user", "testdb", "public"}},
+				}, nil
+			},
+			"nspowner": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{cols: []string{"coalesce"}, values: [][]driver.Value{{"postgres"}}}, nil
+			},
+			"has_schema_privilege": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{cols: []string{"has_usage", "has_create"}, values: [][]driver.Value{{false, false}}}, nil
+			},
+			"azure_pg_admin": func(args []driver.Value) (driver.Rows, error) {
+				return &mockRows{cols: []string{"exists"}, values: [][]driver.Value{{false}}}, nil
+			},
+		}
+		mockDriverInstance.mu.Unlock()
+
+		pqErr := &pq.Error{Code: "42501", Message: "permission denied for schema public"}
+		got := DiagnosePostgresError(context.Background(), db, pqErr, "CREATE TABLE x (id INT);", 0)
+		if got == nil {
+			t.Fatal("expected error, got nil")
+		}
+		errMsg := got.Error()
+		if !strings.Contains(errMsg, "permission denied for schema public") {
+			t.Errorf("expected the formatted error first, got: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "[permission diagnostic (SQLSTATE 42501)]") {
+			t.Errorf("expected the permission diagnostic appended, got: %s", errMsg)
 		}
 	})
 }

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -93,15 +92,8 @@ func (d *pgResetDriver) Run(migration io.Reader) error {
 		strings.NewReader(prefix),
 		bytes.NewReader(migrationBytes),
 	)); err != nil {
-		formattedErr := FormatPostgresError(err, string(migrationBytes), prefixRunes)
-		var pqErr *pq.Error
-		if errors.As(err, &pqErr) && pqErr != nil && pqErr.Code == "42501" {
-			diag := RunPermissionDiagnostic(context.Background(), d.db, pqErr)
-			if diag != "" {
-				formattedErr = fmt.Errorf("%w\n\n%s", formattedErr, diag)
-			}
-		}
-		return fmt.Errorf("running migration: %w", formattedErr)
+		diagnosed := DiagnosePostgresError(context.Background(), d.db, err, string(migrationBytes), prefixRunes)
+		return fmt.Errorf("running migration: %w", diagnosed)
 	}
 	return nil
 }

--- a/skills/using-dbtools/private-network-jobs.md
+++ b/skills/using-dbtools/private-network-jobs.md
@@ -90,6 +90,26 @@ When combining `--json` (machine output) and `--log-format=json` (structured log
 
 This allows CI/CD orchestrators to parse `$STDOUT` with `jq` while log scrapers ingest `$STDERR` into log analytics.
 
+### Job-Completion Summary Record
+
+`dbtools up` and `dbtools push` (the mutating job commands from section 2)
+also print one final JSON-lines record to **stdout** when `--json` is
+set, after their normal result payload:
+
+```json
+{"event":"job_complete","ok":true}
+{"event":"job_complete","ok":false,"error":"connection refused"}
+```
+
+This is emitted via a `defer`, so it fires on every path the command's
+own logic returns through — success, a refused/invalid target, a real
+migration failure — but **not** on a hard crash (OOM-kill, SIGKILL,
+timeout). A log scraper watching for this line can distinguish "the job
+ran to completion and reported its own outcome" from "the job died
+mid-write and never got to say so" — the two failure modes look
+identical from the exit code alone, since an orchestrator killing the
+container also reports a non-zero exit.
+
 ---
 
 ## 5. PostgreSQL Diagnostics in Detached Jobs


### PR DESCRIPTION
## Summary

Two-axis code review of the 4 PRs closing #60 (1e36e55...8281d4d) found 4 judgement-call standards items and 1 spec gap. All 4 fixed here:

**Standards:**
- Feature Envy: `pgreset.go`'s `Run()` did its own `pq.Error`/SQLSTATE orchestration to glue `FormatPostgresError` + `RunPermissionDiagnostic` together. Added `DiagnosePostgresError` as the single entry point.
- Duplicated Code: extracted `queryOptionalString`/`queryOptionalBool` for the two genuinely-duplicated single-value diagnostic queries in `pgdiagnostic.go` (left the two-column privilege query as-is, since it's a different shape, not part of the actual duplication).
- Primitive Obsession/Data Clump: documented that `--json` and `--log-format` are intentionally orthogonal (data payload vs. log stream), not one concept split in two.
- The review also flagged `cmd/root.go`'s `logger.SetOutput(os.Stderr)` call as redundant dead code — **it isn't**. `TestLogFormat_JSONOutputStderr` locks in that `--json` must force logs back to stderr even after a prior redirection. Removing it broke that test; kept it with a comment explaining why once I checked.

**Spec:**
- Issue #60 item 2 asked for "a terminal summary record so a scraper can tell 'the job finished and reported' from 'the job died mid-write'" — missing from the original implementation. Added `emitJobSummary`, deferred in `up`/`push`'s `RunE` so it fires on every return path (success, refusal, real failure) but never on a hard crash/kill — which is the entire point. Documented in `private-network-jobs.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` clean
- [x] New tests: `TestDiagnosePostgresError` (3 cases), `TestEmitJobSummary_*` (3 cases), `TestUpCommand_EmitsJobSummaryOnRefusal`
- [x] Existing `pgreset_test.go`/`pgdiagnostic_test.go`/`log_format_test.go` all still pass unchanged — the refactors preserve exact prior behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a final `job_complete` JSON record for `dbtools up` and `dbtools push` when JSON output is enabled, reporting success or failure.

* **Bug Fixes**
  * Improved PostgreSQL permission-error messages with additional diagnostic details.
  * Ensured job completion summaries are emitted across normal success and failure paths.

* **Documentation**
  * Documented JSON job-completion records and how they distinguish reported failures from externally terminated jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->