### PR TITLE
feat: implement dbtools adopt command (closes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ dbtools status
 | `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |
 | `rollback` | `dbtools rollback <target> [--yes]` | Ledger-only soft-revert (marks `reverted`, never data-destroying). The safe prod verb. |
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |
+| `adopt` | `dbtools adopt <target> [--yes] [--force]` | Imports existing migration history from another tool (Flyway, Knex, EF, Alembic, golang-migrate). |
 | `force` | `dbtools force <version> [--target <target>] [--yes]` | Sets tracking version cursor and clears dirty state without running migration SQL. |
 | `reset` | `dbtools reset [target] [--yes]` | Unprotected targets: drops database, replays all migrations from zero, and executes `seed.sql`. |
 | `generate` | `dbtools generate [target] [--lang python\|ts] [--zod] [--out file]` | Introspects live schema and renders Pydantic v2 models (`python`, default) or Supabase-style TypeScript interfaces (`ts`; `--zod` adds zod schemas). |

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/seanpham99/dbtools/internal/adopt"
+	"github.com/seanpham99/dbtools/internal/config"
 	"github.com/seanpham99/dbtools/internal/ddlcheck"
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/ledger"
@@ -80,18 +81,7 @@ func runAdopt(targetName string) error {
 	}
 	defer db.Close()
 
-	migrationsDir := cfg.MigrationsDir
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	upSuffix := cfg.Migrations.UpSuffix
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	ledgerTable := cfg.Ledger.Table
-	if ledgerTable == "" {
-		ledgerTable = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
 	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
@@ -149,7 +139,12 @@ func runAdopt(targetName string) error {
 	}
 	defer m.Close()
 
-	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
+	// EnsureSchema only, never Sync: Sync also backfills a row for every
+	// version the golang-migrate cursor already considers applied, tagged
+	// with the normal (non-adopted) hash source — exactly the "hash now,
+	// treat as verified" outcome adopt's hash_source design exists to
+	// avoid. adopt writes only the matched set below, all tagged adopted.
+	if err := eng.Ledger().EnsureSchema(db, ledgerTable); err != nil {
 		return err
 	}
 

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -124,6 +124,20 @@ func runAdopt(targetName string) error {
 		}
 	}
 
+	// A pending version below the highest matched one would become
+	// permanently unreachable: PendingAfter only returns versions above
+	// the stamped cursor, so stamping past it would silently strand that
+	// migration's file forever. Checked before any write, like the
+	// orphan gate above.
+	if len(plan.Matched) > 0 {
+		highest := plan.Matched[len(plan.Matched)-1]
+		for _, p := range plan.Pending {
+			if p <= highest {
+				return fmt.Errorf("adopt found pending version %d below the highest matched version %d — stamping the cursor past it would make it permanently unreachable; apply or remove that migration file first", p, highest)
+			}
+		}
+	}
+
 	if !adoptYes {
 		logger.Infof("dry run — pass --yes to write %d matched version(s) to the ledger", len(plan.Matched))
 		return nil

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/seanpham99/dbtools/internal/adopt"
+	"github.com/seanpham99/dbtools/internal/ddlcheck"
+	"github.com/seanpham99/dbtools/internal/engine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/logger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+	"github.com/spf13/cobra"
+)
+
+var (
+	adoptYes             bool
+	adoptForce           bool
+	adoptFromTable       string
+	adoptVersionColumn   string
+	adoptAppliedAtColumn string
+)
+
+var adoptCmd = &cobra.Command{
+	Use:   "adopt [target]",
+	Short: "Import an existing migration ledger from another tool into dbtools",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if adoptFromTable != "" && adoptVersionColumn == "" {
+			return fmt.Errorf("--from-table requires --version-column")
+		}
+		return runAdopt(args[0])
+	},
+}
+
+func init() {
+	adoptCmd.Flags().BoolVar(&adoptYes, "yes", false, "write the imported rows to the ledger (omit to only print the plan)")
+	adoptCmd.Flags().BoolVar(&adoptForce, "force", false, "proceed even if orphan history rows exist (rows with no matching file)")
+	adoptCmd.Flags().StringVar(&adoptFromTable, "from-table", "", "bespoke source table name (auto-detected from a known list if omitted)")
+	adoptCmd.Flags().StringVar(&adoptVersionColumn, "version-column", "", "column in --from-table holding the migration version")
+	adoptCmd.Flags().StringVar(&adoptAppliedAtColumn, "applied-at-column", "", "optional column in --from-table holding the applied timestamp")
+	rootCmd.AddCommand(adoptCmd)
+}
+
+func tableExists(eng engine.Engine, db *sql.DB, tableName string) (bool, error) {
+	schema := ""
+	switch eng.Name() {
+	case "postgres":
+		schema = "public"
+	case "sqlite":
+		schema = "main"
+	case "mssql":
+		schema = "dbo"
+	case "mysql":
+		schema = ""
+	}
+	return eng.DDL().Exists(db, ddlcheck.ObjectRef{Schema: schema, Name: tableName, Kind: "table"})
+}
+
+func runAdopt(targetName string) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+
+	url, err := cfg.ResolveURLOrFlag(targetName, "")
+	if err != nil {
+		return err
+	}
+
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), url)
+	if err != nil {
+		return err
+	}
+
+	db, err := eng.Open(url)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	migrationsDir := cfg.MigrationsDir
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	upSuffix := cfg.Migrations.UpSuffix
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	ledgerTable := cfg.Ledger.Table
+	if ledgerTable == "" {
+		ledgerTable = "dbtools_migration_history"
+	}
+
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
+	if err != nil {
+		return err
+	}
+
+	table := adoptFromTable
+	versionCol := adoptVersionColumn
+	appliedAtCol := adoptAppliedAtColumn
+
+	if table == "" {
+		existsFunc := func(_ ledger.DBTX, name string) (bool, error) {
+			return tableExists(eng, db, name)
+		}
+		table, err = adopt.DetectSourceTable(db, existsFunc, adopt.KnownTableNames())
+		if err != nil {
+			return err
+		}
+		defVer, defApp := adopt.DefaultColumnsForTable(table)
+		if versionCol == "" {
+			versionCol = defVer
+		}
+		if appliedAtCol == "" {
+			appliedAtCol = defApp
+		}
+	}
+
+	sourceRows, err := adopt.ReadSourceRows(db, table, versionCol, appliedAtCol)
+	if err != nil {
+		return err
+	}
+
+	plan := adopt.BuildPlan(table, sourceRows, dir)
+	printAdoptPlan(plan)
+
+	if len(plan.Orphan) > 0 && !adoptForce {
+		return &ExitCodeError{
+			Code:    1,
+			Message: fmt.Sprintf("adopt found %d orphan history row(s) with no matching migration file — review them, then pass --force to proceed anyway", len(plan.Orphan)),
+		}
+	}
+
+	if !adoptYes {
+		logger.Infof("dry run — pass --yes to write %d matched version(s) to the ledger", len(plan.Matched))
+		return nil
+	}
+
+	if err := requireUnprotected(cfg, targetName); err != nil {
+		return err
+	}
+
+	m, err := migrator.Open(url, migrationsDir)
+	if err != nil {
+		return err
+	}
+	defer m.Close()
+
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
+		return err
+	}
+
+	for _, v := range plan.Matched {
+		hash, _ := dir.ContentHash(v)
+		if err := eng.Ledger().SetStatusAdopted(db, v, "adopted from "+table, hash, ledgerTable); err != nil {
+			return err
+		}
+	}
+
+	if len(plan.Matched) > 0 {
+		highest := plan.Matched[len(plan.Matched)-1]
+		if err := m.Stamp(highest); err != nil {
+			return err
+		}
+	}
+
+	logger.Infof("adopted %d version(s) from %s", len(plan.Matched), table)
+	return nil
+}
+
+func printAdoptPlan(plan adopt.Plan) {
+	if jsonOutput {
+		b, _ := json.Marshal(plan)
+		fmt.Println(string(b))
+		return
+	}
+	logger.Infof("source table: %s", plan.SourceTable)
+	logger.Infof("matched: %v", plan.Matched)
+	logger.Infof("pending (no source row): %v", plan.Pending)
+	logger.Infof("orphan (no file): %v", plan.Orphan)
+}

--- a/cmd/adopt_test.go
+++ b/cmd/adopt_test.go
@@ -199,6 +199,85 @@ func TestAdoptCommand_WritesMatchedWithYes(t *testing.T) {
 	}
 }
 
+// TestAdoptCommand_DoesNotBackfillVersionsOutsideSourceTable is a
+// regression test for a review finding: adopt used to call
+// eng.Ledger().Sync before writing, which also backfills a row (tagged
+// with a normal, non-"adopted" hash source) for every version the
+// golang-migrate cursor already considers applied — even one the
+// incumbent's source table never recorded. That silently produced a
+// "verified" ledger row whose hash was never actually checked, which is
+// exactly what hash_source="adopted" exists to prevent. adopt must use
+// EnsureSchema (create the table only) instead of Sync (create + backfill).
+func TestAdoptCommand_DoesNotBackfillVersionsOutsideSourceTable(t *testing.T) {
+	dir, rawURL, cfg := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second migration file dbtools' own cursor will be stamped to,
+	// simulating a version applied by dbtools after the incumbent tool's
+	// ledger was last updated. The source table below never mentions it.
+	m2Up := `CREATE TABLE widgets (id INTEGER PRIMARY KEY);`
+	if err := os.WriteFile(filepath.Join(dir, "migrations", "20260822000002_widgets.up.sql"), []byte(m2Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// A distinct name from golang-migrate's own "schema_migrations" cursor
+	// table (which m.Stamp below writes to) so stamping the migrate
+	// cursor doesn't also mutate the simulated incumbent's ledger.
+	if _, err := db.Exec(`CREATE TABLE legacy_migrations (version INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO legacy_migrations (version) VALUES (20260822000001)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stamp the migrate cursor past version 2, which the source table
+	// above never recorded — this is what Sync's backfill would have
+	// picked up.
+	m, err := migrator.Open(rawURL, cfg.MigrationsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stamp(20260822000002); err != nil {
+		t.Fatal(err)
+	}
+	m.Close()
+
+	adoptYes = true
+	adoptForce = false
+	adoptFromTable = "legacy_migrations"
+	adoptVersionColumn = "version"
+	adoptAppliedAtColumn = ""
+
+	if err := runAdopt("testdb"); err != nil {
+		t.Fatalf("runAdopt() returned unexpected error: %v", err)
+	}
+
+	entries, err := eng.Ledger().List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1 (version 2 must not be backfilled): %+v", len(entries), entries)
+	}
+	if entries[0].Version != 20260822000001 || entries[0].HashSource != ledger.HashSourceAdopted {
+		t.Errorf("entries[0] = %+v, want version 20260822000001 with hash_source=adopted", entries[0])
+	}
+}
+
 func TestAdoptCommand_FromTableOverride(t *testing.T) {
 	dir, rawURL, _ := setupAdoptTestEnv(t)
 	wd, err := os.Getwd()

--- a/cmd/adopt_test.go
+++ b/cmd/adopt_test.go
@@ -1,0 +1,268 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/adopt"
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+func setupAdoptTestEnv(t *testing.T) (string, string, *config.Config) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "adopt_test.db")
+	rawURL := fmt.Sprintf("sqlite://%s", dbPath)
+	migrationsDir := filepath.Join(dir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m1Up := `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);`
+	m1Down := `DROP TABLE users;`
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.up.sql"), []byte(m1Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.down.sql"), []byte(m1Down), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgContent := fmt.Sprintf(`migrations_dir = %q
+[targets.testdb]
+url_env = "DBTOOLS_TEST_ADOPT_URL"
+engine = "sqlite"
+protected = false
+`, migrationsDir)
+
+	configPath := filepath.Join(dir, "dbtools.toml")
+	if err := os.WriteFile(configPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DBTOOLS_TEST_ADOPT_URL", rawURL)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, rawURL, cfg
+}
+
+func TestAdoptCommand_RefusesWithoutYes(t *testing.T) {
+	dir, rawURL, _ := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create legacy schema_migrations table
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, dirty BOOLEAN)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version, dirty) VALUES (20260822000001, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	adoptYes = false
+	adoptForce = false
+	adoptFromTable = ""
+	adoptVersionColumn = ""
+	adoptAppliedAtColumn = ""
+
+	err = runAdopt("testdb")
+	if err != nil {
+		t.Fatalf("runAdopt() returned unexpected error: %v", err)
+	}
+
+	// Verify nothing was written to dbtools_migration_history
+	entries, err := eng.Ledger().List(db, "dbtools_migration_history")
+	if err == nil && len(entries) > 0 {
+		t.Fatalf("ledger entries written without --yes: %+v", entries)
+	}
+}
+
+func TestAdoptCommand_RefusesOrphansWithoutForce(t *testing.T) {
+	dir, rawURL, _ := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, dirty BOOLEAN)`); err != nil {
+		t.Fatal(err)
+	}
+	// Insert orphan version (no file for 20260822000099)
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version, dirty) VALUES (20260822000099, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	adoptYes = true
+	adoptForce = false
+	adoptFromTable = ""
+	adoptVersionColumn = ""
+	adoptAppliedAtColumn = ""
+
+	err = runAdopt("testdb")
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("runAdopt() err = %v, want ExitCodeError with Code=1", err)
+	}
+}
+
+func TestAdoptCommand_WritesMatchedWithYes(t *testing.T) {
+	dir, rawURL, cfg := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, dirty BOOLEAN)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version, dirty) VALUES (20260822000001, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	adoptYes = true
+	adoptForce = false
+	adoptFromTable = ""
+	adoptVersionColumn = ""
+	adoptAppliedAtColumn = ""
+
+	err = runAdopt("testdb")
+	if err != nil {
+		t.Fatalf("runAdopt() returned unexpected error: %v", err)
+	}
+
+	entries, err := eng.Ledger().List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Version != 20260822000001 || e.Status != ledger.StatusApplied || e.HashSource != "adopted" {
+		t.Errorf("entry = %+v, want version 20260822000001, applied, hash_source=adopted", e)
+	}
+
+	// Verify migrator cursor is stamped
+	m, err := migrator.Open(rawURL, cfg.MigrationsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	curVer, _, hasVer, err := m.Version()
+	if err != nil || !hasVer || curVer != 20260822000001 {
+		t.Errorf("migrator cursor = (%d, %v), want (20260822000001, true)", curVer, hasVer)
+	}
+}
+
+func TestAdoptCommand_FromTableOverride(t *testing.T) {
+	dir, rawURL, _ := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE custom_hist (v_id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO custom_hist (v_id) VALUES (20260822000001)`); err != nil {
+		t.Fatal(err)
+	}
+
+	adoptYes = true
+	adoptForce = false
+	adoptFromTable = "custom_hist"
+	adoptVersionColumn = "v_id"
+	adoptAppliedAtColumn = ""
+
+	err = runAdopt("testdb")
+	if err != nil {
+		t.Fatalf("runAdopt() returned unexpected error: %v", err)
+	}
+
+	entries, err := eng.Ledger().List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Version != 20260822000001 {
+		t.Fatalf("entries = %+v, want 1 adopted entry", entries)
+	}
+}
+
+func TestAdoptCommand_JSONOutput(t *testing.T) {
+	plan := adopt.Plan{
+		SourceTable: "schema_migrations",
+		Matched:     []uint64{1, 2},
+		Pending:     []uint64{3},
+		Orphan:      []uint64{4},
+	}
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = false })
+
+	b, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed adopt.Plan
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.SourceTable != "schema_migrations" || len(parsed.Matched) != 2 {
+		t.Errorf("parsed plan mismatch: %+v", parsed)
+	}
+}

--- a/cmd/adopt_test.go
+++ b/cmd/adopt_test.go
@@ -278,6 +278,68 @@ func TestAdoptCommand_DoesNotBackfillVersionsOutsideSourceTable(t *testing.T) {
 	}
 }
 
+// TestAdoptCommand_RefusesPendingBelowHighestMatched is a regression test
+// for a review finding: stamping the migrate cursor to the highest matched
+// version while a lower-numbered version is still only "pending" (file on
+// disk, no source row) would make that pending version permanently
+// unreachable — PendingAfter only returns versions above the cursor.
+func TestAdoptCommand_RefusesPendingBelowHighestMatched(t *testing.T) {
+	dir, rawURL, _ := setupAdoptTestEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second, later migration file with no source-table row: this
+	// stays "pending" and must block stamping the cursor past it.
+	m2Up := `CREATE TABLE widgets (id INTEGER PRIMARY KEY);`
+	if err := os.WriteFile(filepath.Join(dir, "migrations", "20260822000002_widgets.up.sql"), []byte(m2Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// And a third file the source table DOES record, so plan.Matched's
+	// highest version (3) is above the pending version (2).
+	m3Up := `CREATE TABLE gadgets (id INTEGER PRIMARY KEY);`
+	if err := os.WriteFile(filepath.Join(dir, "migrations", "20260822000003_gadgets.up.sql"), []byte(m3Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, dirty BOOLEAN)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version, dirty) VALUES (20260822000001, 0), (20260822000003, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	adoptYes = true
+	adoptForce = false
+	adoptFromTable = ""
+	adoptVersionColumn = ""
+	adoptAppliedAtColumn = ""
+
+	err = runAdopt("testdb")
+	if err == nil {
+		t.Fatal("runAdopt() with a pending version below the highest matched: want error, got nil")
+	}
+
+	// The check runs before EnsureSchema, so the ledger table was never
+	// even created — the strongest possible evidence nothing was written.
+	entries, listErr := eng.Ledger().List(db, "dbtools_migration_history")
+	if listErr == nil && len(entries) != 0 {
+		t.Fatalf("entries = %+v, want no writes when the pending-below-matched check fails", entries)
+	}
+}
+
 func TestAdoptCommand_FromTableOverride(t *testing.T) {
 	dir, rawURL, _ := setupAdoptTestEnv(t)
 	wd, err := os.Getwd()

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -181,12 +181,18 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 			})
 		} else {
 			hashMismatches := 0
+			hashSkipped := 0
 			for _, e := range entries {
-				if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" {
-					sum, err := dir.ContentHash(e.Version)
-					if err != nil || sum != e.ContentSHA256 {
-						hashMismatches++
-					}
+				if e.Status != ledger.StatusApplied || e.ContentSHA256 == "" {
+					continue
+				}
+				if e.HashSource == "adopted" {
+					hashSkipped++
+					continue
+				}
+				sum, err := dir.ContentHash(e.Version)
+				if err != nil || sum != e.ContentSHA256 {
+					hashMismatches++
 				}
 			}
 			if hashMismatches > 0 {
@@ -196,10 +202,14 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 					Message: fmt.Sprintf("content hash mismatch in %d migration(s)", hashMismatches),
 				})
 			} else {
+				msg := fmt.Sprintf("%d ledger entries verified (hashes match)", len(entries))
+				if hashSkipped > 0 {
+					msg = fmt.Sprintf("%d ledger entries verified (hashes match), %d skipped (imported via adopt, unverified)", len(entries)-hashSkipped, hashSkipped)
+				}
 				report.Checks = append(report.Checks, CheckResult{
 					Name:    "ledger-integrity",
 					Status:  "ok",
-					Message: fmt.Sprintf("%d ledger entries verified (hashes match)", len(entries)),
+					Message: msg,
 				})
 			}
 		}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -182,6 +182,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 		} else {
 			hashMismatches := 0
 			hashSkipped := 0
+			hashVerified := 0
 			for _, e := range entries {
 				if e.Status != ledger.StatusApplied || e.ContentSHA256 == "" {
 					continue
@@ -193,7 +194,9 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 				sum, err := dir.ContentHash(e.Version)
 				if err != nil || sum != e.ContentSHA256 {
 					hashMismatches++
+					continue
 				}
+				hashVerified++
 			}
 			if hashMismatches > 0 {
 				report.Checks = append(report.Checks, CheckResult{
@@ -202,9 +205,9 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 					Message: fmt.Sprintf("content hash mismatch in %d migration(s)", hashMismatches),
 				})
 			} else {
-				msg := fmt.Sprintf("%d ledger entries verified (hashes match)", len(entries))
+				msg := fmt.Sprintf("%d ledger entries verified (hashes match)", hashVerified)
 				if hashSkipped > 0 {
-					msg = fmt.Sprintf("%d ledger entries verified (hashes match), %d skipped (imported via adopt, unverified)", len(entries)-hashSkipped, hashSkipped)
+					msg = fmt.Sprintf("%d ledger entries verified (hashes match), %d skipped (imported via adopt, unverified)", hashVerified, hashSkipped)
 				}
 				report.Checks = append(report.Checks, CheckResult{
 					Name:    "ledger-integrity",

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -186,7 +186,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 				if e.Status != ledger.StatusApplied || e.ContentSHA256 == "" {
 					continue
 				}
-				if e.HashSource == "adopted" {
+				if e.HashSource == ledger.HashSourceAdopted {
 					hashSkipped++
 					continue
 				}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -162,7 +162,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 	// 3. Ledger integrity check
 	var ledgerEntries []ledger.Entry
 	ledgerExists := true
-	entries, err := eng.Ledger().List(db)
+	entries, err := eng.Ledger().List(db, cfg.Ledger.Table)
 	if err != nil {
 		ledgerExists = false
 		report.Checks = append(report.Checks, CheckResult{
@@ -263,7 +263,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 
 	// 5. Drift summary
 	if ledgerExists && len(ledgerEntries) > 0 {
-		vReport, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
+		vReport, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, targetName)
 		if err != nil {
 			report.Checks = append(report.Checks, CheckResult{
 				Name:    "drift-summary",

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -172,7 +172,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 		})
 	} else {
 		ledgerEntries = entries
-		dir, dirErr := migrator.ReadDir(cfg.MigrationsDir)
+		dir, dirErr := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 		if dirErr != nil {
 			report.Checks = append(report.Checks, CheckResult{
 				Name:    "ledger-integrity",
@@ -229,7 +229,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 			currentVer = v
 			isDirty = dirty
 			hasVer = hv
-			dir, dirErr := migrator.ReadDir(cfg.MigrationsDir)
+			dir, dirErr := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 			if dirErr != nil {
 				report.Checks = append(report.Checks, CheckResult{
 					Name:    "version-sync",
@@ -263,7 +263,7 @@ func evaluateTarget(cfg *config.Config, targetName string) *DoctorReport {
 
 	// 5. Drift summary
 	if ledgerExists && len(ledgerEntries) > 0 {
-		vReport, err := verify.Collect(db, eng, cfg.MigrationsDir, targetName)
+		vReport, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
 		if err != nil {
 			report.Checks = append(report.Checks, CheckResult{
 				Name:    "drift-summary",

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -300,6 +300,61 @@ func TestDoctorLiveObjectDropDrift(t *testing.T) {
 	}
 }
 
+func TestDoctor_SkipsHashCheckForAdoptedRows(t *testing.T) {
+	dir, rawURL, cfg := setupTestDoctorEnv(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply migration first
+	_, err = apply.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mark the row as adopted with a deliberately wrong hash
+	eng := sqliteengine.SQLite{}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`UPDATE dbtools_migration_history SET content_sha256 = 'deliberatelywronghash', hash_source = 'adopted' WHERE version = 20260822000001`); err != nil {
+		t.Fatal(err)
+	}
+
+	report := evaluateTarget(cfg, "testdb")
+	if !report.Healthy {
+		t.Fatalf("evaluateTarget() healthy = false, want true when row is adopted. Checks: %+v", report.Checks)
+	}
+	if report.Exit != 0 {
+		t.Fatalf("evaluateTarget() exit = %d, want 0", report.Exit)
+	}
+
+	var ledgerCheck *CheckResult
+	for i := range report.Checks {
+		if report.Checks[i].Name == "ledger-integrity" {
+			ledgerCheck = &report.Checks[i]
+			break
+		}
+	}
+	if ledgerCheck == nil {
+		t.Fatal("ledger-integrity check not found in report")
+	}
+	if ledgerCheck.Status != "ok" {
+		t.Fatalf("ledger-integrity status = %q, want ok", ledgerCheck.Status)
+	}
+	if !strings.Contains(ledgerCheck.Message, "skipped") {
+		t.Fatalf("ledger-integrity message = %q, want it to mention skipped", ledgerCheck.Message)
+	}
+}
+
 func TestRenderDoctorHuman(t *testing.T) {
 	rep := &DoctorReport{
 		Target:  "prod",

--- a/cmd/dryrun.go
+++ b/cmd/dryrun.go
@@ -46,7 +46,7 @@ func runDryRun(cfg *config.Config, targetName, urlOverride string) error {
 		return fmt.Errorf("target %q: migration cursor is dirty at version %d; run `dbtools repair %s` to resolve it", targetName, curVer, targetName)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 	if err != nil {
 		return err
 	}

--- a/cmd/force.go
+++ b/cmd/force.go
@@ -58,7 +58,7 @@ func runForce(targetName string, version uint64) error {
 
 	// Also update ledger status
 	note := fmt.Sprintf("forced to version %d via force command", version)
-	_ = eng.Ledger().SetStatus(db, version, ledger.StatusApplied, note)
+	_ = eng.Ledger().SetStatus(db, version, ledger.StatusApplied, note, cfg.Ledger.Table)
 
 	if jsonOutput {
 		b, err := json.Marshal(struct {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -35,7 +35,7 @@ func runNew(now time.Time, name string) (string, error) {
 		return "", fmt.Errorf("loading dbtools.toml (run 'dbtools init' first?): %w", err)
 	}
 
-	filename, err := scaffold.NextUpFilename(now, cfg.MigrationsDir, name)
+	filename, err := scaffold.NextUpFilename(now, cfg.MigrationsDir, cfg.Migrations.UpSuffix, name)
 	if err != nil {
 		return "", fmt.Errorf("determining next migration filename: %w", err)
 	}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -117,7 +117,7 @@ func buildPlanEntries(cfg *config.Config) []planJSONEntry {
 			url, _ := cfg.ResolveURLOrFlag(r.Target, override)
 			eng, err := engine.ForTarget(cfg.EngineName(r.Target), url)
 			if err == nil {
-				e.Drift = planDrift(url, eng, cfg.MigrationsDir, r.Target)
+				e.Drift = planDrift(url, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, r.Target)
 			}
 		}
 		entries = append(entries, e)
@@ -127,14 +127,14 @@ func buildPlanEntries(cfg *config.Config) []planJSONEntry {
 
 // planDrift runs a read-only verify pass against url and returns the
 // drift details for applied/reverted versions.
-func planDrift(url string, eng engine.Engine, migrationsDir, targetName string) []string {
+func planDrift(url string, eng engine.Engine, migrationsDir, upSuffix, targetName string) []string {
 	db, err := eng.Open(url)
 	if err != nil {
 		return []string{"verify: " + err.Error()}
 	}
 	defer db.Close()
 
-	report, err := verify.Collect(db, eng, migrationsDir, targetName)
+	report, err := verify.Collect(db, eng, migrationsDir, upSuffix, targetName)
 	if err != nil {
 		return []string{"verify: " + err.Error()}
 	}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -117,7 +117,7 @@ func buildPlanEntries(cfg *config.Config) []planJSONEntry {
 			url, _ := cfg.ResolveURLOrFlag(r.Target, override)
 			eng, err := engine.ForTarget(cfg.EngineName(r.Target), url)
 			if err == nil {
-				e.Drift = planDrift(url, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, r.Target)
+				e.Drift = planDrift(url, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, r.Target)
 			}
 		}
 		entries = append(entries, e)
@@ -127,14 +127,14 @@ func buildPlanEntries(cfg *config.Config) []planJSONEntry {
 
 // planDrift runs a read-only verify pass against url and returns the
 // drift details for applied/reverted versions.
-func planDrift(url string, eng engine.Engine, migrationsDir, upSuffix, targetName string) []string {
+func planDrift(url string, eng engine.Engine, migrationsDir, upSuffix, table, targetName string) []string {
 	db, err := eng.Open(url)
 	if err != nil {
 		return []string{"verify: " + err.Error()}
 	}
 	defer db.Close()
 
-	report, err := verify.Collect(db, eng, migrationsDir, upSuffix, targetName)
+	report, err := verify.Collect(db, eng, migrationsDir, upSuffix, table, targetName)
 	if err != nil {
 		return []string{"verify: " + err.Error()}
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -49,7 +49,7 @@ func runPush(targetName string) (err error) {
 	if _, err := engine.ForTarget(cfg.EngineName(targetName), url); err != nil {
 		return err
 	}
-	preview, err := statusinfo.Collect(url, cfg.MigrationsDir, targetName)
+	preview, err := statusinfo.Collect(url, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -104,7 +104,7 @@ func runRepair(targetName string, pairs []repair.Pair) error {
 	}
 	defer m.Close()
 
-	result, err := repair.Run(db, eng, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix, pairs, repairForce)
+	result, err := repair.Run(db, eng, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, pairs, repairForce)
 	if err != nil {
 		return err
 	}

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -104,7 +104,7 @@ func runRepair(targetName string, pairs []repair.Pair) error {
 	}
 	defer m.Close()
 
-	result, err := repair.Run(db, eng, m, cfg.MigrationsDir, pairs, repairForce)
+	result, err := repair.Run(db, eng, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix, pairs, repairForce)
 	if err != nil {
 		return err
 	}

--- a/cmd/sqlite_loop_test.go
+++ b/cmd/sqlite_loop_test.go
@@ -69,7 +69,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	defer db.Close()
 
 	// verify: clean after up
-	report, err := verify.Collect(db, eng, "migrations", "local")
+	report, err := verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() returned error: %v", err)
 	}
@@ -83,7 +83,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	if _, err := db.Exec(`DROP VIEW active_users`); err != nil {
 		t.Fatal(err)
 	}
-	report, err = verify.Collect(db, eng, "migrations", "local")
+	report, err = verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() after drop returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	}
 
 	// verify: after down, table is gone and ledger records reverted (not drift)
-	report, err = verify.Collect(db2, eng, "migrations", "local")
+	report, err = verify.Collect(db2, eng, "migrations", cfg.Migrations.UpSuffix, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() after down returned error: %v", err)
 	}

--- a/cmd/sqlite_loop_test.go
+++ b/cmd/sqlite_loop_test.go
@@ -69,7 +69,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	defer db.Close()
 
 	// verify: clean after up
-	report, err := verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, "local")
+	report, err := verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, cfg.Ledger.Table, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() returned error: %v", err)
 	}
@@ -83,7 +83,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	if _, err := db.Exec(`DROP VIEW active_users`); err != nil {
 		t.Fatal(err)
 	}
-	report, err = verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, "local")
+	report, err = verify.Collect(db, eng, "migrations", cfg.Migrations.UpSuffix, cfg.Ledger.Table, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() after drop returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ CREATE VIEW active_users AS SELECT * FROM users;`
 	}
 
 	// verify: after down, table is gone and ledger records reverted (not drift)
-	report, err = verify.Collect(db2, eng, "migrations", cfg.Migrations.UpSuffix, "local")
+	report, err = verify.Collect(db2, eng, "migrations", cfg.Migrations.UpSuffix, cfg.Ledger.Table, "local")
 	if err != nil {
 		t.Fatalf("verify.Collect() after down returned error: %v", err)
 	}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -63,16 +63,16 @@ func runVerify(targetName string) error {
 	}
 	defer m.Close()
 
-	entries, err := eng.Ledger().List(db)
+	entries, err := eng.Ledger().List(db, cfg.Ledger.Table)
 	if err != nil {
 		// No ledger table at all: with --init-ledger, create it (and
 		// backfill); without it, refuse — verify must not perform DDL/DML
 		// on a target it was asked to inspect read-only.
 		if verifyInitLedger {
-			if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
+			if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table); err != nil {
 				return err
 			}
-			entries, err = eng.Ledger().List(db)
+			entries, err = eng.Ledger().List(db, cfg.Ledger.Table)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func runVerify(targetName string) error {
 		}
 	}
 
-	report, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
+	report, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, targetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -69,7 +69,7 @@ func runVerify(targetName string) error {
 		// backfill); without it, refuse — verify must not perform DDL/DML
 		// on a target it was asked to inspect read-only.
 		if verifyInitLedger {
-			if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+			if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
 				return err
 			}
 			entries, err = eng.Ledger().List(db)
@@ -86,7 +86,7 @@ func runVerify(targetName string) error {
 		}
 	}
 
-	report, err := verify.Collect(db, eng, cfg.MigrationsDir, targetName)
+	report, err := verify.Collect(db, eng, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
 	if err != nil {
 		return err
 	}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,9 @@ same core.
 | v0.3/4 ✅ | **Clone prod→dev** | Shipped: `dbtools clone <source> <dest>`, `internal/clone`. Masking on by default (built-in sensitive-column list + `[clone.mask]` overrides); `--no-mask` is the explicit opt-out. Same-engine only; row-count/WHERE subsetting via `--limit`/`--where`. |
 | v0.3/4 ✅ | **MySQL engine** | Shipped: `internal/engine/mysqlengine`, mirroring the mssql/postgres/sqlite seam. classicmodels fixtures ported to MySQL with real FKs. Scope: TABLE/VIEW DDL detection only (no stored procedures — see the implementation plan for why). `internal/container` local-dev support shipped separately (see Docker project lifecycle, below). |
 | v0.4 ✅ | **Docker project lifecycle** | Shipped: project-scoped local container/volume naming (path-hash or `[project] name`), dynamic or pinned (`[container] port`) host ports, data persists across `stop`/`start` via a named volume (`stop --no-backup` opts back into a full wipe), new `restart`/`logs` commands, and the missing MySQL container spec. `dbtools reset` on MySQL remains unsupported (separate, deferred gap — `cmd/reset.go` has no `mysql` case yet). |
-| v0.5 | **Backup** | Table-stakes backup/restore. |
+| v0.5 ✅ | **Private-network job execution** (issue #60) | Shipped: official multi-arch Docker image (`ghcr.io/seanpham99/dbtools`), Postgres diagnostics (NOTICE forwarding, character-offset error translation, SQLSTATE 42501 permission diagnostic), `--log-format=json` structured logging with clean stdout/stderr separation, job-completion summary record, and container-orchestrator retry-semantics docs. Landed as `feat:` commits, correctly bumping past v0.4 per semver — this table is the roadmap's record of *why*, not a manual override of the version number. |
+| v0.6 | **Incumbent-ledger adoption** (issues #61–#63) | `dbtools adopt` (import an existing migration ledger + configurable table name/filename convention), ledger-free read-only mode for `plan`/`verify`/`doctor`/`status`, `dbtools diff` (replay-and-compare drift check), `dbtools squash` (verified baseline collapse, safe on fresh and existing databases). In progress — see `docs/superpowers/plans/2026-08-25-adopt.md` for `adopt`. |
+| v0.7 | **Backup** | Table-stakes backup/restore. |
 | Mongo | **C → B → A** | Starts only after SQL is stable (gate = v0.2 shipped — met). See design below. |
 | launch | — | Public launch (announcements, directories) happens only after the v0.2/v0.3 features above. |
 
@@ -110,7 +112,7 @@ non-SQL seam, so it is a semantic fork, not a new engine. Sequence:
 
 ## Open questions (deferred)
 
-- Backup scope (v0.4): full vs incremental, engine support, restore test strategy.
+- Backup scope (v0.7): full vs incremental, engine support, restore test strategy.
 - `doctor` exact check list — spec at v0.3 start.
 - Exact exit-code values — written up in `docs/exit-codes.md` with v0.2.
 - Mongo `generate` output shape — decide at step B (pydantic vs TS).

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -1,0 +1,243 @@
+// Package adopt provides detection, reading, diffing, and adoption logic
+// for preexisting database migration history tables into dbtools.
+package adopt
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+// KnownTable describes a known third-party migration tracking table.
+type KnownTable struct {
+	Name          string
+	VersionCol    string
+	AppliedAtCol  string
+}
+
+// KnownSourceTables lists the supported third-party migration tracking tables
+// in probe order.
+var KnownSourceTables = []KnownTable{
+	{Name: "schema_migrations", VersionCol: "version", AppliedAtCol: ""},
+	{Name: "flyway_schema_history", VersionCol: "version", AppliedAtCol: "installed_on"},
+	{Name: "__EFMigrationsHistory", VersionCol: "MigrationId", AppliedAtCol: "AppliedDate"},
+	{Name: "knex_migrations", VersionCol: "name", AppliedAtCol: "migration_time"},
+	{Name: "alembic_version", VersionCol: "version_num", AppliedAtCol: ""},
+	{Name: "SchemaVersions", VersionCol: "ScriptName", AppliedAtCol: "Applied"},
+}
+
+// KnownTableNames returns the names of the known candidate tables.
+func KnownTableNames() []string {
+	names := make([]string, len(KnownSourceTables))
+	for i, kt := range KnownSourceTables {
+		names[i] = kt.Name
+	}
+	return names
+}
+
+// DefaultColumnsForTable returns the default version and applied-at column names
+// for a known source table, or defaults to ("version", "") if unknown.
+func DefaultColumnsForTable(tableName string) (versionCol, appliedAtCol string) {
+	for _, kt := range KnownSourceTables {
+		if strings.EqualFold(kt.Name, tableName) {
+			return kt.VersionCol, kt.AppliedAtCol
+		}
+	}
+	return "version", ""
+}
+
+// SourceRow is one migration record read from a third-party migration table.
+type SourceRow struct {
+	Version   uint64
+	AppliedAt *time.Time
+}
+
+// Plan is the 3-way diff between source table rows and on-disk migration files.
+type Plan struct {
+	SourceTable string   `json:"source_table"`
+	Matched     []uint64 `json:"matched"`
+	Pending     []uint64 `json:"pending"`
+	Orphan      []uint64 `json:"orphan"`
+}
+
+// DetectSourceTable probes candidateTables in order via existsFunc
+// and returns the first matching table name, or an error if none match.
+func DetectSourceTable(db ledger.DBTX, existsFunc func(ledger.DBTX, string) (bool, error), candidateTables []string) (string, error) {
+	for _, tbl := range candidateTables {
+		exists, err := existsFunc(db, tbl)
+		if err != nil {
+			return "", fmt.Errorf("checking existence of table %q: %w", tbl, err)
+		}
+		if exists {
+			return tbl, nil
+		}
+	}
+	return "", fmt.Errorf("no candidate migration table found among [%s]; specify --from-table <name> --version-column <col>", strings.Join(candidateTables, ", "))
+}
+
+var leadingDigitsPattern = regexp.MustCompile(`^(\d+)`)
+
+// parseVersion extracts a uint64 version from a database value (numeric or string).
+func parseVersion(v any) (uint64, error) {
+	switch val := v.(type) {
+	case int64:
+		if val < 0 {
+			return 0, fmt.Errorf("negative version number: %d", val)
+		}
+		return uint64(val), nil
+	case int:
+		if val < 0 {
+			return 0, fmt.Errorf("negative version number: %d", val)
+		}
+		return uint64(val), nil
+	case uint64:
+		return val, nil
+	case []byte:
+		return parseVersionString(string(val))
+	case string:
+		return parseVersionString(val)
+	default:
+		return parseVersionString(fmt.Sprint(v))
+	}
+}
+
+func parseVersionString(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	// Try parsing full string as uint64 first
+	if u, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return u, nil
+	}
+	// Extract leading digits (e.g. "20260822000001_create_users" or "V1__initial")
+	clean := strings.TrimPrefix(s, "V")
+	clean = strings.TrimPrefix(clean, "v")
+	match := leadingDigitsPattern.FindString(clean)
+	if match != "" {
+		if u, err := strconv.ParseUint(match, 10, 64); err == nil {
+			return u, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot parse version number from %q", s)
+}
+
+// ReadSourceRows reads rows from table using the specified version and applied-at columns.
+func ReadSourceRows(db ledger.DBTX, table, versionColumn, appliedAtColumn string) ([]SourceRow, error) {
+	if err := ledger.ValidateTableName(table); err != nil {
+		return nil, err
+	}
+	if err := ledger.ValidateTableName(versionColumn); err != nil {
+		return nil, err
+	}
+	if appliedAtColumn != "" {
+		if err := ledger.ValidateTableName(appliedAtColumn); err != nil {
+			return nil, err
+		}
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s", versionColumn, table)
+	if appliedAtColumn != "" {
+		query = fmt.Sprintf("SELECT %s, %s FROM %s", versionColumn, appliedAtColumn, table)
+	}
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	var result []SourceRow
+	for rows.Next() {
+		var rawVersion any
+		var rawAppliedAt any
+		if appliedAtColumn != "" {
+			if err := rows.Scan(&rawVersion, &rawAppliedAt); err != nil {
+				return nil, fmt.Errorf("scanning %s row: %w", table, err)
+			}
+		} else {
+			if err := rows.Scan(&rawVersion); err != nil {
+				return nil, fmt.Errorf("scanning %s row: %w", table, err)
+			}
+		}
+
+		if rawVersion == nil {
+			continue
+		}
+
+		ver, err := parseVersion(rawVersion)
+		if err != nil {
+			return nil, fmt.Errorf("parsing version from %s: %w", table, err)
+		}
+
+		sr := SourceRow{Version: ver}
+		if rawAppliedAt != nil {
+			switch at := rawAppliedAt.(type) {
+			case time.Time:
+				sr.AppliedAt = &at
+			case *time.Time:
+				sr.AppliedAt = at
+			}
+		}
+		result = append(result, sr)
+	}
+
+	return result, rows.Err()
+}
+
+// BuildPlan constructs a 3-way diff between source table rows and files on disk.
+func BuildPlan(sourceTable string, sourceRows []SourceRow, dir *migrator.Dir) Plan {
+	diskVersions := make(map[uint64]bool)
+	if dir != nil {
+		for _, v := range dir.ListVersions() {
+			diskVersions[v] = true
+		}
+	}
+
+	srcVersions := make(map[uint64]bool)
+	for _, r := range sourceRows {
+		srcVersions[r.Version] = true
+	}
+
+	var matched []uint64
+	var pending []uint64
+	var orphan []uint64
+
+	// Collect union of all versions
+	allVersionsMap := make(map[uint64]bool)
+	for v := range diskVersions {
+		allVersionsMap[v] = true
+	}
+	for v := range srcVersions {
+		allVersionsMap[v] = true
+	}
+
+	var allVersions []uint64
+	for v := range allVersionsMap {
+		allVersions = append(allVersions, v)
+	}
+	sort.Slice(allVersions, func(i, j int) bool { return allVersions[i] < allVersions[j] })
+
+	for _, v := range allVersions {
+		inDisk := diskVersions[v]
+		inSrc := srcVersions[v]
+		switch {
+		case inDisk && inSrc:
+			matched = append(matched, v)
+		case inDisk && !inSrc:
+			pending = append(pending, v)
+		case !inDisk && inSrc:
+			orphan = append(orphan, v)
+		}
+	}
+
+	return Plan{
+		SourceTable: sourceTable,
+		Matched:     matched,
+		Pending:     pending,
+		Orphan:      orphan,
+	}
+}

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -118,6 +118,14 @@ func parseVersionString(s string) (uint64, error) {
 	clean = strings.TrimPrefix(clean, "v")
 	match := leadingDigitsPattern.FindString(clean)
 	if match != "" {
+		rest := clean[len(match):]
+		// A dotted multi-part version (Flyway's "V1.1", "V2.3.1") would
+		// silently truncate to its first segment here, colliding "1.1"
+		// and "1.2" onto the same uint64 version and corrupting the
+		// adopted ledger. Refuse rather than guess.
+		if strings.HasPrefix(rest, ".") && len(rest) > 1 && rest[1] >= '0' && rest[1] <= '9' {
+			return 0, fmt.Errorf("cannot adopt dotted version %q: multi-part versions (e.g. Flyway's V1.1) can't be represented as dbtools' single integer version without collisions — use --from-table with a purely numeric column", s)
+		}
 		if u, err := strconv.ParseUint(match, 10, 64); err == nil {
 			return u, nil
 		}

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -16,9 +16,9 @@ import (
 
 // KnownTable describes a known third-party migration tracking table.
 type KnownTable struct {
-	Name          string
-	VersionCol    string
-	AppliedAtCol  string
+	Name         string
+	VersionCol   string
+	AppliedAtCol string
 }
 
 // KnownSourceTables lists the supported third-party migration tracking tables

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -122,7 +122,7 @@ func parseVersionString(s string) (uint64, error) {
 			return u, nil
 		}
 	}
-	return 0, fmt.Errorf("cannot parse version number from %q", s)
+	return 0, fmt.Errorf("cannot parse version number from %q: dbtools requires a numeric version per row (e.g. Alembic's default non-numeric revision hashes aren't supported — see skills/using-dbtools/adopt.md)", s)
 }
 
 // ReadSourceRows reads rows from table using the specified version and applied-at columns.

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -1,0 +1,129 @@
+package adopt_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/seanpham99/dbtools/internal/adopt"
+	"github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+	"github.com/seanpham99/dbtools/internal/ledger"
+	"github.com/seanpham99/dbtools/internal/migrator"
+)
+
+func openTestSQLite(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sqliteengine.SQLite{}.Open("sqlite://" + filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestDetectSourceTable_FirstMatchWins(t *testing.T) {
+	exists := func(_ ledger.DBTX, name string) (bool, error) {
+		return name == "flyway_schema_history", nil
+	}
+	table, err := adopt.DetectSourceTable(nil, exists, []string{"schema_migrations", "flyway_schema_history"})
+	if err != nil {
+		t.Fatalf("DetectSourceTable() returned error: %v", err)
+	}
+	if table != "flyway_schema_history" {
+		t.Errorf("table = %q, want flyway_schema_history", table)
+	}
+}
+
+func TestDetectSourceTable_NoneFound(t *testing.T) {
+	exists := func(_ ledger.DBTX, _ string) (bool, error) { return false, nil }
+	_, err := adopt.DetectSourceTable(nil, exists, []string{"schema_migrations"})
+	if err == nil {
+		t.Fatal("DetectSourceTable() with no match: want error, got nil")
+	}
+}
+
+func TestBuildPlan_ThreeWayDiff(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "1_a.up.sql"), []byte("-- sql"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "2_b.up.sql"), []byte("-- sql"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := migrator.ReadDir(dir, ".up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sourceRows := []adopt.SourceRow{{Version: 1}, {Version: 3}}
+	plan := adopt.BuildPlan("schema_migrations", sourceRows, d)
+
+	if len(plan.Matched) != 1 || plan.Matched[0] != 1 {
+		t.Errorf("Matched = %v, want [1]", plan.Matched)
+	}
+	if len(plan.Pending) != 1 || plan.Pending[0] != 2 {
+		t.Errorf("Pending = %v, want [2]", plan.Pending)
+	}
+	if len(plan.Orphan) != 1 || plan.Orphan[0] != 3 {
+		t.Errorf("Orphan = %v, want [3]", plan.Orphan)
+	}
+}
+
+func TestReadSourceRows_SQLite(t *testing.T) {
+	db := openTestSQLite(t)
+
+	if _, err := db.Exec(`CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TIMESTAMP)`); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	if _, err := db.Exec(`INSERT INTO schema_migrations (version, applied_at) VALUES (1, ?), (2, ?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := adopt.ReadSourceRows(db, "schema_migrations", "version", "applied_at")
+	if err != nil {
+		t.Fatalf("ReadSourceRows() returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0].Version != 1 || rows[1].Version != 2 {
+		t.Errorf("rows versions = %d, %d, want 1, 2", rows[0].Version, rows[1].Version)
+	}
+}
+
+func TestReadSourceRows_StringVersions(t *testing.T) {
+	db := openTestSQLite(t)
+
+	if _, err := db.Exec(`CREATE TABLE __EFMigrationsHistory (MigrationId TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO __EFMigrationsHistory (MigrationId) VALUES ('20260822000001_Initial'), ('20260822000002_AddUsers')`); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := adopt.ReadSourceRows(db, "__EFMigrationsHistory", "MigrationId", "")
+	if err != nil {
+		t.Fatalf("ReadSourceRows() returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0].Version != 20260822000001 || rows[1].Version != 20260822000002 {
+		t.Errorf("rows versions = %d, %d, want 20260822000001, 20260822000002", rows[0].Version, rows[1].Version)
+	}
+}
+
+func TestReadSourceRows_RejectsInvalidIdentifiers(t *testing.T) {
+	if _, err := adopt.ReadSourceRows(nil, "bad table; name", "version", ""); err == nil {
+		t.Fatal("ReadSourceRows() with invalid table name: want error, got nil")
+	}
+	if _, err := adopt.ReadSourceRows(nil, "schema_migrations", "bad col; name", ""); err == nil {
+		t.Fatal("ReadSourceRows() with invalid version column: want error, got nil")
+	}
+	if _, err := adopt.ReadSourceRows(nil, "schema_migrations", "version", "bad applied; col"); err == nil {
+		t.Fatal("ReadSourceRows() with invalid applied_at column: want error, got nil")
+	}
+}

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -116,6 +116,25 @@ func TestReadSourceRows_StringVersions(t *testing.T) {
 	}
 }
 
+// TestReadSourceRows_RejectsDottedVersions is a regression test for a
+// review finding: a Flyway-style dotted version ("V1.1", "V1.2") used to
+// silently truncate to its leading digit, colliding two distinct rows onto
+// the same uint64 version and corrupting the adopted ledger.
+func TestReadSourceRows_RejectsDottedVersions(t *testing.T) {
+	db := openTestSQLite(t)
+
+	if _, err := db.Exec(`CREATE TABLE flyway_schema_history (version TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO flyway_schema_history (version) VALUES ('1.1')`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := adopt.ReadSourceRows(db, "flyway_schema_history", "version", ""); err == nil {
+		t.Fatal("ReadSourceRows() with dotted version '1.1': want error, got nil")
+	}
+}
+
 func TestReadSourceRows_RejectsInvalidIdentifiers(t *testing.T) {
 	if _, err := adopt.ReadSourceRows(nil, "bad table; name", "version", ""); err == nil {
 		t.Fatal("ReadSourceRows() with invalid table name: want error, got nil")

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -35,6 +35,17 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 
 	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
+	// migrator.Open wraps golang-migrate, whose own file source driver
+	// looks for "<version>_<name>.up.sql" unconditionally — it has no way
+	// to honor a custom up_suffix. A non-default suffix would make our
+	// own dir.PendingAfter (below) report files as pending that
+	// golang-migrate's m.Step() can never find, silently applying
+	// nothing while looking like success. Fail closed instead: today,
+	// up_suffix is only honored by the read-only commands and `adopt`.
+	if upSuffix != config.DefaultUpSuffix {
+		return nil, fmt.Errorf("target %q: migrations.up_suffix=%q is not supported for applying migrations (up/push) — golang-migrate's execution engine requires %q; the read-only commands and `dbtools adopt` honor the custom suffix, but up/push cannot yet", targetName, upSuffix, config.DefaultUpSuffix)
+	}
+
 	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
 		return nil, err

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -33,18 +33,7 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		}
 	}
 
-	migrationsDir := cfg.MigrationsDir
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	upSuffix := cfg.Migrations.UpSuffix
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	ledgerTable := cfg.Ledger.Table
-	if ledgerTable == "" {
-		ledgerTable = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
 	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -45,11 +45,11 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -89,7 +89,7 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		}
 	}
 
-	status, err := statusinfo.Collect(url, cfg.MigrationsDir, targetName)
+	status, err := statusinfo.Collect(url, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -33,7 +33,20 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		}
 	}
 
-	m, err := migrator.Open(url, cfg.MigrationsDir)
+	migrationsDir := cfg.MigrationsDir
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	upSuffix := cfg.Migrations.UpSuffix
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	ledgerTable := cfg.Ledger.Table
+	if ledgerTable == "" {
+		ledgerTable = "dbtools_migration_history"
+	}
+
+	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +58,11 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -84,12 +97,12 @@ func Run(cfg *config.Config, targetName string, urlOverride string) (*statusinfo
 		if err != nil {
 			return nil, fmt.Errorf("target %q: %w", targetName, err)
 		}
-		if err := eng.Ledger().SetStatusWithHash(db, versionAfter, ledger.StatusApplied, "applied via up/push", hash); err != nil {
+		if err := eng.Ledger().SetStatusWithHash(db, versionAfter, ledger.StatusApplied, "applied via up/push", hash, ledgerTable); err != nil {
 			return nil, fmt.Errorf("target %q: %w", targetName, err)
 		}
 	}
 
-	status, err := statusinfo.Collect(url, cfg.MigrationsDir, cfg.Migrations.UpSuffix, targetName)
+	status, err := statusinfo.Collect(url, migrationsDir, upSuffix, targetName)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}

--- a/internal/apply/apply_integration_test.go
+++ b/internal/apply/apply_integration_test.go
@@ -82,7 +82,7 @@ func TestRun_RecordsLedgerEntries(t *testing.T) {
 	}
 	defer db.Close()
 
-	entries, err := mssqlengine.List(db)
+	entries, err := mssqlengine.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("ledger.List() returned error: %v", err)
 	}

--- a/internal/apply/apply_partial_integration_test.go
+++ b/internal/apply/apply_partial_integration_test.go
@@ -62,7 +62,7 @@ func TestRun_RecordsPartiallyAppliedMigrationsOnFailure(t *testing.T) {
 	}
 	defer db.Close()
 
-	entries, err := eng.Ledger().List(db)
+	entries, err := eng.Ledger().List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestRun_RecordsPartiallyAppliedMigrationsOnFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if err := eng.Ledger().SetStatus(db, 3, ledger.StatusReverted, "repair: previously failed"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 3, ledger.StatusReverted, "repair: previously failed", "dbtools_migration_history"); err != nil {
 		t.Fatalf("marking 3 reverted: %v", err)
 	}
 	m, err := migratorOpen(rawURL, dir)
@@ -123,7 +123,7 @@ func TestRun_RecordsPartiallyAppliedMigrationsOnFailure(t *testing.T) {
 	if _, err := Run(cfg, "local", ""); err != nil {
 		t.Fatalf("Run() after adding migration 4 returned error: %v", err)
 	}
-	entries, err = eng.Ledger().List(db)
+	entries, err = eng.Ledger().List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -28,6 +28,25 @@ func TestRun_EnvVarNotSet(t *testing.T) {
 	}
 }
 
+// TestRun_RefusesCustomUpSuffix is a regression test for a review finding:
+// golang-migrate's own file source is hardcoded to ".up.sql"/".down.sql"
+// regardless of migrations.up_suffix, so a custom suffix would make
+// dir.PendingAfter report files as pending that m.Step() can never find —
+// applying silently nothing while looking like success. Run must refuse
+// instead of no-op'ing.
+func TestRun_RefusesCustomUpSuffix(t *testing.T) {
+	cfg := &config.Config{
+		MigrationsDir: "migrations",
+		Migrations:    config.MigrationsConfig{UpSuffix: ".sql"},
+		Targets:       map[string]config.Target{"staging": {URLEnv: "DBTOOLS_APPLY_TEST_UNSET_SUFFIX"}},
+	}
+	t.Setenv("DBTOOLS_APPLY_TEST_UNSET_SUFFIX", "sqlite://"+filepath.Join(t.TempDir(), "test.db"))
+	_, err := Run(cfg, "staging", "")
+	if err == nil {
+		t.Fatal("Run() with custom up_suffix: want error, got nil")
+	}
+}
+
 func TestRun_BatchTimestampMigrations(t *testing.T) {
 	tmpDir := t.TempDir()
 	migDir := filepath.Join(tmpDir, "migrations")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	toml "github.com/pelletier/go-toml/v2"
+	"github.com/seanpham99/dbtools/internal/ledger"
 )
 
 // UnsetEnvError indicates a target's connection URL environment variable is not defined.
@@ -118,6 +119,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Ledger.Table == "" {
 		cfg.Ledger.Table = "dbtools_migration_history"
+	}
+	if err := ledger.ValidateTableName(cfg.Ledger.Table); err != nil {
+		return nil, fmt.Errorf("dbtools.toml: %w", err)
 	}
 	if cfg.Migrations.UpSuffix == "" {
 		cfg.Migrations.UpSuffix = ".up.sql"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,7 +148,11 @@ func Load(path string) (*Config, error) {
 	// Default exclude list to internal tool tables unless the key was set at all
 	// (including explicitly to an empty list, which means "exclude nothing").
 	if cfg.Generate.Exclude == nil {
-		cfg.Generate.Exclude = []string{"dbtools_migration_history", "schema_migrations"}
+		exclude := []string{"dbtools_migration_history", "schema_migrations"}
+		if cfg.Ledger.Table != DefaultLedgerTable {
+			exclude = append(exclude, cfg.Ledger.Table)
+		}
+		cfg.Generate.Exclude = exclude
 	}
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,33 @@ type MigrationsConfig struct {
 	UpSuffix string `toml:"up_suffix"`
 }
 
+// Defaults for the three migration-location values below, shared with
+// ResolveDefaults so every caller (Load included) derives them once.
+const (
+	DefaultMigrationsDir = "migrations"
+	DefaultUpSuffix      = ".up.sql"
+	DefaultLedgerTable   = "dbtools_migration_history"
+)
+
+// ResolveDefaults fills in the standard default for any of migrationsDir,
+// upSuffix, or table that is empty. Load applies these to a *Config
+// directly; this exists for the internal packages (repair, verify, down,
+// apply, rollback, adopt) that take the three as plain parameters rather
+// than a *Config, so each one defaults identically instead of every
+// caller re-deriving its own copy of the same three checks.
+func ResolveDefaults(migrationsDir, upSuffix, table string) (resolvedDir, resolvedSuffix, resolvedTable string) {
+	if migrationsDir == "" {
+		migrationsDir = DefaultMigrationsDir
+	}
+	if upSuffix == "" {
+		upSuffix = DefaultUpSuffix
+	}
+	if table == "" {
+		table = DefaultLedgerTable
+	}
+	return migrationsDir, upSuffix, table
+}
+
 // Config is the parsed contents of dbtools.toml.
 type Config struct {
 	MigrationsDir string            `toml:"migrations_dir"`
@@ -114,17 +141,9 @@ func Load(path string) (*Config, error) {
 	if err := toml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config %s: %w", path, err)
 	}
-	if cfg.MigrationsDir == "" {
-		cfg.MigrationsDir = "migrations"
-	}
-	if cfg.Ledger.Table == "" {
-		cfg.Ledger.Table = "dbtools_migration_history"
-	}
+	cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table = ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 	if err := ledger.ValidateTableName(cfg.Ledger.Table); err != nil {
 		return nil, fmt.Errorf("dbtools.toml: %w", err)
-	}
-	if cfg.Migrations.UpSuffix == "" {
-		cfg.Migrations.UpSuffix = ".up.sql"
 	}
 	// Default exclude list to internal tool tables unless the key was set at all
 	// (including explicitly to an empty list, which means "exclude nothing").

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,21 @@ type ContainerConfig struct {
 	Port int `toml:"port"`
 }
 
+// LedgerConfig configures the migration-ledger table dbtools reads and writes.
+type LedgerConfig struct {
+	// Table overrides the ledger table name — set this to coexist with an
+	// incumbent migration tool's table (e.g. "schema_migrations") instead
+	// of dbtools' own "dbtools_migration_history".
+	Table string `toml:"table"`
+}
+
+// MigrationsConfig configures how migration files on disk are recognized.
+type MigrationsConfig struct {
+	// UpSuffix overrides the up-migration filename suffix (default
+	// ".up.sql"). Set to ".sql" for a flat "<version>_<name>.sql" layout.
+	UpSuffix string `toml:"up_suffix"`
+}
+
 // Config is the parsed contents of dbtools.toml.
 type Config struct {
 	MigrationsDir string            `toml:"migrations_dir"`
@@ -84,6 +99,8 @@ type Config struct {
 	Clone         CloneConfig       `toml:"clone"`
 	Project       ProjectConfig     `toml:"project"`
 	Container     ContainerConfig   `toml:"container"`
+	Ledger        LedgerConfig      `toml:"ledger"`
+	Migrations    MigrationsConfig  `toml:"migrations"`
 }
 
 // Load reads and parses the dbtools.toml file at path.
@@ -98,6 +115,12 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.MigrationsDir == "" {
 		cfg.MigrationsDir = "migrations"
+	}
+	if cfg.Ledger.Table == "" {
+		cfg.Ledger.Table = "dbtools_migration_history"
+	}
+	if cfg.Migrations.UpSuffix == "" {
+		cfg.Migrations.UpSuffix = ".up.sql"
 	}
 	// Default exclude list to internal tool tables unless the key was set at all
 	// (including explicitly to an empty list, which means "exclude nothing").

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -228,3 +228,48 @@ url_env = "L_URL"
 		t.Errorf("Container.Port = %d, want 0 (meaning: let Docker assign a port)", cfg.Container.Port)
 	}
 }
+
+func TestLoad_DefaultsLedgerTableAndUpSuffix(t *testing.T) {
+	path := writeTemp(t, `
+migrations_dir = "migrations"
+
+[targets.local]
+url_env = "L_URL"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.Ledger.Table != "dbtools_migration_history" {
+		t.Errorf("Ledger.Table = %q, want default", cfg.Ledger.Table)
+	}
+	if cfg.Migrations.UpSuffix != ".up.sql" {
+		t.Errorf("Migrations.UpSuffix = %q, want default", cfg.Migrations.UpSuffix)
+	}
+}
+
+func TestLoad_OverridesLedgerTableAndUpSuffix(t *testing.T) {
+	path := writeTemp(t, `
+migrations_dir = "migrations"
+
+[ledger]
+table = "schema_migrations"
+
+[migrations]
+up_suffix = ".sql"
+
+[targets.local]
+url_env = "L_URL"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.Ledger.Table != "schema_migrations" {
+		t.Errorf("Ledger.Table = %q, want override", cfg.Ledger.Table)
+	}
+	if cfg.Migrations.UpSuffix != ".sql" {
+		t.Errorf("Migrations.UpSuffix = %q, want override", cfg.Migrations.UpSuffix)
+	}
+}
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,28 @@ func TestResolveDefaults_FillsOnlyEmptyValues(t *testing.T) {
 	}
 }
 
+func TestLoad_GenerateExcludeIncludesCustomLedgerTable(t *testing.T) {
+	path := writeTemp(t, `
+[targets.local]
+url_env = "DBTOOLS_LOCAL_URL"
+[ledger]
+table = "my_custom_history"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	found := false
+	for _, name := range cfg.Generate.Exclude {
+		if name == "my_custom_history" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Generate.Exclude = %v, want it to contain the custom ledger table %q", cfg.Generate.Exclude, "my_custom_history")
+	}
+}
+
 func TestLoad_ExplicitMigrationsDir(t *testing.T) {
 	path := writeTemp(t, `
 migrations_dir = "db/migrations"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -273,3 +273,15 @@ url_env = "L_URL"
 	}
 }
 
+func TestLoad_RejectsInvalidLedgerTableName(t *testing.T) {
+	path := writeTemp(t, `
+migrations_dir = "migrations"
+[ledger]
+table = "bad; drop table users"
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load() with invalid ledger table name: want error, got nil")
+	}
+}
+
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -283,5 +283,3 @@ table = "bad; drop table users"
 		t.Fatal("Load() with invalid ledger table name: want error, got nil")
 	}
 }
-
-

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,18 @@ url_env = "DBTOOLS_LOCAL_URL"
 	}
 }
 
+func TestResolveDefaults_FillsOnlyEmptyValues(t *testing.T) {
+	dir, suffix, table := ResolveDefaults("", "", "")
+	if dir != DefaultMigrationsDir || suffix != DefaultUpSuffix || table != DefaultLedgerTable {
+		t.Errorf("ResolveDefaults(\"\", \"\", \"\") = (%q, %q, %q), want the three defaults", dir, suffix, table)
+	}
+
+	dir, suffix, table = ResolveDefaults("db/migrations", ".sql", "schema_migrations")
+	if dir != "db/migrations" || suffix != ".sql" || table != "schema_migrations" {
+		t.Errorf("ResolveDefaults with all set = (%q, %q, %q), want inputs unchanged", dir, suffix, table)
+	}
+}
+
 func TestLoad_ExplicitMigrationsDir(t *testing.T) {
 	path := writeTemp(t, `
 migrations_dir = "db/migrations"

--- a/internal/dashboard/rows.go
+++ b/internal/dashboard/rows.go
@@ -41,4 +41,3 @@ func BuildRows(cfg *config.Config, collect CollectFunc) []Row {
 	}
 	return rows
 }
-

--- a/internal/dashboard/rows.go
+++ b/internal/dashboard/rows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/seanpham99/dbtools/internal/statusinfo"
 )
 
-type CollectFunc func(databaseURL, migrationsDir, targetName string) (*statusinfo.Status, error)
+type CollectFunc func(databaseURL, migrationsDir, upSuffix, targetName string) (*statusinfo.Status, error)
 
 type Row struct {
 	Target string
@@ -31,7 +31,7 @@ func BuildRows(cfg *config.Config, collect CollectFunc) []Row {
 			continue
 		}
 
-		status, err := collect(url, cfg.MigrationsDir, name)
+		status, err := collect(url, cfg.MigrationsDir, cfg.Migrations.UpSuffix, name)
 		if err != nil {
 			rows = append(rows, Row{Target: name, Err: err})
 			continue
@@ -41,3 +41,4 @@ func BuildRows(cfg *config.Config, collect CollectFunc) []Row {
 	}
 	return rows
 }
+

--- a/internal/dashboard/rows_guard_test.go
+++ b/internal/dashboard/rows_guard_test.go
@@ -21,7 +21,7 @@ func TestBuildRows_RejectsEngineSchemeMismatchWithoutDialing(t *testing.T) {
 	}
 
 	called := false
-	rows := BuildRows(cfg, func(url, dir, name string) (*statusinfo.Status, error) {
+	rows := BuildRows(cfg, func(url, dir, upSuffix, name string) (*statusinfo.Status, error) {
 		called = true
 		return nil, nil
 	})

--- a/internal/dashboard/rows_test.go
+++ b/internal/dashboard/rows_test.go
@@ -22,7 +22,7 @@ func TestBuildRows_MixedSuccessAndErrors(t *testing.T) {
 	}
 	t.Setenv("DASHBOARD_TEST_PROD_URL_UNUSED", "mssql://sa:pw@localhost:1433?database=y")
 
-	fakeCollect := func(databaseURL, migrationsDir, targetName string) (*statusinfo.Status, error) {
+	fakeCollect := func(databaseURL, migrationsDir, upSuffix, targetName string) (*statusinfo.Status, error) {
 		if targetName == "prod" {
 			return nil, errors.New("connection refused")
 		}
@@ -57,7 +57,7 @@ func TestBuildRows_MixedSuccessAndErrors(t *testing.T) {
 
 func TestBuildRows_EmptyConfig(t *testing.T) {
 	cfg := &config.Config{MigrationsDir: "migrations", Targets: map[string]config.Target{}}
-	rows := BuildRows(cfg, func(string, string, string) (*statusinfo.Status, error) {
+	rows := BuildRows(cfg, func(string, string, string, string) (*statusinfo.Status, error) {
 		t.Fatal("collect should not be called when there are no targets")
 		return nil, nil
 	})

--- a/internal/down/down.go
+++ b/internal/down/down.go
@@ -30,18 +30,7 @@ func Preview(cfg *config.Config, targetName string, steps int, urlOverride strin
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	migrationsDir := cfg.MigrationsDir
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	upSuffix := cfg.Migrations.UpSuffix
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	ledgerTable := cfg.Ledger.Table
-	if ledgerTable == "" {
-		ledgerTable = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
 	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
@@ -85,18 +74,7 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	migrationsDir := cfg.MigrationsDir
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	upSuffix := cfg.Migrations.UpSuffix
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	ledgerTable := cfg.Ledger.Table
-	if ledgerTable == "" {
-		ledgerTable = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
 	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {

--- a/internal/down/down.go
+++ b/internal/down/down.go
@@ -42,11 +42,11 @@ func Preview(cfg *config.Config, targetName string, steps int, urlOverride strin
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -84,11 +84,11 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir)
+	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}

--- a/internal/down/down.go
+++ b/internal/down/down.go
@@ -30,7 +30,20 @@ func Preview(cfg *config.Config, targetName string, steps int, urlOverride strin
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	m, err := migrator.Open(url, cfg.MigrationsDir)
+	migrationsDir := cfg.MigrationsDir
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	upSuffix := cfg.Migrations.UpSuffix
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	ledgerTable := cfg.Ledger.Table
+	if ledgerTable == "" {
+		ledgerTable = "dbtools_migration_history"
+	}
+
+	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -42,16 +55,16 @@ func Preview(cfg *config.Config, targetName string, steps int, urlOverride strin
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	applied, err := eng.Ledger().AppliedVersions(db)
+	applied, err := eng.Ledger().AppliedVersions(db, ledgerTable)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -72,7 +85,20 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	m, err := migrator.Open(url, cfg.MigrationsDir)
+	migrationsDir := cfg.MigrationsDir
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	upSuffix := cfg.Migrations.UpSuffix
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	ledgerTable := cfg.Ledger.Table
+	if ledgerTable == "" {
+		ledgerTable = "dbtools_migration_history"
+	}
+
+	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +110,11 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	dir, err := migrator.ReadDir(cfg.MigrationsDir, cfg.Migrations.UpSuffix)
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -101,7 +127,7 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 		return nil, fmt.Errorf("target %q: migration cursor is dirty at version %d; run `dbtools repair %s` to resolve it", targetName, versionBefore, targetName)
 	}
 
-	applied, err := eng.Ledger().AppliedVersions(db)
+	applied, err := eng.Ledger().AppliedVersions(db, ledgerTable)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -135,7 +161,7 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 			return nil, fmt.Errorf("target %q: %w", targetName, err)
 		}
 
-		if err := eng.Ledger().SetStatusWithHash(db, f.Version, ledger.StatusReverted, "reverted via down", hash); err != nil {
+		if err := eng.Ledger().SetStatusWithHash(db, f.Version, ledger.StatusReverted, "reverted via down", hash, ledgerTable); err != nil {
 			return nil, fmt.Errorf("target %q: %w", targetName, err)
 		}
 		reverted = append(reverted, f.Version)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -66,6 +66,12 @@ type LedgerStore interface {
 	// version the migrate cursor already considers applied. Refuses to
 	// backfill when the cursor is dirty.
 	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error
+	// EnsureSchema creates table if it doesn't already exist (idempotent),
+	// without touching any row. Callers that must not backfill —
+	// `dbtools adopt`, so a pre-existing migrate cursor never gets
+	// silently recorded with an unverified hash — call this instead of
+	// Sync.
+	EnsureSchema(db ledger.DBTX, table string) error
 	// SetStatus upserts version's ledger row, preserving content_sha256
 	// when the row already exists.
 	SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -65,7 +65,7 @@ type LedgerStore interface {
 	// Sync ensures the ledger table exists and backfills a row for every
 	// version the migrate cursor already considers applied. Refuses to
 	// backfill when the cursor is dirty.
-	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error
+	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error
 	// SetStatus upserts version's ledger row, preserving content_sha256
 	// when the row already exists.
 	SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -73,6 +73,12 @@ type LedgerStore interface {
 	// file's content hash, so verify can detect edits after apply. Used by
 	// the apply path only.
 	SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error
+	// SetStatusAdopted records version as applied with hash_source
+	// "adopted": the content hash is stored for reference but never
+	// compared against — the row's actual apply-time content was never
+	// observed by dbtools, only inferred from the file's current state at
+	// adopt time. Used by `dbtools adopt` only.
+	SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error
 	List(db ledger.DBTX, table string) ([]ledger.Entry, error)
 	AppliedVersions(db ledger.DBTX, table string) ([]uint64, error)
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -65,16 +65,16 @@ type LedgerStore interface {
 	// Sync ensures the ledger table exists and backfills a row for every
 	// version the migrate cursor already considers applied. Refuses to
 	// backfill when the cursor is dirty.
-	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error
+	Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error
 	// SetStatus upserts version's ledger row, preserving content_sha256
 	// when the row already exists.
-	SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error
+	SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error
 	// SetStatusWithHash is SetStatus plus recording the applied migration
 	// file's content hash, so verify can detect edits after apply. Used by
 	// the apply path only.
-	SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error
-	List(db ledger.DBTX) ([]ledger.Entry, error)
-	AppliedVersions(db ledger.DBTX) ([]uint64, error)
+	SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error
+	List(db ledger.DBTX, table string) ([]ledger.Entry, error)
+	AppliedVersions(db ledger.DBTX, table string) ([]uint64, error)
 }
 
 var registry = map[string]Engine{}

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -150,7 +150,7 @@ func AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 }
 
 // Sync ensures MSSQL db's ledger table exists and is backfilled.
-func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
+func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
 	if err := EnsureSchema(db); err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
 	if dirty {
 		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair %s` to resolve it before syncing the ledger", version, "target")
 	}
-	allVersions, err := migrator.ListVersions(migrationsDir)
+	allVersions, err := migrator.ListVersions(migrationsDir, upSuffix)
 	if err != nil {
 		return err
 	}
@@ -170,8 +170,8 @@ func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
 
 type mssqlLedgerStore struct{}
 
-func (mssqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
-	return Sync(db, m, migrationsDir)
+func (mssqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
+	return Sync(db, m, migrationsDir, upSuffix)
 }
 
 func (mssqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -223,4 +223,3 @@ func (mssqlLedgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64,
 }
 
 var _ engine.LedgerStore = mssqlLedgerStore{}
-

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -19,13 +19,21 @@ BEGIN
         status          VARCHAR(10)   NOT NULL CHECK (status IN ('applied', 'reverted')),
         recorded_at     DATETIME2(0)  NULL,
         note            NVARCHAR(400) NULL,
-        content_sha256  CHAR(64)      NULL
+        content_sha256  CHAR(64)      NULL,
+        hash_source     VARCHAR(20)   NULL
     );
 END;
-ELSE IF COL_LENGTH(N'%s', N'content_sha256') IS NULL
+ELSE
 BEGIN
-    ALTER TABLE %s ADD content_sha256 CHAR(64) NULL;
-END;`, table, table, table, table))
+    IF COL_LENGTH(N'%s', N'content_sha256') IS NULL
+    BEGIN
+        ALTER TABLE %s ADD content_sha256 CHAR(64) NULL;
+    END;
+    IF COL_LENGTH(N'%s', N'hash_source') IS NULL
+    BEGIN
+        ALTER TABLE %s ADD hash_source VARCHAR(20) NULL;
+    END;
+END;`, table, table, table, table, table, table))
 	if err != nil {
 		return fmt.Errorf("ensuring %s schema: %w", table, err)
 	}
@@ -100,9 +108,28 @@ ELSE
 	return nil
 }
 
+// SetStatusAdopted records version as applied with hash_source "adopted".
+func SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(fmt.Sprintf(`
+IF EXISTS (SELECT 1 FROM %s WITH (HOLDLOCK) WHERE version = @p1)
+    UPDATE %s
+    SET status = 'applied', recorded_at = SYSUTCDATETIME(), note = @p2, content_sha256 = @p3, hash_source = 'adopted'
+    WHERE version = @p1
+ELSE
+    INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
+    VALUES (@p1, 'applied', SYSUTCDATETIME(), @p2, @p3, 'adopted');`, table, table, table), int64(version), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row in MSSQL, ordered by version ascending.
 func List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
-	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256, hash_source FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -114,8 +141,8 @@ func List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note, contentHash sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
+		var note, contentHash, hashSource sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash, &hashSource); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -129,6 +156,7 @@ func List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		}
 		e.Note = note.String
 		e.ContentSHA256 = contentHash.String
+		e.HashSource = hashSource.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -180,6 +208,10 @@ func (mssqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.
 
 func (mssqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
 	return SetStatusWithHash(db, version, status, note, contentHash, table)
+}
+
+func (mssqlLedgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
+	return SetStatusAdopted(db, version, note, contentHash, table)
 }
 
 func (mssqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -116,11 +116,11 @@ func SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table s
 	_, err := db.Exec(fmt.Sprintf(`
 IF EXISTS (SELECT 1 FROM %s WITH (HOLDLOCK) WHERE version = @p1)
     UPDATE %s
-    SET status = 'applied', recorded_at = SYSUTCDATETIME(), note = @p2, content_sha256 = @p3, hash_source = 'adopted'
+    SET status = 'applied', recorded_at = SYSUTCDATETIME(), note = @p2, content_sha256 = @p3, hash_source = @p4
     WHERE version = @p1
 ELSE
     INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
-    VALUES (@p1, 'applied', SYSUTCDATETIME(), @p2, @p3, 'adopted');`, table, table, table), int64(version), note, contentHash)
+    VALUES (@p1, 'applied', SYSUTCDATETIME(), @p2, @p3, @p4);`, table, table, table), int64(version), note, contentHash, ledger.HashSourceAdopted)
 	if err != nil {
 		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
 	}
@@ -197,6 +197,10 @@ func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table strin
 }
 
 type mssqlLedgerStore struct{}
+
+func (mssqlLedgerStore) EnsureSchema(db ledger.DBTX, table string) error {
+	return EnsureSchema(db, table)
+}
 
 func (mssqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
 	return Sync(db, m, migrationsDir, upSuffix, table)

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -9,12 +9,12 @@ import (
 	"github.com/seanpham99/dbtools/internal/migrator"
 )
 
-// EnsureSchema creates dbtools_migration_history if it doesn't already exist.
-func EnsureSchema(db ledger.DBTX) error {
-	_, err := db.Exec(`
-IF OBJECT_ID(N'dbtools_migration_history', N'U') IS NULL
+// EnsureSchema creates table if it doesn't already exist.
+func EnsureSchema(db ledger.DBTX, table string) error {
+	_, err := db.Exec(fmt.Sprintf(`
+IF OBJECT_ID(N'%s', N'U') IS NULL
 BEGIN
-    CREATE TABLE dbtools_migration_history (
+    CREATE TABLE %s (
         version         BIGINT        NOT NULL PRIMARY KEY,
         status          VARCHAR(10)   NOT NULL CHECK (status IN ('applied', 'reverted')),
         recorded_at     DATETIME2(0)  NULL,
@@ -22,12 +22,12 @@ BEGIN
         content_sha256  CHAR(64)      NULL
     );
 END;
-ELSE IF COL_LENGTH(N'dbtools_migration_history', N'content_sha256') IS NULL
+ELSE IF COL_LENGTH(N'%s', N'content_sha256') IS NULL
 BEGIN
-    ALTER TABLE dbtools_migration_history ADD content_sha256 CHAR(64) NULL;
-END;`)
+    ALTER TABLE %s ADD content_sha256 CHAR(64) NULL;
+END;`, table, table, table, table))
 	if err != nil {
-		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+		return fmt.Errorf("ensuring %s schema: %w", table, err)
 	}
 	return nil
 }
@@ -40,7 +40,7 @@ func checkVersionRange(version uint64) error {
 }
 
 // Backfill inserts an "applied" row for every version <= currentVersion.
-func Backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64) error {
+func Backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64, table string) error {
 	if !hasVersion {
 		return nil
 	}
@@ -51,10 +51,10 @@ func Backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersion
 		if err := checkVersionRange(v); err != nil {
 			return err
 		}
-		_, err := db.Exec(`
-IF NOT EXISTS (SELECT 1 FROM dbtools_migration_history WHERE version = @p1)
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
-VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, int64(v))
+		_, err := db.Exec(fmt.Sprintf(`
+IF NOT EXISTS (SELECT 1 FROM %s WHERE version = @p1)
+INSERT INTO %s (version, status, recorded_at, note)
+VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, table, table), int64(v))
 		if err != nil {
 			return fmt.Errorf("backfilling version %d: %w", v, err)
 		}
@@ -63,18 +63,18 @@ VALUES (@p1, 'applied', NULL, 'backfilled: applied before ledger existed');`, in
 }
 
 // SetStatus upserts version's ledger row.
-func SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
+func SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-IF EXISTS (SELECT 1 FROM dbtools_migration_history WITH (HOLDLOCK) WHERE version = @p1)
-    UPDATE dbtools_migration_history
+	_, err := db.Exec(fmt.Sprintf(`
+IF EXISTS (SELECT 1 FROM %s WITH (HOLDLOCK) WHERE version = @p1)
+    UPDATE %s
     SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3
     WHERE version = @p1
 ELSE
-    INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
-    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3);`, int64(version), string(status), note)
+    INSERT INTO %s (version, status, recorded_at, note)
+    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3);`, table, table, table), int64(version), string(status), note)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
 	}
@@ -82,18 +82,18 @@ ELSE
 }
 
 // SetStatusWithHash is SetStatus plus recording the migration file's content hash.
-func SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+func SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-IF EXISTS (SELECT 1 FROM dbtools_migration_history WITH (HOLDLOCK) WHERE version = @p1)
-    UPDATE dbtools_migration_history
+	_, err := db.Exec(fmt.Sprintf(`
+IF EXISTS (SELECT 1 FROM %s WITH (HOLDLOCK) WHERE version = @p1)
+    UPDATE %s
     SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3
     WHERE version = @p1
 ELSE
-    INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
-    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3, @p4);`, int64(version), string(status), note, contentHash)
+    INSERT INTO %s (version, status, recorded_at, note, content_sha256)
+    VALUES (@p1, @p2, SYSUTCDATETIME(), @p3, @p4);`, table, table, table), int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
 	}
@@ -101,8 +101,8 @@ ELSE
 }
 
 // List returns every ledger row in MSSQL, ordered by version ascending.
-func List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
+func List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -135,8 +135,8 @@ func List(db ledger.DBTX) ([]ledger.Entry, error) {
 }
 
 // AppliedVersions returns every version currently marked "applied", ascending.
-func AppliedVersions(db ledger.DBTX) ([]uint64, error) {
-	entries, err := List(db)
+func AppliedVersions(db ledger.DBTX, table string) ([]uint64, error) {
+	entries, err := List(db, table)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +150,8 @@ func AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 }
 
 // Sync ensures MSSQL db's ledger table exists and is backfilled.
-func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
-	if err := EnsureSchema(db); err != nil {
+func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
+	if err := EnsureSchema(db, table); err != nil {
 		return err
 	}
 	version, dirty, hasVersion, err := m.Version()
@@ -165,29 +165,30 @@ func Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) erro
 	if err != nil {
 		return err
 	}
-	return Backfill(db, version, hasVersion, allVersions)
+	return Backfill(db, version, hasVersion, allVersions, table)
 }
 
 type mssqlLedgerStore struct{}
 
-func (mssqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
-	return Sync(db, m, migrationsDir, upSuffix)
+func (mssqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
+	return Sync(db, m, migrationsDir, upSuffix, table)
 }
 
-func (mssqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
-	return SetStatus(db, version, status, note)
+func (mssqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error {
+	return SetStatus(db, version, status, note, table)
 }
 
-func (mssqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
-	return SetStatusWithHash(db, version, status, note, contentHash)
+func (mssqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
+	return SetStatusWithHash(db, version, status, note, contentHash, table)
 }
 
-func (mssqlLedgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	return List(db)
+func (mssqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
+	return List(db, table)
 }
 
-func (mssqlLedgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
-	return AppliedVersions(db)
+func (mssqlLedgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, error) {
+	return AppliedVersions(db, table)
 }
 
 var _ engine.LedgerStore = mssqlLedgerStore{}
+

--- a/internal/engine/mssqlengine/ledger.go
+++ b/internal/engine/mssqlengine/ledger.go
@@ -97,7 +97,7 @@ func SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, not
 	_, err := db.Exec(fmt.Sprintf(`
 IF EXISTS (SELECT 1 FROM %s WITH (HOLDLOCK) WHERE version = @p1)
     UPDATE %s
-    SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3
+    SET status = @p2, recorded_at = SYSUTCDATETIME(), note = @p3, content_sha256 = @p4, hash_source = ''
     WHERE version = @p1
 ELSE
     INSERT INTO %s (version, status, recorded_at, note, content_sha256)

--- a/internal/engine/mssqlengine/ledger_integration_test.go
+++ b/internal/engine/mssqlengine/ledger_integration_test.go
@@ -33,25 +33,25 @@ func openTestDB(t *testing.T) *sql.DB {
 func TestEnsureSchema_Idempotent(t *testing.T) {
 	db := openTestDB(t)
 
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("EnsureSchema() returned error: %v", err)
 	}
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("second EnsureSchema() returned error: %v", err)
 	}
 }
 
 func TestBackfillAndList(t *testing.T) {
 	db := openTestDB(t)
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Backfill(db, 20260102000000, true, []uint64{20260101000000, 20260102000000, 20260103000000}); err != nil {
+	if err := Backfill(db, 20260102000000, true, []uint64{20260101000000, 20260102000000, 20260103000000}, "dbtools_migration_history"); err != nil {
 		t.Fatalf("Backfill() returned error: %v", err)
 	}
 
-	entries, err := List(db)
+	entries, err := List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("List() returned error: %v", err)
 	}
@@ -71,13 +71,13 @@ func TestBackfillAndList(t *testing.T) {
 
 func TestBackfill_NoVersionYet(t *testing.T) {
 	db := openTestDB(t)
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := Backfill(db, 0, false, []uint64{20260101000000}); err != nil {
+	if err := Backfill(db, 0, false, []uint64{20260101000000}, "dbtools_migration_history"); err != nil {
 		t.Fatalf("Backfill() returned error: %v", err)
 	}
-	entries, err := List(db)
+	entries, err := List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,14 +88,14 @@ func TestBackfill_NoVersionYet(t *testing.T) {
 
 func TestSetStatusInsertsAndUpdates(t *testing.T) {
 	db := openTestDB(t)
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := SetStatus(db, 20260101000000, ledger.StatusApplied, "test insert"); err != nil {
+	if err := SetStatus(db, 20260101000000, ledger.StatusApplied, "test insert", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus() (insert) returned error: %v", err)
 	}
-	entries, err := List(db)
+	entries, err := List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,10 +103,10 @@ func TestSetStatusInsertsAndUpdates(t *testing.T) {
 		t.Fatalf("after insert: entries = %+v, want one applied row with non-nil RecordedAt", entries)
 	}
 
-	if err := SetStatus(db, 20260101000000, ledger.StatusReverted, "test update"); err != nil {
+	if err := SetStatus(db, 20260101000000, ledger.StatusReverted, "test update", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus() (update) returned error: %v", err)
 	}
-	entries, err = List(db)
+	entries, err = List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,20 +117,20 @@ func TestSetStatusInsertsAndUpdates(t *testing.T) {
 
 func TestAppliedVersions(t *testing.T) {
 	db := openTestDB(t)
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := SetStatus(db, 20260101000000, ledger.StatusApplied, ""); err != nil {
+	if err := SetStatus(db, 20260101000000, ledger.StatusApplied, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := SetStatus(db, 20260102000000, ledger.StatusReverted, ""); err != nil {
+	if err := SetStatus(db, 20260102000000, ledger.StatusReverted, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := SetStatus(db, 20260103000000, ledger.StatusApplied, ""); err != nil {
+	if err := SetStatus(db, 20260103000000, ledger.StatusApplied, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	versions, err := AppliedVersions(db)
+	versions, err := AppliedVersions(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("AppliedVersions() returned error: %v", err)
 	}
@@ -174,11 +174,11 @@ func TestSync(t *testing.T) {
 	}
 	defer db.Close()
 
-	if err := Sync(db, m, dir); err != nil {
+	if err := Sync(db, m, dir, ".up.sql", "dbtools_migration_history"); err != nil {
 		t.Fatalf("Sync() returned error: %v", err)
 	}
 
-	entries, err := List(db)
+	entries, err := List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("List() returned error: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestSync(t *testing.T) {
 
 func TestSetStatus_WithinTransaction(t *testing.T) {
 	db := openTestDB(t)
-	if err := EnsureSchema(db); err != nil {
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,17 +202,17 @@ func TestSetStatus_WithinTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("db.Begin() returned error: %v", err)
 	}
-	if err := SetStatus(tx, 20260101000000, ledger.StatusApplied, "via tx, committed"); err != nil {
+	if err := SetStatus(tx, 20260101000000, ledger.StatusApplied, "via tx, committed", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus() within tx returned error: %v", err)
 	}
-	if _, err := AppliedVersions(tx); err != nil {
+	if _, err := AppliedVersions(tx, "dbtools_migration_history"); err != nil {
 		t.Fatalf("AppliedVersions() within tx returned error: %v", err)
 	}
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("tx.Commit() returned error: %v", err)
 	}
 
-	versions, err := AppliedVersions(db)
+	versions, err := AppliedVersions(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,14 +224,14 @@ func TestSetStatus_WithinTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("db.Begin() returned error: %v", err)
 	}
-	if err := SetStatus(tx2, 20260102000000, ledger.StatusApplied, "via tx, rolled back"); err != nil {
+	if err := SetStatus(tx2, 20260102000000, ledger.StatusApplied, "via tx, rolled back", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus() within tx2 returned error: %v", err)
 	}
 	if err := tx2.Rollback(); err != nil {
 		t.Fatalf("tx2.Rollback() returned error: %v", err)
 	}
 
-	versions, err = AppliedVersions(db)
+	versions, err = AppliedVersions(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/mssqlengine/ledger_integration_test.go
+++ b/internal/engine/mssqlengine/ledger_integration_test.go
@@ -198,7 +198,7 @@ func TestSetStatusAdopted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := SetStatusAdopted(db, 20260101000000, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+	if err := SetStatusAdopted(db, 20260101000000, "adopted from schema_migrations", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() returned error: %v", err)
 	}
 
@@ -216,8 +216,8 @@ func TestSetStatusAdopted(t *testing.T) {
 	if e.HashSource != ledger.HashSourceAdopted {
 		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
 	}
-	if e.ContentSHA256 != "abc123" {
-		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	if e.ContentSHA256 != "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" {
+		t.Errorf("ContentSHA256 = %q, want the expected hash", e.ContentSHA256)
 	}
 }
 
@@ -250,7 +250,7 @@ CREATE TABLE dbtools_migration_history (
 	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("EnsureSchema() on preexisting table returned error: %v", err)
 	}
-	if err := SetStatusAdopted(db, 20260101000000, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+	if err := SetStatusAdopted(db, 20260101000000, "adopted", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() after EnsureSchema migration returned error: %v", err)
 	}
 }

--- a/internal/engine/mssqlengine/ledger_integration_test.go
+++ b/internal/engine/mssqlengine/ledger_integration_test.go
@@ -192,6 +192,69 @@ func TestSync(t *testing.T) {
 	}
 }
 
+func TestSetStatusAdopted(t *testing.T) {
+	db := openTestDB(t)
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetStatusAdopted(db, 20260101000000, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() returned error: %v", err)
+	}
+
+	entries, err := List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Status != ledger.StatusApplied {
+		t.Errorf("Status = %q, want applied", e.Status)
+	}
+	if e.HashSource != ledger.HashSourceAdopted {
+		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
+	}
+	if e.ContentSHA256 != "abc123" {
+		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	}
+}
+
+func TestEnsureSchema_AddsHashSourceToPreexistingTable(t *testing.T) {
+	url := os.Getenv("DBTOOLS_TEST_MSSQL_URL")
+	if url == "" {
+		t.Skip("DBTOOLS_TEST_MSSQL_URL not set, skipping integration test")
+	}
+	if err := testdb.ResetTracking(url); err != nil {
+		t.Fatal(err)
+	}
+	db, err := Open(url)
+	if err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	defer db.Close()
+
+	// Simulate a table created before hash_source existed: the original
+	// schema, minus both content_sha256 and hash_source.
+	if _, err := db.Exec(`
+CREATE TABLE dbtools_migration_history (
+    version     BIGINT       NOT NULL PRIMARY KEY,
+    status      VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
+    recorded_at DATETIME2(0) NULL,
+    note        NVARCHAR(400) NULL
+)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatalf("EnsureSchema() on preexisting table returned error: %v", err)
+	}
+	if err := SetStatusAdopted(db, 20260101000000, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() after EnsureSchema migration returned error: %v", err)
+	}
+}
+
 func TestSetStatus_WithinTransaction(t *testing.T) {
 	db := openTestDB(t)
 	if err := EnsureSchema(db, "dbtools_migration_history"); err != nil {

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -113,7 +113,7 @@ func (mysqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status
 	_, err := db.Exec(fmt.Sprintf(`
 INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES (?, ?, NOW(), ?, ?)
-ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256)`, table),
+ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256), hash_source = ''`, table),
 		int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -13,33 +13,33 @@ import (
 // ledger. Semantics match internal/ledger exactly — only the SQL differs.
 type mysqlLedgerStore struct{}
 
-func (mysqlLedgerStore) ensureSchema(db ledger.DBTX) error {
-	_, err := db.Exec(`
-CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+func (mysqlLedgerStore) ensureSchema(db ledger.DBTX, table string) error {
+	_, err := db.Exec(fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
     version         BIGINT       NOT NULL PRIMARY KEY,
     status          VARCHAR(10)  NOT NULL,
     recorded_at     DATETIME     NULL,
     note            VARCHAR(400) NULL,
     content_sha256  CHAR(64)     NULL,
     CHECK (status IN ('applied', 'reverted'))
-) ENGINE=InnoDB`)
+) ENGINE=InnoDB`, table))
 	if err != nil {
-		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+		return fmt.Errorf("ensuring %s schema: %w", table, err)
 	}
 	// Column added by dbtools builds before content hashing existed.
 	// MySQL's "ADD COLUMN IF NOT EXISTS" is version-gated (8.0.29+), so
 	// check information_schema first for broader compatibility — same
 	// approach as sqliteengine's pragma_table_info check.
-	cols, err := db.Query(`
+	cols, err := db.Query(fmt.Sprintf(`
 SELECT COLUMN_NAME FROM information_schema.columns
-WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'dbtools_migration_history' AND COLUMN_NAME = 'content_sha256'`)
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = 'content_sha256'`, table))
 	if err != nil {
-		return fmt.Errorf("inspecting dbtools_migration_history columns: %w", err)
+		return fmt.Errorf("inspecting %s columns: %w", table, err)
 	}
 	defer cols.Close()
 	if !cols.Next() {
-		if _, err := db.Exec(`ALTER TABLE dbtools_migration_history ADD COLUMN content_sha256 CHAR(64) NULL`); err != nil {
-			return fmt.Errorf("adding content_sha256 to dbtools_migration_history: %w", err)
+		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN content_sha256 CHAR(64) NULL`, table)); err != nil {
+			return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
 		}
 	}
 	return nil
@@ -52,7 +52,7 @@ func checkVersionRange(version uint64) error {
 	return nil
 }
 
-func (mysqlLedgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64) error {
+func (mysqlLedgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64, table string) error {
 	if !hasVersion {
 		return nil
 	}
@@ -63,9 +63,9 @@ func (mysqlLedgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersi
 		if err := checkVersionRange(v); err != nil {
 			return err
 		}
-		_, err := db.Exec(`
-INSERT IGNORE INTO dbtools_migration_history (version, status, recorded_at, note)
-VALUES (?, 'applied', NULL, 'backfilled: applied before ledger existed')`, int64(v))
+		_, err := db.Exec(fmt.Sprintf(`
+INSERT IGNORE INTO %s (version, status, recorded_at, note)
+VALUES (?, 'applied', NULL, 'backfilled: applied before ledger existed')`, table), int64(v))
 		if err != nil {
 			return fmt.Errorf("backfilling version %d: %w", v, err)
 		}
@@ -75,14 +75,14 @@ VALUES (?, 'applied', NULL, 'backfilled: applied before ledger existed')`, int64
 
 // SetStatus upserts version's ledger row, preserving content_sha256 on
 // update — the ON DUPLICATE KEY UPDATE clause deliberately omits it.
-func (mysqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
+func (mysqlLedgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note)
 VALUES (?, ?, NOW(), ?)
-ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note)`,
+ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note)`, table),
 		int64(version), string(status), note)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -92,14 +92,14 @@ ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_a
 
 // SetStatusWithHash is SetStatus plus recording the applied migration
 // file's content hash, so verify can detect edits after apply.
-func (mysqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+func (mysqlLedgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES (?, ?, NOW(), ?, ?)
-ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256)`,
+ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256)`, table),
 		int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -108,8 +108,8 @@ ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_a
 }
 
 // List returns every ledger row, ordered by version ascending.
-func (mysqlLedgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
+func (mysqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -142,8 +142,8 @@ func (mysqlLedgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 }
 
 // AppliedVersions returns every version currently marked "applied", ascending.
-func (s mysqlLedgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
-	entries, err := s.List(db)
+func (s mysqlLedgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, error) {
+	entries, err := s.List(db, table)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,8 @@ func (s mysqlLedgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 
 // Sync ensures MySQL db's ledger table exists and is backfilled. Refuses
 // to backfill when the cursor is dirty (a previous apply failed partway).
-func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
-	if err := s.ensureSchema(db); err != nil {
+func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
+	if err := s.ensureSchema(db, table); err != nil {
 		return err
 	}
 	version, dirty, hasVersion, err := m.Version()
@@ -173,6 +173,7 @@ func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, 
 	if err != nil {
 		return err
 	}
-	return s.backfill(db, version, hasVersion, allVersions)
+	return s.backfill(db, version, hasVersion, allVersions, table)
 }
+
 

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -158,7 +158,7 @@ func (s mysqlLedgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 
 // Sync ensures MySQL db's ledger table exists and is backfilled. Refuses
 // to backfill when the cursor is dirty (a previous apply failed partway).
-func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
+func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
 	if err := s.ensureSchema(db); err != nil {
 		return err
 	}
@@ -169,9 +169,10 @@ func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir s
 	if dirty {
 		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair <target>` to resolve it before syncing the ledger", version)
 	}
-	allVersions, err := migrator.ListVersions(migrationsDir)
+	allVersions, err := migrator.ListVersions(migrationsDir, upSuffix)
 	if err != nil {
 		return err
 	}
 	return s.backfill(db, version, hasVersion, allVersions)
 }
+

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -128,9 +128,9 @@ func (mysqlLedgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, c
 	}
 	_, err := db.Exec(fmt.Sprintf(`
 INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
-VALUES (?, 'applied', NOW(), ?, ?, 'adopted')
+VALUES (?, 'applied', NOW(), ?, ?, ?)
 ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256), hash_source = VALUES(hash_source)`, table),
-		int64(version), note, contentHash)
+		int64(version), note, contentHash, ledger.HashSourceAdopted)
 	if err != nil {
 		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
 	}
@@ -189,6 +189,10 @@ func (s mysqlLedgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint6
 
 // Sync ensures MySQL db's ledger table exists and is backfilled. Refuses
 // to backfill when the cursor is dirty (a previous apply failed partway).
+func (s mysqlLedgerStore) EnsureSchema(db ledger.DBTX, table string) error {
+	return s.ensureSchema(db, table)
+}
+
 func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
 	if err := s.ensureSchema(db, table); err != nil {
 		return err

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS %s (
     recorded_at     DATETIME     NULL,
     note            VARCHAR(400) NULL,
     content_sha256  CHAR(64)     NULL,
+    hash_source     VARCHAR(20)  NULL,
     CHECK (status IN ('applied', 'reverted'))
 ) ENGINE=InnoDB`, table))
 	if err != nil {
@@ -40,6 +41,19 @@ WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = 'content
 	if !cols.Next() {
 		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN content_sha256 CHAR(64) NULL`, table)); err != nil {
 			return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
+		}
+	}
+	// Column added for adopt command.
+	srcCols, err := db.Query(fmt.Sprintf(`
+SELECT COLUMN_NAME FROM information_schema.columns
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = 'hash_source'`, table))
+	if err != nil {
+		return fmt.Errorf("inspecting %s columns: %w", table, err)
+	}
+	defer srcCols.Close()
+	if !srcCols.Next() {
+		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN hash_source VARCHAR(20) NULL`, table)); err != nil {
+			return fmt.Errorf("adding hash_source to %s: %w", table, err)
 		}
 	}
 	return nil
@@ -107,9 +121,25 @@ ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_a
 	return nil
 }
 
+// SetStatusAdopted records version as applied with hash_source "adopted".
+func (mysqlLedgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
+VALUES (?, 'applied', NOW(), ?, ?, 'adopted')
+ON DUPLICATE KEY UPDATE status = VALUES(status), recorded_at = VALUES(recorded_at), note = VALUES(note), content_sha256 = VALUES(content_sha256), hash_source = VALUES(hash_source)`, table),
+		int64(version), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row, ordered by version ascending.
 func (mysqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
-	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256, hash_source FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -121,8 +151,8 @@ func (mysqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, erro
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note, contentHash sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
+		var note, contentHash, hashSource sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash, &hashSource); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -136,6 +166,7 @@ func (mysqlLedgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, erro
 		}
 		e.Note = note.String
 		e.ContentSHA256 = contentHash.String
+		e.HashSource = hashSource.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()

--- a/internal/engine/mysqlengine/ledger.go
+++ b/internal/engine/mysqlengine/ledger.go
@@ -206,5 +206,3 @@ func (s mysqlLedgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, 
 	}
 	return s.backfill(db, version, hasVersion, allVersions, table)
 }
-
-

--- a/internal/engine/mysqlengine/ledger_integration_test.go
+++ b/internal/engine/mysqlengine/ledger_integration_test.go
@@ -30,10 +30,10 @@ func openTestDB(t *testing.T) *sql.DB {
 func TestEnsureSchema_Idempotent(t *testing.T) {
 	db := openTestDB(t)
 	store := mysqlLedgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("ensureSchema() returned error: %v", err)
 	}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("second ensureSchema() returned error: %v", err)
 	}
 }
@@ -41,14 +41,14 @@ func TestEnsureSchema_Idempotent(t *testing.T) {
 func TestSetStatusInsertsAndUpdates(t *testing.T) {
 	db := openTestDB(t)
 	store := mysqlLedgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := store.SetStatus(db, 1, ledger.StatusApplied, "first"); err != nil {
+	if err := store.SetStatus(db, 1, ledger.StatusApplied, "first", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus(insert) returned error: %v", err)
 	}
-	entries, err := store.List(db)
+	entries, err := store.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,10 +56,10 @@ func TestSetStatusInsertsAndUpdates(t *testing.T) {
 		t.Fatalf("after insert: entries = %+v, want one applied row with non-nil RecordedAt", entries)
 	}
 
-	if err := store.SetStatus(db, 1, ledger.StatusReverted, "second"); err != nil {
+	if err := store.SetStatus(db, 1, ledger.StatusReverted, "second", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus(update) returned error: %v", err)
 	}
-	entries, err = store.List(db)
+	entries, err = store.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,16 +71,16 @@ func TestSetStatusInsertsAndUpdates(t *testing.T) {
 func TestSetStatusWithHashPreservesHashOnPlainUpdate(t *testing.T) {
 	db := openTestDB(t)
 	store := mysqlLedgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetStatusWithHash(db, 1, ledger.StatusApplied, "with hash", "deadbeef"); err != nil {
+	if err := store.SetStatusWithHash(db, 1, ledger.StatusApplied, "with hash", "deadbeef", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetStatus(db, 1, ledger.StatusApplied, "touched again"); err != nil {
+	if err := store.SetStatus(db, 1, ledger.StatusApplied, "touched again", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := store.List(db)
+	entries, err := store.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,19 +92,19 @@ func TestSetStatusWithHashPreservesHashOnPlainUpdate(t *testing.T) {
 func TestAppliedVersions(t *testing.T) {
 	db := openTestDB(t)
 	store := mysqlLedgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetStatus(db, 1, ledger.StatusApplied, ""); err != nil {
+	if err := store.SetStatus(db, 1, ledger.StatusApplied, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetStatus(db, 2, ledger.StatusReverted, ""); err != nil {
+	if err := store.SetStatus(db, 2, ledger.StatusReverted, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetStatus(db, 3, ledger.StatusApplied, ""); err != nil {
+	if err := store.SetStatus(db, 3, ledger.StatusApplied, "", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	versions, err := store.AppliedVersions(db)
+	versions, err := store.AppliedVersions(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/mysqlengine/ledger_integration_test.go
+++ b/internal/engine/mysqlengine/ledger_integration_test.go
@@ -96,7 +96,7 @@ func TestSetStatusAdopted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() returned error: %v", err)
 	}
 	entries, err := store.List(db, "dbtools_migration_history")
@@ -113,8 +113,8 @@ func TestSetStatusAdopted(t *testing.T) {
 	if e.HashSource != ledger.HashSourceAdopted {
 		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
 	}
-	if e.ContentSHA256 != "abc123" {
-		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	if e.ContentSHA256 != "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" {
+		t.Errorf("ContentSHA256 = %q, want the expected hash", e.ContentSHA256)
 	}
 }
 
@@ -136,7 +136,7 @@ CREATE TABLE dbtools_migration_history (
 	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("ensureSchema() on preexisting table returned error: %v", err)
 	}
-	if err := store.SetStatusAdopted(db, 1, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+	if err := store.SetStatusAdopted(db, 1, "adopted", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() after ensureSchema migration returned error: %v", err)
 	}
 }

--- a/internal/engine/mysqlengine/ledger_integration_test.go
+++ b/internal/engine/mysqlengine/ledger_integration_test.go
@@ -89,6 +89,58 @@ func TestSetStatusWithHashPreservesHashOnPlainUpdate(t *testing.T) {
 	}
 }
 
+func TestSetStatusAdopted(t *testing.T) {
+	db := openTestDB(t)
+	store := mysqlLedgerStore{}
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() returned error: %v", err)
+	}
+	entries, err := store.List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Status != ledger.StatusApplied {
+		t.Errorf("Status = %q, want applied", e.Status)
+	}
+	if e.HashSource != ledger.HashSourceAdopted {
+		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
+	}
+	if e.ContentSHA256 != "abc123" {
+		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	}
+}
+
+func TestEnsureSchema_AddsHashSourceToPreexistingTable(t *testing.T) {
+	db := openTestDB(t)
+	// Simulate a table created before hash_source existed.
+	if _, err := db.Exec(`
+CREATE TABLE dbtools_migration_history (
+    version     BIGINT       NOT NULL PRIMARY KEY,
+    status      VARCHAR(10)  NOT NULL,
+    recorded_at DATETIME     NULL,
+    note        VARCHAR(400) NULL,
+    CHECK (status IN ('applied', 'reverted'))
+) ENGINE=InnoDB`); err != nil {
+		t.Fatal(err)
+	}
+
+	store := mysqlLedgerStore{}
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatalf("ensureSchema() on preexisting table returned error: %v", err)
+	}
+	if err := store.SetStatusAdopted(db, 1, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() after ensureSchema migration returned error: %v", err)
+	}
+}
+
 func TestAppliedVersions(t *testing.T) {
 	db := openTestDB(t)
 	store := mysqlLedgerStore{}

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -115,10 +115,10 @@ func (ledgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, conten
 	}
 	_, err := db.Exec(fmt.Sprintf(`
 INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
-VALUES ($1, 'applied', now(), $2, $3, 'adopted')
+VALUES ($1, 'applied', now(), $2, $3, $4)
 ON CONFLICT (version) DO UPDATE
 SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note, content_sha256 = EXCLUDED.content_sha256, hash_source = EXCLUDED.hash_source`, table),
-		int64(version), note, contentHash)
+		int64(version), note, contentHash, ledger.HashSourceAdopted)
 	if err != nil {
 		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
 	}
@@ -179,6 +179,10 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, er
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
+func (s ledgerStore) EnsureSchema(db ledger.DBTX, table string) error {
+	return s.ensureSchema(db, table)
+}
+
 func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
 	if err := s.ensureSchema(db, table); err != nil {
 		return err

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -155,7 +155,7 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
-func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
+func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
 	if err := s.ensureSchema(db); err != nil {
 		return err
 	}
@@ -166,9 +166,10 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string
 	if dirty {
 		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair <target>` to resolve it before syncing the ledger", version)
 	}
-	allVersions, err := migrator.ListVersions(migrationsDir)
+	allVersions, err := migrator.ListVersions(migrationsDir, upSuffix)
 	if err != nil {
 		return err
 	}
 	return s.backfill(db, version, hasVersion, allVersions)
 }
+

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -196,5 +196,3 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuf
 	}
 	return s.backfill(db, version, hasVersion, allVersions, table)
 }
-
-

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -100,7 +100,7 @@ func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledg
 INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES ($1, $2, now(), $3, $4)
 ON CONFLICT (version) DO UPDATE
-SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`, table),
+SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note, content_sha256 = EXCLUDED.content_sha256, hash_source = ''`, table),
 		int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -14,23 +14,23 @@ import (
 // exactly the semantics documented there — only the SQL differs.
 type ledgerStore struct{}
 
-func (ledgerStore) ensureSchema(db ledger.DBTX) error {
-	_, err := db.Exec(`
-CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+func (ledgerStore) ensureSchema(db ledger.DBTX, table string) error {
+	_, err := db.Exec(fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
     version         BIGINT       NOT NULL PRIMARY KEY,
     status          VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
     recorded_at     TIMESTAMPTZ  NULL,
     note            VARCHAR(400) NULL,
     content_sha256  CHAR(64)     NULL
-)`)
+)`, table))
 	if err != nil {
-		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+		return fmt.Errorf("ensuring %s schema: %w", table, err)
 	}
 	// Column added by dbtools builds before content hashing existed —
 	// idempotent when already present.
-	_, err = db.Exec(`ALTER TABLE dbtools_migration_history ADD COLUMN IF NOT EXISTS content_sha256 CHAR(64) NULL`)
+	_, err = db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS content_sha256 CHAR(64) NULL`, table))
 	if err != nil {
-		return fmt.Errorf("adding content_sha256 to dbtools_migration_history: %w", err)
+		return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func checkVersionRange(version uint64) error {
 	return nil
 }
 
-func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64) error {
+func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64, table string) error {
 	if !hasVersion {
 		return nil
 	}
@@ -55,10 +55,10 @@ func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bo
 		if err := checkVersionRange(v); err != nil {
 			return err
 		}
-		_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
+		_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note)
 VALUES ($1, 'applied', NULL, 'backfilled: applied before ledger existed')
-ON CONFLICT (version) DO NOTHING`, int64(v))
+ON CONFLICT (version) DO NOTHING`, table), int64(v))
 		if err != nil {
 			return fmt.Errorf("backfilling version %d: %w", v, err)
 		}
@@ -68,15 +68,15 @@ ON CONFLICT (version) DO NOTHING`, int64(v))
 
 // SetStatus upserts version's ledger row, preserving content_sha256 on
 // update (the applied file's hash must not be clobbered by a status edit).
-func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
+func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note)
 VALUES ($1, $2, now(), $3)
 ON CONFLICT (version) DO UPDATE
-SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`,
+SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`, table),
 		int64(version), string(status), note)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -86,15 +86,15 @@ SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDE
 
 // SetStatusWithHash is SetStatus plus recording the applied migration
 // file's content hash, so verify can detect edits after apply.
-func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES ($1, $2, now(), $3, $4)
 ON CONFLICT (version) DO UPDATE
-SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`,
+SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note`, table),
 		int64(version), string(status), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -103,8 +103,8 @@ SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDE
 }
 
 // List returns every ledger row, ordered by version ascending.
-func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
+func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -137,8 +137,8 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 }
 
 // AppliedVersions returns every version currently marked "applied", ascending.
-func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
-	entries, err := s.List(db)
+func (s ledgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, error) {
+	entries, err := s.List(db, table)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +155,8 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
-func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
-	if err := s.ensureSchema(db); err != nil {
+func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
+	if err := s.ensureSchema(db, table); err != nil {
 		return err
 	}
 	version, dirty, hasVersion, err := m.Version()
@@ -170,6 +170,7 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuf
 	if err != nil {
 		return err
 	}
-	return s.backfill(db, version, hasVersion, allVersions)
+	return s.backfill(db, version, hasVersion, allVersions, table)
 }
+
 

--- a/internal/engine/postgresengine/ledger.go
+++ b/internal/engine/postgresengine/ledger.go
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS %s (
     status          VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
     recorded_at     TIMESTAMPTZ  NULL,
     note            VARCHAR(400) NULL,
-    content_sha256  CHAR(64)     NULL
+    content_sha256  CHAR(64)     NULL,
+    hash_source     VARCHAR(20)  NULL
 )`, table))
 	if err != nil {
 		return fmt.Errorf("ensuring %s schema: %w", table, err)
@@ -31,6 +32,11 @@ CREATE TABLE IF NOT EXISTS %s (
 	_, err = db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS content_sha256 CHAR(64) NULL`, table))
 	if err != nil {
 		return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
+	}
+	// Column added for adopt command.
+	_, err = db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS hash_source VARCHAR(20) NULL`, table))
+	if err != nil {
+		return fmt.Errorf("adding hash_source to %s: %w", table, err)
 	}
 	return nil
 }
@@ -102,9 +108,26 @@ SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDE
 	return nil
 }
 
+// SetStatusAdopted records version as applied with hash_source "adopted".
+func (ledgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
+VALUES ($1, 'applied', now(), $2, $3, 'adopted')
+ON CONFLICT (version) DO UPDATE
+SET status = EXCLUDED.status, recorded_at = EXCLUDED.recorded_at, note = EXCLUDED.note, content_sha256 = EXCLUDED.content_sha256, hash_source = EXCLUDED.hash_source`, table),
+		int64(version), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row, ordered by version ascending.
 func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
-	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256, hash_source FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -116,8 +139,8 @@ func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note, contentHash sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
+		var note, contentHash, hashSource sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash, &hashSource); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -131,6 +154,7 @@ func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		}
 		e.Note = note.String
 		e.ContentSHA256 = contentHash.String
+		e.HashSource = hashSource.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()

--- a/internal/engine/postgresengine/ledger_integration_test.go
+++ b/internal/engine/postgresengine/ledger_integration_test.go
@@ -34,7 +34,7 @@ func TestSetStatusAdopted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() returned error: %v", err)
 	}
 	entries, err := store.List(db, "dbtools_migration_history")
@@ -51,8 +51,8 @@ func TestSetStatusAdopted(t *testing.T) {
 	if e.HashSource != ledger.HashSourceAdopted {
 		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
 	}
-	if e.ContentSHA256 != "abc123" {
-		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	if e.ContentSHA256 != "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" {
+		t.Errorf("ContentSHA256 = %q, want the expected hash", e.ContentSHA256)
 	}
 }
 
@@ -73,7 +73,7 @@ CREATE TABLE dbtools_migration_history (
 	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("ensureSchema() on preexisting table returned error: %v", err)
 	}
-	if err := store.SetStatusAdopted(db, 1, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+	if err := store.SetStatusAdopted(db, 1, "adopted", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatusAdopted() after ensureSchema migration returned error: %v", err)
 	}
 }

--- a/internal/engine/postgresengine/ledger_integration_test.go
+++ b/internal/engine/postgresengine/ledger_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package postgresengine
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/ledger"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	url := os.Getenv("DBTOOLS_TEST_POSTGRES_URL")
+	if url == "" {
+		t.Skip("DBTOOLS_TEST_POSTGRES_URL not set, skipping integration test")
+	}
+	db, err := Postgres{}.Open(url)
+	if err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Exec(`DROP TABLE IF EXISTS dbtools_migration_history`)
+		db.Close()
+	})
+	return db
+}
+
+func TestSetStatusAdopted(t *testing.T) {
+	db := openTestDB(t)
+	store := ledgerStore{}
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() returned error: %v", err)
+	}
+	entries, err := store.List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Status != ledger.StatusApplied {
+		t.Errorf("Status = %q, want applied", e.Status)
+	}
+	if e.HashSource != ledger.HashSourceAdopted {
+		t.Errorf("HashSource = %q, want %q", e.HashSource, ledger.HashSourceAdopted)
+	}
+	if e.ContentSHA256 != "abc123" {
+		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	}
+}
+
+func TestEnsureSchema_AddsHashSourceToPreexistingTable(t *testing.T) {
+	db := openTestDB(t)
+	// Simulate a table created before hash_source existed.
+	if _, err := db.Exec(`
+CREATE TABLE dbtools_migration_history (
+    version         BIGINT       NOT NULL PRIMARY KEY,
+    status          VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
+    recorded_at     TIMESTAMPTZ  NULL,
+    note            VARCHAR(400) NULL
+)`); err != nil {
+		t.Fatal(err)
+	}
+
+	store := ledgerStore{}
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatalf("ensureSchema() on preexisting table returned error: %v", err)
+	}
+	if err := store.SetStatusAdopted(db, 1, "adopted", "abc123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() after ensureSchema migration returned error: %v", err)
+	}
+}

--- a/internal/engine/postgresengine/ledger_test.go
+++ b/internal/engine/postgresengine/ledger_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestSetStatusRejectsVersionAboveBigintRange(t *testing.T) {
-	err := ledgerStore{}.SetStatus(nil, math.MaxInt64+1, ledger.StatusApplied, "")
+	err := ledgerStore{}.SetStatus(nil, math.MaxInt64+1, ledger.StatusApplied, "", "dbtools_migration_history")
 	if err == nil || !strings.Contains(err.Error(), "BIGINT range") {
 		t.Fatalf("SetStatus(MaxInt64+1) err = %v, want BIGINT range error", err)
 	}
 }
 
 func TestBackfillRejectsVersionAboveBigintRange(t *testing.T) {
-	err := ledgerStore{}.backfill(nil, math.MaxUint64, true, []uint64{math.MaxInt64 + 1})
+	err := ledgerStore{}.backfill(nil, math.MaxUint64, true, []uint64{math.MaxInt64 + 1}, "dbtools_migration_history")
 	if err == nil || !strings.Contains(err.Error(), "BIGINT range") {
 		t.Fatalf("backfill(MaxInt64+1) err = %v, want BIGINT range error", err)
 	}

--- a/internal/engine/postgresengine/ledger_test.go
+++ b/internal/engine/postgresengine/ledger_test.go
@@ -21,3 +21,10 @@ func TestBackfillRejectsVersionAboveBigintRange(t *testing.T) {
 		t.Fatalf("backfill(MaxInt64+1) err = %v, want BIGINT range error", err)
 	}
 }
+
+func TestSetStatusAdoptedRejectsVersionAboveBigintRange(t *testing.T) {
+	err := ledgerStore{}.SetStatusAdopted(nil, math.MaxInt64+1, "", "", "dbtools_migration_history")
+	if err == nil || !strings.Contains(err.Error(), "BIGINT range") {
+		t.Fatalf("SetStatusAdopted(MaxInt64+1) err = %v, want BIGINT range error", err)
+	}
+}

--- a/internal/engine/postgresengine/postgresengine_integration_test.go
+++ b/internal/engine/postgresengine/postgresengine_integration_test.go
@@ -32,19 +32,19 @@ func TestLiveLedgerDDLAndIntrospection(t *testing.T) {
 	// Ledger round trip.
 	t.Cleanup(func() { db.Exec(`DROP TABLE IF EXISTS dbtools_migration_history`) })
 	store := ledgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("ensureSchema() returned error: %v", err)
 	}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatalf("second ensureSchema() should be idempotent: %v", err)
 	}
-	if err := store.SetStatus(db, 42, ledger.StatusApplied, "first"); err != nil {
+	if err := store.SetStatus(db, 42, ledger.StatusApplied, "first", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus(insert) returned error: %v", err)
 	}
-	if err := store.SetStatus(db, 42, ledger.StatusReverted, "second"); err != nil {
+	if err := store.SetStatus(db, 42, ledger.StatusReverted, "second", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus(upsert) returned error: %v", err)
 	}
-	entries, err := store.List(db)
+	entries, err := store.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("List() returned error: %v", err)
 	}
@@ -54,10 +54,10 @@ func TestLiveLedgerDDLAndIntrospection(t *testing.T) {
 	if entries[0].RecordedAt == nil {
 		t.Fatal("List() row RecordedAt = nil, want a timestamp")
 	}
-	if err := store.backfill(db, 100, true, []uint64{42, 99, 150}); err != nil {
+	if err := store.backfill(db, 100, true, []uint64{42, 99, 150}, "dbtools_migration_history"); err != nil {
 		t.Fatalf("backfill() returned error: %v", err)
 	}
-	applied, err := store.AppliedVersions(db)
+	applied, err := store.AppliedVersions(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("AppliedVersions() returned error: %v", err)
 	}

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -25,33 +25,33 @@ func checkVersionRange(version uint64) error {
 	return nil
 }
 
-func (ledgerStore) ensureSchema(db ledger.DBTX) error {
-	_, err := db.Exec(`
-CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+func (ledgerStore) ensureSchema(db ledger.DBTX, table string) error {
+	_, err := db.Exec(fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
     version         INTEGER NOT NULL PRIMARY KEY,
     status          TEXT    NOT NULL CHECK (status IN ('applied', 'reverted')),
     recorded_at     TIMESTAMP NULL,
     note            TEXT    NULL,
     content_sha256  TEXT    NULL
-)`)
+)`, table))
 	if err != nil {
-		return fmt.Errorf("ensuring dbtools_migration_history schema: %w", err)
+		return fmt.Errorf("ensuring %s schema: %w", table, err)
 	}
 	// Column added by dbtools builds before content hashing existed.
-	cols, err := db.Query(`SELECT name FROM pragma_table_info('dbtools_migration_history') WHERE name = 'content_sha256'`)
+	cols, err := db.Query(fmt.Sprintf(`SELECT name FROM pragma_table_info('%s') WHERE name = 'content_sha256'`, table))
 	if err != nil {
-		return fmt.Errorf("inspecting dbtools_migration_history columns: %w", err)
+		return fmt.Errorf("inspecting %s columns: %w", table, err)
 	}
 	defer cols.Close()
 	if !cols.Next() {
-		if _, err := db.Exec(`ALTER TABLE dbtools_migration_history ADD COLUMN content_sha256 TEXT NULL`); err != nil {
-			return fmt.Errorf("adding content_sha256 to dbtools_migration_history: %w", err)
+		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN content_sha256 TEXT NULL`, table)); err != nil {
+			return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
 		}
 	}
 	return nil
 }
 
-func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64) error {
+func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bool, allVersions []uint64, table string) error {
 	if !hasVersion {
 		return nil
 	}
@@ -62,10 +62,10 @@ func (ledgerStore) backfill(db ledger.DBTX, currentVersion uint64, hasVersion bo
 		if err := checkVersionRange(v); err != nil {
 			return err
 		}
-		_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
+		_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note)
 VALUES (?, 'applied', NULL, 'backfilled: applied before ledger existed')
-ON CONFLICT (version) DO NOTHING`, int64(v))
+ON CONFLICT (version) DO NOTHING`, table), int64(v))
 		if err != nil {
 			return fmt.Errorf("backfilling version %d: %w", v, err)
 		}
@@ -75,15 +75,15 @@ ON CONFLICT (version) DO NOTHING`, int64(v))
 
 // SetStatus upserts version's ledger row, preserving content_sha256 on
 // update (the applied file's hash must not be clobbered by a status edit).
-func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note string) error {
+func (ledgerStore) SetStatus(db ledger.DBTX, version uint64, status ledger.Status, note, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note)
 VALUES (?, ?, ?, ?)
 ON CONFLICT (version) DO UPDATE
-SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`,
+SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`, table),
 		int64(version), string(status), time.Now().UTC(), note)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -93,15 +93,15 @@ SET status = excluded.status, recorded_at = excluded.recorded_at, note = exclude
 
 // SetStatusWithHash is SetStatus plus recording the applied migration
 // file's content hash, so verify can detect edits after apply.
-func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash string) error {
+func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledger.Status, note, contentHash, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
-	_, err := db.Exec(`
-INSERT INTO dbtools_migration_history (version, status, recorded_at, note, content_sha256)
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES (?, ?, ?, ?, ?)
 ON CONFLICT (version) DO UPDATE
-SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`,
+SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`, table),
 		int64(version), string(status), time.Now().UTC(), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)
@@ -110,8 +110,8 @@ SET status = excluded.status, recorded_at = excluded.recorded_at, note = exclude
 }
 
 // List returns every ledger row, ordered by version ascending.
-func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
-	rows, err := db.Query(`SELECT version, status, recorded_at, note, content_sha256 FROM dbtools_migration_history ORDER BY version ASC`)
+func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -144,8 +144,8 @@ func (ledgerStore) List(db ledger.DBTX) ([]ledger.Entry, error) {
 }
 
 // AppliedVersions returns every version currently marked "applied", ascending.
-func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
-	entries, err := s.List(db)
+func (s ledgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, error) {
+	entries, err := s.List(db, table)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +162,8 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
-func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
-	if err := s.ensureSchema(db); err != nil {
+func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
+	if err := s.ensureSchema(db, table); err != nil {
 		return err
 	}
 	version, dirty, hasVersion, err := m.Version()
@@ -177,6 +177,7 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuf
 	if err != nil {
 		return err
 	}
-	return s.backfill(db, version, hasVersion, allVersions)
+	return s.backfill(db, version, hasVersion, allVersions, table)
 }
+
 

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -209,5 +209,3 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuf
 	}
 	return s.backfill(db, version, hasVersion, allVersions, table)
 }
-
-

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -162,7 +162,7 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX) ([]uint64, error) {
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
-func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string) error {
+func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix string) error {
 	if err := s.ensureSchema(db); err != nil {
 		return err
 	}
@@ -173,9 +173,10 @@ func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir string
 	if dirty {
 		return fmt.Errorf("migration cursor is dirty (a previous apply failed partway through version %d); run `dbtools repair <target>` to resolve it before syncing the ledger", version)
 	}
-	allVersions, err := migrator.ListVersions(migrationsDir)
+	allVersions, err := migrator.ListVersions(migrationsDir, upSuffix)
 	if err != nil {
 		return err
 	}
 	return s.backfill(db, version, hasVersion, allVersions)
 }
+

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS %s (
     status          TEXT    NOT NULL CHECK (status IN ('applied', 'reverted')),
     recorded_at     TIMESTAMP NULL,
     note            TEXT    NULL,
-    content_sha256  TEXT    NULL
+    content_sha256  TEXT    NULL,
+    hash_source     TEXT    NULL
 )`, table))
 	if err != nil {
 		return fmt.Errorf("ensuring %s schema: %w", table, err)
@@ -46,6 +47,17 @@ CREATE TABLE IF NOT EXISTS %s (
 	if !cols.Next() {
 		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN content_sha256 TEXT NULL`, table)); err != nil {
 			return fmt.Errorf("adding content_sha256 to %s: %w", table, err)
+		}
+	}
+	// Column added for adopt command.
+	srcCols, err := db.Query(fmt.Sprintf(`SELECT name FROM pragma_table_info('%s') WHERE name = 'hash_source'`, table))
+	if err != nil {
+		return fmt.Errorf("inspecting %s columns: %w", table, err)
+	}
+	defer srcCols.Close()
+	if !srcCols.Next() {
+		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN hash_source TEXT NULL`, table)); err != nil {
+			return fmt.Errorf("adding hash_source to %s: %w", table, err)
 		}
 	}
 	return nil
@@ -109,9 +121,26 @@ SET status = excluded.status, recorded_at = excluded.recorded_at, note = exclude
 	return nil
 }
 
+// SetStatusAdopted records version as applied with hash_source "adopted".
+func (ledgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
+	if err := checkVersionRange(version); err != nil {
+		return err
+	}
+	_, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
+VALUES (?, 'applied', ?, ?, ?, 'adopted')
+ON CONFLICT (version) DO UPDATE
+SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note, content_sha256 = excluded.content_sha256, hash_source = excluded.hash_source`, table),
+		int64(version), time.Now().UTC(), note, contentHash)
+	if err != nil {
+		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
+	}
+	return nil
+}
+
 // List returns every ledger row, ordered by version ascending.
 func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
-	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256 FROM %s ORDER BY version ASC`, table))
+	rows, err := db.Query(fmt.Sprintf(`SELECT version, status, recorded_at, note, content_sha256, hash_source FROM %s ORDER BY version ASC`, table))
 	if err != nil {
 		return nil, fmt.Errorf("listing ledger: %w", err)
 	}
@@ -123,8 +152,8 @@ func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		var version int64
 		var status string
 		var recordedAt sql.NullTime
-		var note, contentHash sql.NullString
-		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash); err != nil {
+		var note, contentHash, hashSource sql.NullString
+		if err := rows.Scan(&version, &status, &recordedAt, &note, &contentHash, &hashSource); err != nil {
 			return nil, fmt.Errorf("scanning ledger row: %w", err)
 		}
 		if version < 0 {
@@ -138,6 +167,7 @@ func (ledgerStore) List(db ledger.DBTX, table string) ([]ledger.Entry, error) {
 		}
 		e.Note = note.String
 		e.ContentSHA256 = contentHash.String
+		e.HashSource = hashSource.String
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -113,7 +113,7 @@ func (ledgerStore) SetStatusWithHash(db ledger.DBTX, version uint64, status ledg
 INSERT INTO %s (version, status, recorded_at, note, content_sha256)
 VALUES (?, ?, ?, ?, ?)
 ON CONFLICT (version) DO UPDATE
-SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note`, table),
+SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note, content_sha256 = excluded.content_sha256, hash_source = ''`, table),
 		int64(version), string(status), time.Now().UTC(), note, contentHash)
 	if err != nil {
 		return fmt.Errorf("setting status for version %d: %w", version, err)

--- a/internal/engine/sqliteengine/ledger.go
+++ b/internal/engine/sqliteengine/ledger.go
@@ -121,17 +121,18 @@ SET status = excluded.status, recorded_at = excluded.recorded_at, note = exclude
 	return nil
 }
 
-// SetStatusAdopted records version as applied with hash_source "adopted".
+// SetStatusAdopted records version as applied with hash_source
+// ledger.HashSourceAdopted.
 func (ledgerStore) SetStatusAdopted(db ledger.DBTX, version uint64, note, contentHash, table string) error {
 	if err := checkVersionRange(version); err != nil {
 		return err
 	}
 	_, err := db.Exec(fmt.Sprintf(`
 INSERT INTO %s (version, status, recorded_at, note, content_sha256, hash_source)
-VALUES (?, 'applied', ?, ?, ?, 'adopted')
+VALUES (?, 'applied', ?, ?, ?, ?)
 ON CONFLICT (version) DO UPDATE
 SET status = excluded.status, recorded_at = excluded.recorded_at, note = excluded.note, content_sha256 = excluded.content_sha256, hash_source = excluded.hash_source`, table),
-		int64(version), time.Now().UTC(), note, contentHash)
+		int64(version), time.Now().UTC(), note, contentHash, ledger.HashSourceAdopted)
 	if err != nil {
 		return fmt.Errorf("setting adopted status for version %d: %w", version, err)
 	}
@@ -192,6 +193,10 @@ func (s ledgerStore) AppliedVersions(db ledger.DBTX, table string) ([]uint64, er
 // backfill a row for every version m's cursor already considers applied.
 // Refuses to backfill when the cursor is dirty (a previous apply failed
 // partway) — see ledger.Sync.
+func (s ledgerStore) EnsureSchema(db ledger.DBTX, table string) error {
+	return s.ensureSchema(db, table)
+}
+
 func (s ledgerStore) Sync(db *sql.DB, m *migrator.Migrator, migrationsDir, upSuffix, table string) error {
 	if err := s.ensureSchema(db, table); err != nil {
 		return err

--- a/internal/engine/sqliteengine/migrate_integration_test.go
+++ b/internal/engine/sqliteengine/migrate_integration_test.go
@@ -63,13 +63,13 @@ func TestLiveMigrateUpAndLedger(t *testing.T) {
 
 	// Ledger round trip through the engine seam.
 	store := ledgerStore{}
-	if err := store.Sync(db, m, dir); err != nil {
+	if err := store.Sync(db, m, dir, ".up.sql", "dbtools_migration_history"); err != nil {
 		t.Fatalf("Sync() returned error: %v", err)
 	}
-	if err := store.SetStatus(db, 20260817000001, "applied", "applied via integration test"); err != nil {
+	if err := store.SetStatus(db, 20260817000001, "applied", "applied via integration test", "dbtools_migration_history"); err != nil {
 		t.Fatalf("SetStatus() returned error: %v", err)
 	}
-	entries, err := store.List(db)
+	entries, err := store.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("List() returned error: %v", err)
 	}

--- a/internal/engine/sqliteengine/sqliteengine_test.go
+++ b/internal/engine/sqliteengine/sqliteengine_test.go
@@ -171,27 +171,28 @@ func TestExists(t *testing.T) {
 func TestLedgerRoundTrip(t *testing.T) {
 	db := openTemp(t)
 	store := ledgerStore{}
-	if err := store.ensureSchema(db); err != nil {
+	table := "dbtools_migration_history"
+	if err := store.ensureSchema(db, table); err != nil {
 		t.Fatalf("ensureSchema() returned error: %v", err)
 	}
-	if err := store.ensureSchema(db); err != nil {
+	if err := store.ensureSchema(db, table); err != nil {
 		t.Fatalf("second ensureSchema() returned error: %v", err)
 	}
 
-	if err := store.SetStatus(db, 100, ledger.StatusApplied, "first"); err != nil {
+	if err := store.SetStatus(db, 100, ledger.StatusApplied, "first", table); err != nil {
 		t.Fatalf("SetStatus() returned error: %v", err)
 	}
-	if err := store.SetStatus(db, 100, ledger.StatusReverted, "rolled back"); err != nil {
+	if err := store.SetStatus(db, 100, ledger.StatusReverted, "rolled back", table); err != nil {
 		t.Fatalf("SetStatus() upsert returned error: %v", err)
 	}
-	if err := store.SetStatus(db, 200, ledger.StatusApplied, "second"); err != nil {
+	if err := store.SetStatus(db, 200, ledger.StatusApplied, "second", table); err != nil {
 		t.Fatalf("SetStatus() returned error: %v", err)
 	}
-	if err := store.backfill(db, 300, true, []uint64{100, 200, 300, 400}); err != nil {
+	if err := store.backfill(db, 300, true, []uint64{100, 200, 300, 400}, table); err != nil {
 		t.Fatalf("backfill() returned error: %v", err)
 	}
 
-	entries, err := store.List(db)
+	entries, err := store.List(db, table)
 	if err != nil {
 		t.Fatalf("List() returned error: %v", err)
 	}
@@ -208,7 +209,7 @@ func TestLedgerRoundTrip(t *testing.T) {
 		t.Errorf("entry[2] = %+v, want backfilled 300 with nil RecordedAt", entries[2])
 	}
 
-	applied, err := store.AppliedVersions(db)
+	applied, err := store.AppliedVersions(db, table)
 	if err != nil {
 		t.Fatalf("AppliedVersions() returned error: %v", err)
 	}
@@ -217,11 +218,37 @@ func TestLedgerRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLedgerStore_CustomTableName(t *testing.T) {
+	db := openTemp(t)
+	store := ledgerStore{}
+	customTable := "custom_migration_history"
+
+	if err := store.ensureSchema(db, customTable); err != nil {
+		t.Fatalf("ensureSchema(customTable): %v", err)
+	}
+	if err := store.SetStatus(db, 1, ledger.StatusApplied, "first", customTable); err != nil {
+		t.Fatalf("SetStatus(customTable): %v", err)
+	}
+	entries, err := store.List(db, customTable)
+	if err != nil {
+		t.Fatalf("List(customTable): %v", err)
+	}
+	if len(entries) != 1 || entries[0].Version != 1 {
+		t.Fatalf("List(customTable) = %+v, want 1 entry", entries)
+	}
+
+	// Verify table was created with custom name
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='custom_migration_history'`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("custom table count = %d, want 1", count)
+	}
+}
+
 func TestLedgerRejectsVersionsAboveIntegerRange(t *testing.T) {
-	if err := (ledgerStore{}).SetStatus(nil, math.MaxInt64+1, ledger.StatusApplied, ""); err == nil || !strings.Contains(err.Error(), "INTEGER range") {
+	if err := (ledgerStore{}).SetStatus(nil, math.MaxInt64+1, ledger.StatusApplied, "", "dbtools_migration_history"); err == nil || !strings.Contains(err.Error(), "INTEGER range") {
 		t.Errorf("SetStatus(MaxInt64+1) err = %v, want INTEGER range error", err)
 	}
-	if err := (ledgerStore{}).backfill(nil, math.MaxUint64, true, []uint64{math.MaxInt64 + 1}); err == nil || !strings.Contains(err.Error(), "INTEGER range") {
+	if err := (ledgerStore{}).backfill(nil, math.MaxUint64, true, []uint64{math.MaxInt64 + 1}, "dbtools_migration_history"); err == nil || !strings.Contains(err.Error(), "INTEGER range") {
 		t.Errorf("backfill(MaxInt64+1) err = %v, want INTEGER range error", err)
 	}
 }

--- a/internal/engine/sqliteengine/sqliteengine_test.go
+++ b/internal/engine/sqliteengine/sqliteengine_test.go
@@ -23,6 +23,46 @@ func openTemp(t *testing.T) *sql.DB {
 	return db
 }
 
+// TestSetStatusWithHash_ClearsAdoptedHashSourceOnReapply is a regression
+// test for a review finding: SetStatusWithHash's ON CONFLICT branch didn't
+// update content_sha256 or hash_source, so a version adopted (hash_source
+// "adopted") and later reverted and genuinely re-applied would keep
+// reporting the stale adopted hash and provenance forever — doctor/verify
+// would never promote it to "actually verified" even after a real apply
+// recorded its real hash.
+func TestSetStatusWithHash_ClearsAdoptedHashSourceOnReapply(t *testing.T) {
+	db := openTemp(t)
+	store := ledgerStore{}
+	if err := store.ensureSchema(db, "dbtools_migration_history"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "deadbeef", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusAdopted() returned error: %v", err)
+	}
+	if err := store.SetStatus(db, 1, ledger.StatusReverted, "reverted", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatus(reverted) returned error: %v", err)
+	}
+	if err := store.SetStatusWithHash(db, 1, ledger.StatusApplied, "applied via up/push", "realhash123", "dbtools_migration_history"); err != nil {
+		t.Fatalf("SetStatusWithHash() returned error: %v", err)
+	}
+
+	entries, err := store.List(db, "dbtools_migration_history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.ContentSHA256 != "realhash123" {
+		t.Errorf("ContentSHA256 = %q, want realhash123 (must overwrite the stale adopted hash)", e.ContentSHA256)
+	}
+	if e.HashSource != "" {
+		t.Errorf("HashSource = %q, want empty (a genuine re-apply must clear the adopted tag)", e.HashSource)
+	}
+}
+
 func TestPathFromURL(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"sqlite://relative/to.db", "relative/to.db"},

--- a/internal/engine/sqliteengine/sqliteengine_test.go
+++ b/internal/engine/sqliteengine/sqliteengine_test.go
@@ -244,6 +244,38 @@ func TestLedgerStore_CustomTableName(t *testing.T) {
 	}
 }
 
+func TestLedgerStore_SetStatusAdopted(t *testing.T) {
+	db := openTemp(t)
+	store := ledgerStore{}
+	table := "dbtools_migration_history"
+
+	if err := store.ensureSchema(db, table); err != nil {
+		t.Fatalf("ensureSchema() returned error: %v", err)
+	}
+
+	if err := store.SetStatusAdopted(db, 1, "adopted from schema_migrations", "abc123", table); err != nil {
+		t.Fatalf("SetStatusAdopted() returned error: %v", err)
+	}
+
+	entries, err := store.List(db, table)
+	if err != nil {
+		t.Fatalf("List() returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.HashSource != "adopted" {
+		t.Errorf("HashSource = %q, want \"adopted\"", e.HashSource)
+	}
+	if e.Status != ledger.StatusApplied {
+		t.Errorf("Status = %q, want applied", e.Status)
+	}
+	if e.ContentSHA256 != "abc123" {
+		t.Errorf("ContentSHA256 = %q, want abc123", e.ContentSHA256)
+	}
+}
+
 func TestLedgerRejectsVersionsAboveIntegerRange(t *testing.T) {
 	if err := (ledgerStore{}).SetStatus(nil, math.MaxInt64+1, ledger.StatusApplied, "", "dbtools_migration_history"); err == nil || !strings.Contains(err.Error(), "INTEGER range") {
 		t.Errorf("SetStatus(MaxInt64+1) err = %v, want INTEGER range error", err)

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -6,6 +6,8 @@ package ledger
 
 import (
 	"database/sql"
+	"fmt"
+	"regexp"
 	"time"
 )
 
@@ -37,3 +39,16 @@ type DBTX interface {
 	Query(query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row
 }
+
+var validTableName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidateTableName rejects a ledger table name that isn't a plain SQL
+// identifier — table names are inlined into SQL text (they can't be bind
+// parameters), so this is the injection guard.
+func ValidateTableName(name string) error {
+	if !validTableName.MatchString(name) {
+		return fmt.Errorf("invalid ledger table name %q: must match %s", name, validTableName.String())
+	}
+	return nil
+}
+

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -54,4 +54,3 @@ func ValidateTableName(name string) error {
 	}
 	return nil
 }
-

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -19,6 +19,10 @@ const (
 	StatusReverted Status = "reverted"
 )
 
+// HashSourceAdopted marks an Entry's ContentSHA256 as recorded by `dbtools
+// adopt` rather than observed at apply time — see Entry.HashSource.
+const HashSourceAdopted = "adopted"
+
 // Entry is one row of dbtools_migration_history.
 type Entry struct {
 	Version    uint64

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -28,6 +28,9 @@ type Entry struct {
 	// ContentSHA256 is the hex SHA-256 of the migration file that was
 	// applied, or "" for backfilled rows recorded before hashes existed.
 	ContentSHA256 string
+	// HashSource indicates the provenance of ContentSHA256: "" for normal applies,
+	// "adopted" for rows imported without verification.
+	HashSource string
 }
 
 // DBTX is the subset of *sql.DB's interface needed for ledger operations.

--- a/internal/ledger/sync_dirty_test.go
+++ b/internal/ledger/sync_dirty_test.go
@@ -55,7 +55,7 @@ func TestSync_RefusesDirtyCursor(t *testing.T) {
 	defer db.Close()
 
 	ls := sqliteengine.SQLite{}.Ledger()
-	err = ls.Sync(db, m, dir, ".up.sql")
+	err = ls.Sync(db, m, dir, ".up.sql", "dbtools_migration_history")
 	if err == nil {
 		t.Fatal("Sync() over a dirty cursor should refuse")
 	}
@@ -64,7 +64,7 @@ func TestSync_RefusesDirtyCursor(t *testing.T) {
 	}
 
 	// And the ledger must NOT have backfilled the failed version.
-	entries, err := ls.List(db)
+	entries, err := ls.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,10 +90,10 @@ func TestSync_BackfillSkipsDirty(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if err := (sqliteengine.SQLite{}).Ledger().Sync(db, m, dir, ".up.sql"); err != nil {
+	if err := (sqliteengine.SQLite{}).Ledger().Sync(db, m, dir, ".up.sql", "dbtools_migration_history"); err != nil {
 		t.Fatalf("Sync() clean: %v", err)
 	}
-	entries, err := (sqliteengine.SQLite{}).Ledger().List(db)
+	entries, err := (sqliteengine.SQLite{}).Ledger().List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ledger/sync_dirty_test.go
+++ b/internal/ledger/sync_dirty_test.go
@@ -55,7 +55,7 @@ func TestSync_RefusesDirtyCursor(t *testing.T) {
 	defer db.Close()
 
 	ls := sqliteengine.SQLite{}.Ledger()
-	err = ls.Sync(db, m, dir)
+	err = ls.Sync(db, m, dir, ".up.sql")
 	if err == nil {
 		t.Fatal("Sync() over a dirty cursor should refuse")
 	}
@@ -90,7 +90,7 @@ func TestSync_BackfillSkipsDirty(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if err := (sqliteengine.SQLite{}).Ledger().Sync(db, m, dir); err != nil {
+	if err := (sqliteengine.SQLite{}).Ledger().Sync(db, m, dir, ".up.sql"); err != nil {
 		t.Fatalf("Sync() clean: %v", err)
 	}
 	entries, err := (sqliteengine.SQLite{}).Ledger().List(db)

--- a/internal/migrator/dir.go
+++ b/internal/migrator/dir.go
@@ -303,4 +303,3 @@ func FindMigrationFile(migrationsDir, upSuffix string, version uint64) (string, 
 	}
 	return f.Filename, nil
 }
-

--- a/internal/migrator/dir.go
+++ b/internal/migrator/dir.go
@@ -14,9 +14,17 @@ import (
 )
 
 var (
-	validUpFilenamePattern   = regexp.MustCompile(`^(\d+)_.+\.up\.sql$`)
 	validDownFilenamePattern = regexp.MustCompile(`^(\d+)_.+\.down\.sql$`)
 )
+
+// upFilenamePattern compiles the up-migration filename pattern for the
+// given suffix, e.g. ".up.sql" -> `^(\d+)_.+\.up\.sql$`, ".sql" -> `^(\d+)_.+\.sql$`.
+func upFilenamePattern(upSuffix string) *regexp.Regexp {
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	return regexp.MustCompile(`^(\d+)_.+` + regexp.QuoteMeta(upSuffix) + `$`)
+}
 
 // File represents one plain-SQL migration file on disk.
 type File struct {
@@ -28,6 +36,7 @@ type File struct {
 // Dir is an in-memory indexed view of a local migrations directory.
 type Dir struct {
 	path          string
+	upSuffix      string
 	upFiles       []File
 	downFiles     []File
 	byVersion     map[uint64]File
@@ -35,13 +44,17 @@ type Dir struct {
 }
 
 // ReadDir scans migrationsDir, parses version numbers, sorts ascending, and indexes
-// all *.up.sql and *.down.sql migration files in memory.
-func ReadDir(migrationsDir string) (*Dir, error) {
+// all migration files matching upSuffix and *.down.sql in memory.
+func ReadDir(migrationsDir, upSuffix string) (*Dir, error) {
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &Dir{
 				path:          migrationsDir,
+				upSuffix:      upSuffix,
 				upFiles:       nil,
 				downFiles:     nil,
 				byVersion:     make(map[uint64]File),
@@ -55,25 +68,14 @@ func ReadDir(migrationsDir string) (*Dir, error) {
 	var downFiles []File
 	byVersion := make(map[uint64]File)
 	byVersionDown := make(map[uint64]File)
+	upPat := upFilenamePattern(upSuffix)
 
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		name := e.Name()
-		if m := validUpFilenamePattern.FindStringSubmatch(name); m != nil {
-			ver, err := strconv.ParseUint(m[1], 10, 64)
-			if err != nil {
-				continue
-			}
-			f := File{
-				Version:  ver,
-				Filename: name,
-				Path:     filepath.Join(migrationsDir, name),
-			}
-			upFiles = append(upFiles, f)
-			byVersion[ver] = f
-		} else if m := validDownFilenamePattern.FindStringSubmatch(name); m != nil {
+		if m := validDownFilenamePattern.FindStringSubmatch(name); m != nil {
 			ver, err := strconv.ParseUint(m[1], 10, 64)
 			if err != nil {
 				continue
@@ -85,6 +87,21 @@ func ReadDir(migrationsDir string) (*Dir, error) {
 			}
 			downFiles = append(downFiles, f)
 			byVersionDown[ver] = f
+		} else if m := upPat.FindStringSubmatch(name); m != nil {
+			if upSuffix != ".up.sql" && strings.HasSuffix(name, ".up.sql") {
+				continue
+			}
+			ver, err := strconv.ParseUint(m[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			f := File{
+				Version:  ver,
+				Filename: name,
+				Path:     filepath.Join(migrationsDir, name),
+			}
+			upFiles = append(upFiles, f)
+			byVersion[ver] = f
 		}
 	}
 
@@ -97,6 +114,7 @@ func ReadDir(migrationsDir string) (*Dir, error) {
 
 	return &Dir{
 		path:          migrationsDir,
+		upSuffix:      upSuffix,
 		upFiles:       upFiles,
 		downFiles:     downFiles,
 		byVersion:     byVersion,
@@ -229,7 +247,11 @@ func (d *Dir) NextUpFilename(now time.Time, name string) (string, error) {
 		return "", err
 	}
 	slug := strings.ReplaceAll(strings.TrimSpace(name), " ", "_")
-	return fmt.Sprintf("%014d_%s.up.sql", ver, slug), nil
+	suffix := d.upSuffix
+	if suffix == "" {
+		suffix = ".up.sql"
+	}
+	return fmt.Sprintf("%014d_%s%s", ver, slug, suffix), nil
 }
 
 // ContentHash computes the SHA-256 hex string of version's *.up.sql file.
@@ -260,18 +282,18 @@ func (d *Dir) DownContentHash(version uint64) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-// ListVersions returns every migration version found in migrationsDir, ascending.
-func ListVersions(migrationsDir string) ([]uint64, error) {
-	d, err := ReadDir(migrationsDir)
+// ListVersions returns every migration version found in migrationsDir matching upSuffix, ascending.
+func ListVersions(migrationsDir, upSuffix string) ([]uint64, error) {
+	d, err := ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
 	}
 	return d.ListVersions(), nil
 }
 
-// FindMigrationFile returns the filename of the .up.sql file for version in migrationsDir.
-func FindMigrationFile(migrationsDir string, version uint64) (string, error) {
-	d, err := ReadDir(migrationsDir)
+// FindMigrationFile returns the filename of the up migration file for version in migrationsDir.
+func FindMigrationFile(migrationsDir, upSuffix string, version uint64) (string, error) {
+	d, err := ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return "", err
 	}
@@ -281,3 +303,4 @@ func FindMigrationFile(migrationsDir string, version uint64) (string, error) {
 	}
 	return f.Filename, nil
 }
+

--- a/internal/migrator/dir_test.go
+++ b/internal/migrator/dir_test.go
@@ -14,7 +14,7 @@ func TestReadDir(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "20260102000000_add_orders.up.sql"), []byte("CREATE TABLE orders (id INT);"), 0o644)
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("not a migration"), 0o644)
 
-	d, err := ReadDir(dir)
+	d, err := ReadDir(dir, ".up.sql")
 	if err != nil {
 		t.Fatalf("ReadDir() returned error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestDir_DownPlan(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "20260102000000_add_orders.up.sql"), []byte("CREATE TABLE orders (id INT);"), 0o644)
 	os.WriteFile(filepath.Join(dir, "20260102000000_add_orders.down.sql"), []byte("DROP TABLE orders;"), 0o644)
 
-	d, err := ReadDir(dir)
+	d, err := ReadDir(dir, ".up.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestDir_DownPlan(t *testing.T) {
 
 	// Missing down file error
 	os.Remove(filepath.Join(dir, "20260102000000_add_orders.down.sql"))
-	d2, _ := ReadDir(dir)
+	d2, _ := ReadDir(dir, ".up.sql")
 	_, err = d2.DownPlan(applied, 1)
 	if err == nil {
 		t.Fatal("expected error when down file missing, got nil")
@@ -127,7 +127,7 @@ func TestDir_NextVersion(t *testing.T) {
 	now := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	clockVer := uint64(20260115100000)
 
-	d, err := ReadDir(dir)
+	d, err := ReadDir(dir, ".up.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestDir_NextVersion(t *testing.T) {
 
 	// Future-dated migration present
 	os.WriteFile(filepath.Join(dir, "20260120000000_future.up.sql"), []byte("SELECT 1;"), 0o644)
-	d, err = ReadDir(dir)
+	d, err = ReadDir(dir, ".up.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,3 +153,24 @@ func TestDir_NextVersion(t *testing.T) {
 		t.Errorf("NextVersion() with future = %d, want 20260120000001", ver)
 	}
 }
+
+func TestReadDir_CustomUpSuffix(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "1_create_widgets.sql"), []byte("-- sql"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A real .up.sql file must NOT also match when a custom suffix is set.
+	if err := os.WriteFile(filepath.Join(dir, "2_create_gadgets.up.sql"), []byte("-- sql"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := ReadDir(dir, ".sql")
+	if err != nil {
+		t.Fatalf("ReadDir() returned error: %v", err)
+	}
+	versions := d.ListVersions()
+	if len(versions) != 1 || versions[0] != 1 {
+		t.Errorf("ListVersions() = %v, want [1]", versions)
+	}
+}
+

--- a/internal/migrator/dir_test.go
+++ b/internal/migrator/dir_test.go
@@ -173,4 +173,3 @@ func TestReadDir_CustomUpSuffix(t *testing.T) {
 		t.Errorf("ListVersions() = %v, want [1]", versions)
 	}
 }
-

--- a/internal/migrator/hash.go
+++ b/internal/migrator/hash.go
@@ -4,10 +4,11 @@ package migrator
 // is what the ledger stores when a migration is applied, so verify can
 // detect an applied migration being edited after the fact — the most
 // common real-world schema drift.
-func ContentHash(migrationsDir string, version uint64) (string, error) {
-	d, err := ReadDir(migrationsDir)
+func ContentHash(migrationsDir, upSuffix string, version uint64) (string, error) {
+	d, err := ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return "", err
 	}
 	return d.ContentHash(version)
 }
+

--- a/internal/migrator/hash.go
+++ b/internal/migrator/hash.go
@@ -11,4 +11,3 @@ func ContentHash(migrationsDir, upSuffix string, version uint64) (string, error)
 	}
 	return d.ContentHash(version)
 }
-

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -27,12 +27,12 @@ type Result struct {
 // applied when its migration's objects don't exist unless force is set),
 // applies all pairs, and recomputes db's cursor as the highest remaining
 // applied version.
-func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir string, pairs []Pair, force bool) (*Result, error) {
-	if err := eng.Ledger().Sync(db, m, migrationsDir); err != nil {
+func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir, upSuffix string, pairs []Pair, force bool) (*Result, error) {
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix); err != nil {
 		return nil, err
 	}
 
-	dir, err := migrator.ReadDir(migrationsDir)
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -27,8 +27,17 @@ type Result struct {
 // applied when its migration's objects don't exist unless force is set),
 // applies all pairs, and recomputes db's cursor as the highest remaining
 // applied version.
-func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir, upSuffix string, pairs []Pair, force bool) (*Result, error) {
-	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix); err != nil {
+func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir, upSuffix, table string, pairs []Pair, force bool) (*Result, error) {
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	if table == "" {
+		table = "dbtools_migration_history"
+	}
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, table); err != nil {
 		return nil, err
 	}
 
@@ -75,12 +84,12 @@ func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir, upS
 	defer tx.Rollback()
 
 	for _, pair := range pairs {
-		if err := eng.Ledger().SetStatus(tx, pair.Version, pair.Status, "repaired via dbtools repair"); err != nil {
+		if err := eng.Ledger().SetStatus(tx, pair.Version, pair.Status, "repaired via dbtools repair", table); err != nil {
 			return nil, err
 		}
 	}
 
-	applied, err := eng.Ledger().AppliedVersions(tx)
+	applied, err := eng.Ledger().AppliedVersions(tx, table)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/seanpham99/dbtools/internal/config"
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/ledger"
 	"github.com/seanpham99/dbtools/internal/migrator"
@@ -28,15 +29,7 @@ type Result struct {
 // applies all pairs, and recomputes db's cursor as the highest remaining
 // applied version.
 func Run(db *sql.DB, eng engine.Engine, m *migrator.Migrator, migrationsDir, upSuffix, table string, pairs []Pair, force bool) (*Result, error) {
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	if table == "" {
-		table = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, table = config.ResolveDefaults(migrationsDir, upSuffix, table)
 	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, table); err != nil {
 		return nil, err
 	}

--- a/internal/repair/repair_integration_test.go
+++ b/internal/repair/repair_integration_test.go
@@ -48,15 +48,15 @@ func TestRun_RefusesWithoutForceWhenObjectMissing(t *testing.T) {
 	// The table was never actually created (reproducing the real
 	// incident) — repair must refuse to mark it applied without --force.
 	pairs := []Pair{{Version: 20260101000000, Status: ledger.StatusApplied}}
-	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, pairs, false); err == nil {
+	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, ".up.sql", "dbtools_migration_history", pairs, false); err == nil {
 		t.Fatal("expected Run() to refuse marking applied when object is missing, got nil error")
 	}
 
-	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, pairs, true); err != nil {
+	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, ".up.sql", "dbtools_migration_history", pairs, true); err != nil {
 		t.Fatalf("Run() with force=true returned error: %v", err)
 	}
 
-	entries, err := mssqlengine.List(db)
+	entries, err := mssqlengine.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestRun_RecomputesCursor(t *testing.T) {
 	// Mark the later version reverted — cursor should recompute down to
 	// the earlier still-applied version.
 	pairs := []Pair{{Version: 20260102000000, Status: ledger.StatusReverted}}
-	result, err := Run(db, mssqlengine.MSSQL{}, m, dir, pairs, false)
+	result, err := Run(db, mssqlengine.MSSQL{}, m, dir, ".up.sql", "dbtools_migration_history", pairs, false)
 	if err != nil {
 		t.Fatalf("Run() returned error: %v", err)
 	}
@@ -131,11 +131,11 @@ func TestRun_RevertsWithoutFilePresent(t *testing.T) {
 	// not require finding a file, since there's nothing to check for a
 	// reverted version.
 	pairs := []Pair{{Version: 20260101000000, Status: ledger.StatusReverted}}
-	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, pairs, false); err != nil {
+	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, ".up.sql", "dbtools_migration_history", pairs, false); err != nil {
 		t.Fatalf("Run() marking reverted with no file present returned error: %v", err)
 	}
 
-	entries, err := mssqlengine.List(db)
+	entries, err := mssqlengine.List(db, "dbtools_migration_history")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestRun_UnknownVersionRejected(t *testing.T) {
 	defer db.Close()
 
 	pairs := []Pair{{Version: 99999999999999, Status: ledger.StatusApplied}}
-	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, pairs, true); err == nil {
+	if _, err := Run(db, mssqlengine.MSSQL{}, m, dir, ".up.sql", "dbtools_migration_history", pairs, true); err == nil {
 		t.Fatal("expected error for a version with no matching migration file, got nil")
 	}
 }

--- a/internal/rollback/rollback.go
+++ b/internal/rollback/rollback.go
@@ -31,18 +31,7 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	migrationsDir := cfg.MigrationsDir
-	if migrationsDir == "" {
-		migrationsDir = "migrations"
-	}
-	upSuffix := cfg.Migrations.UpSuffix
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	ledgerTable := cfg.Ledger.Table
-	if ledgerTable == "" {
-		ledgerTable = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 
 	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {

--- a/internal/rollback/rollback.go
+++ b/internal/rollback/rollback.go
@@ -43,7 +43,7 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir); err != nil {
+	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 

--- a/internal/rollback/rollback.go
+++ b/internal/rollback/rollback.go
@@ -31,7 +31,20 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	m, err := migrator.Open(url, cfg.MigrationsDir)
+	migrationsDir := cfg.MigrationsDir
+	if migrationsDir == "" {
+		migrationsDir = "migrations"
+	}
+	upSuffix := cfg.Migrations.UpSuffix
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	ledgerTable := cfg.Ledger.Table
+	if ledgerTable == "" {
+		ledgerTable = "dbtools_migration_history"
+	}
+
+	m, err := migrator.Open(url, migrationsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -43,11 +56,11 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 	}
 	defer db.Close()
 
-	if err := eng.Ledger().Sync(db, m, cfg.MigrationsDir, cfg.Migrations.UpSuffix); err != nil {
+	if err := eng.Ledger().Sync(db, m, migrationsDir, upSuffix, ledgerTable); err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
 
-	applied, err := eng.Ledger().AppliedVersions(db)
+	applied, err := eng.Ledger().AppliedVersions(db, ledgerTable)
 	if err != nil {
 		return nil, fmt.Errorf("target %q: %w", targetName, err)
 	}
@@ -78,12 +91,12 @@ func Run(cfg *config.Config, targetName string, steps int, urlOverride string) (
 	defer tx.Rollback()
 
 	for _, ver := range reverted {
-		if err := eng.Ledger().SetStatus(tx, ver, ledger.StatusReverted, "soft-reverted via rollback"); err != nil {
+		if err := eng.Ledger().SetStatus(tx, ver, ledger.StatusReverted, "soft-reverted via rollback", ledgerTable); err != nil {
 			return nil, err
 		}
 	}
 
-	remaining, err := eng.Ledger().AppliedVersions(tx)
+	remaining, err := eng.Ledger().AppliedVersions(tx, ledgerTable)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -8,18 +8,21 @@ import (
 )
 
 // UpFilename returns the filename for a new migration created at `now`
-// with the given human-readable name, e.g. "20260701041134_add_widget.up.sql".
-func UpFilename(now time.Time, name string) string {
+// with the given human-readable name and up-migration suffix, e.g. "20260701041134_add_widget.up.sql".
+func UpFilename(now time.Time, name, upSuffix string) string {
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
 	slug := strings.ReplaceAll(strings.TrimSpace(name), " ", "_")
-	return now.UTC().Format("20060102150405") + "_" + slug + ".up.sql"
+	return now.UTC().Format("20060102150405") + "_" + slug + upSuffix
 }
 
 // NextVersion returns the next migration version number to use.
 // It computes max(clock_version, max_existing_version + 1), ensuring that
 // newly scaffolded migrations are never created behind the highest version
 // already present in migrationsDir (e.g. from skewed clocks or future-dated migrations).
-func NextVersion(now time.Time, migrationsDir string) (uint64, error) {
-	d, err := migrator.ReadDir(migrationsDir)
+func NextVersion(now time.Time, migrationsDir, upSuffix string) (uint64, error) {
+	d, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return 0, err
 	}
@@ -27,10 +30,11 @@ func NextVersion(now time.Time, migrationsDir string) (uint64, error) {
 }
 
 // NextUpFilename computes the next migration filename for the given name in migrationsDir.
-func NextUpFilename(now time.Time, migrationsDir, name string) (string, error) {
-	d, err := migrator.ReadDir(migrationsDir)
+func NextUpFilename(now time.Time, migrationsDir, upSuffix, name string) (string, error) {
+	d, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return "", err
 	}
 	return d.NextUpFilename(now, name)
 }
+

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -37,4 +37,3 @@ func NextUpFilename(now time.Time, migrationsDir, upSuffix, name string) (string
 	}
 	return d.NextUpFilename(now, name)
 }
-

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUpFilename(t *testing.T) {
 	now := time.Date(2026, 7, 1, 4, 11, 34, 0, time.UTC)
-	got := UpFilename(now, "add widget table")
+	got := UpFilename(now, "add widget table", ".up.sql")
 	want := "20260701041134_add_widget_table.up.sql"
 	if got != want {
 		t.Errorf("UpFilename() = %q, want %q", got, want)
@@ -18,7 +18,7 @@ func TestUpFilename(t *testing.T) {
 
 func TestUpFilename_AlreadySlug(t *testing.T) {
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	got := UpFilename(now, "add_widget_table")
+	got := UpFilename(now, "add_widget_table", ".up.sql")
 	want := "20260102030405_add_widget_table.up.sql"
 	if got != want {
 		t.Errorf("UpFilename() = %q, want %q", got, want)
@@ -29,7 +29,7 @@ func TestNextVersion_EmptyOrNonExistentDir(t *testing.T) {
 	now := time.Date(2026, 8, 19, 17, 3, 57, 0, time.UTC)
 
 	// Non-existent directory returns clock version
-	ver, err := NextVersion(now, "/non/existent/dir/path")
+	ver, err := NextVersion(now, "/non/existent/dir/path", ".up.sql")
 	if err != nil {
 		t.Fatalf("NextVersion() error: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestNextVersion_EmptyOrNonExistentDir(t *testing.T) {
 
 	// Empty directory returns clock version
 	tmp := t.TempDir()
-	ver, err = NextVersion(now, tmp)
+	ver, err = NextVersion(now, tmp, ".up.sql")
 	if err != nil {
 		t.Fatalf("NextVersion() error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestNextVersion_ExistingBehindClock(t *testing.T) {
 	}
 
 	now := time.Date(2026, 8, 19, 17, 3, 57, 0, time.UTC)
-	ver, err := NextVersion(now, tmp)
+	ver, err := NextVersion(now, tmp, ".up.sql")
 	if err != nil {
 		t.Fatalf("NextVersion() error: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestNextVersion_ExistingAheadOfClock(t *testing.T) {
 	}
 
 	now := time.Date(2026, 8, 19, 17, 3, 57, 0, time.UTC)
-	ver, err := NextVersion(now, tmp)
+	ver, err := NextVersion(now, tmp, ".up.sql")
 	if err != nil {
 		t.Fatalf("NextVersion() error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestNextVersion_ExistingAheadOfClock(t *testing.T) {
 		t.Errorf("NextVersion() = %d, want max+1 (20260820100002)", ver)
 	}
 
-	fn, err := NextUpFilename(now, tmp, "null unbacked source file names")
+	fn, err := NextUpFilename(now, tmp, ".up.sql", "null unbacked source file names")
 	if err != nil {
 		t.Fatalf("NextUpFilename() error: %v", err)
 	}
@@ -99,3 +99,4 @@ func TestNextVersion_ExistingAheadOfClock(t *testing.T) {
 		t.Errorf("NextUpFilename() = %q, want %q", fn, wantFn)
 	}
 }
+

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -99,4 +99,3 @@ func TestNextVersion_ExistingAheadOfClock(t *testing.T) {
 		t.Errorf("NextUpFilename() = %q, want %q", fn, wantFn)
 	}
 }
-

--- a/internal/statusinfo/collect.go
+++ b/internal/statusinfo/collect.go
@@ -25,7 +25,7 @@ type TargetResult struct {
 
 // Collect opens databaseURL, reads its current migration version, and
 // diffs it against every migration file in migrationsDir.
-func Collect(databaseURL, migrationsDir, targetName string) (*Status, error) {
+func Collect(databaseURL, migrationsDir, upSuffix, targetName string) (*Status, error) {
 	m, err := migrator.Open(databaseURL, migrationsDir)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func Collect(databaseURL, migrationsDir, targetName string) (*Status, error) {
 		return nil, err
 	}
 
-	d, err := migrator.ReadDir(migrationsDir)
+	d, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func CollectAll(cfg *config.Config, targetFilter, urlOverride string) []TargetRe
 			results = append(results, TargetResult{Target: name, Err: err})
 			continue
 		}
-		s, err := Collect(url, cfg.MigrationsDir, name)
+		s, err := Collect(url, cfg.MigrationsDir, cfg.Migrations.UpSuffix, name)
 		if err != nil {
 			results = append(results, TargetResult{Target: name, Err: err})
 			continue

--- a/internal/statusinfo/collect_integration_test.go
+++ b/internal/statusinfo/collect_integration_test.go
@@ -30,7 +30,7 @@ func TestCollect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status, err := Collect(url, dir, "local")
+	status, err := Collect(url, dir, ".up.sql", "local")
 	if err != nil {
 		t.Fatalf("Collect() before any Up() returned error: %v", err)
 	}

--- a/internal/testutil/runner.go
+++ b/internal/testutil/runner.go
@@ -116,7 +116,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	}
 
 	// --- E2: Verify clean ledger state ---
-	report, err := verify.Collect(db, eng, migrationsDir, "test-target")
+	report, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
 	if err != nil {
 		t.Fatalf("verify.Collect failed: %v", err)
 	}
@@ -257,7 +257,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	if err := os.WriteFile(mig1Path, append(origMig1, []byte("\n-- edited after apply")...), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	driftReport, err := verify.Collect(db, eng, migrationsDir, "test-target")
+	driftReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
 	if err != nil {
 		t.Fatalf("verify after edit returned err: %v", err)
 	}
@@ -283,7 +283,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	} else {
 		_, _ = db.Exec("DROP TABLE payments")
 	}
-	dropReport, err := verify.Collect(db, eng, migrationsDir, "test-target")
+	dropReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
 	if err != nil {
 		t.Fatalf("verify after drop returned err: %v", err)
 	}
@@ -314,7 +314,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	}
 
 	// Verify ledger marks v4 reverted, not drift
-	downVerify, err := verify.Collect(db, eng, migrationsDir, "test-target")
+	downVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
 	if err != nil {
 		t.Fatalf("verify after down failed: %v", err)
 	}
@@ -333,7 +333,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 		t.Fatalf("reapplyStatus.CurrentVersion = %d, want 20260822000004", reapplyStatus.CurrentVersion)
 	}
 
-	finalVerify, err := verify.Collect(db, eng, migrationsDir, "test-target")
+	finalVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
 	if err != nil {
 		t.Fatalf("final verify failed: %v", err)
 	}

--- a/internal/testutil/runner.go
+++ b/internal/testutil/runner.go
@@ -116,7 +116,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	}
 
 	// --- E2: Verify clean ledger state ---
-	report, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
+	report, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, "test-target")
 	if err != nil {
 		t.Fatalf("verify.Collect failed: %v", err)
 	}
@@ -257,7 +257,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	if err := os.WriteFile(mig1Path, append(origMig1, []byte("\n-- edited after apply")...), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	driftReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
+	driftReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, "test-target")
 	if err != nil {
 		t.Fatalf("verify after edit returned err: %v", err)
 	}
@@ -283,7 +283,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	} else {
 		_, _ = db.Exec("DROP TABLE payments")
 	}
-	dropReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
+	dropReport, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, "test-target")
 	if err != nil {
 		t.Fatalf("verify after drop returned err: %v", err)
 	}
@@ -314,7 +314,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 	}
 
 	// Verify ledger marks v4 reverted, not drift
-	downVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
+	downVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, "test-target")
 	if err != nil {
 		t.Fatalf("verify after down failed: %v", err)
 	}
@@ -333,7 +333,7 @@ func RunAssets(t *testing.T, dialect, rawURL string) {
 		t.Fatalf("reapplyStatus.CurrentVersion = %d, want 20260822000004", reapplyStatus.CurrentVersion)
 	}
 
-	finalVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, "test-target")
+	finalVerify, err := verify.Collect(db, eng, migrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table, "test-target")
 	if err != nil {
 		t.Fatalf("final verify failed: %v", err)
 	}

--- a/internal/verify/collect.go
+++ b/internal/verify/collect.go
@@ -30,8 +30,14 @@ type Report struct {
 // versions marked "applied" must have every object their migration creates
 // actually present AND the migration file's content must still match the
 // hash recorded when it was applied; versions marked "reverted" must not.
-func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, targetName string) (*Report, error) {
-	entries, err := eng.Ledger().List(db)
+func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, table, targetName string) (*Report, error) {
+	if upSuffix == "" {
+		upSuffix = ".up.sql"
+	}
+	if table == "" {
+		table = "dbtools_migration_history"
+	}
+	entries, err := eng.Ledger().List(db, table)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/verify/collect.go
+++ b/internal/verify/collect.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/seanpham99/dbtools/internal/config"
 	"github.com/seanpham99/dbtools/internal/ddlcheck"
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/ledger"
@@ -31,12 +32,7 @@ type Report struct {
 // actually present AND the migration file's content must still match the
 // hash recorded when it was applied; versions marked "reverted" must not.
 func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, table, targetName string) (*Report, error) {
-	if upSuffix == "" {
-		upSuffix = ".up.sql"
-	}
-	if table == "" {
-		table = "dbtools_migration_history"
-	}
+	migrationsDir, upSuffix, table = config.ResolveDefaults(migrationsDir, upSuffix, table)
 	entries, err := eng.Ledger().List(db, table)
 	if err != nil {
 		return nil, err
@@ -104,7 +100,7 @@ func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, table, targ
 		// DB no longer matches what the file says. Backfilled rows have no
 		// hash (recorded before hashing existed) and adopted rows (inferred
 		// at adopt time, not observed at apply time) are skipped.
-		if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" && e.HashSource != "adopted" {
+		if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" && e.HashSource != ledger.HashSourceAdopted {
 			sum, err := dir.ContentHash(e.Version)
 			if err != nil {
 				return nil, err

--- a/internal/verify/collect.go
+++ b/internal/verify/collect.go
@@ -102,8 +102,9 @@ func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, table, targ
 		// Content-hash check: an applied migration whose file was edited
 		// after apply is drift even when every object still exists — the
 		// DB no longer matches what the file says. Backfilled rows have no
-		// hash (recorded before hashing existed) and are skipped.
-		if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" {
+		// hash (recorded before hashing existed) and adopted rows (inferred
+		// at adopt time, not observed at apply time) are skipped.
+		if e.Status == ledger.StatusApplied && e.ContentSHA256 != "" && e.HashSource != "adopted" {
 			sum, err := dir.ContentHash(e.Version)
 			if err != nil {
 				return nil, err

--- a/internal/verify/collect.go
+++ b/internal/verify/collect.go
@@ -30,13 +30,13 @@ type Report struct {
 // versions marked "applied" must have every object their migration creates
 // actually present AND the migration file's content must still match the
 // hash recorded when it was applied; versions marked "reverted" must not.
-func Collect(db *sql.DB, eng engine.Engine, migrationsDir, targetName string) (*Report, error) {
+func Collect(db *sql.DB, eng engine.Engine, migrationsDir, upSuffix, targetName string) (*Report, error) {
 	entries, err := eng.Ledger().List(db)
 	if err != nil {
 		return nil, err
 	}
 
-	dir, err := migrator.ReadDir(migrationsDir)
+	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/verify/collect_integration_test.go
+++ b/internal/verify/collect_integration_test.go
@@ -34,16 +34,16 @@ func TestCollect_DetectsStampedButNeverRunTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 	// Reproduces the 2026-07-10 incident: the ledger claims this version is
 	// applied, but its CREATE TABLE was never actually run.
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "simulated stamp-without-running"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "simulated stamp-without-running", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestCollect_DetectsStampedButNeverRunTable(t *testing.T) {
 	}
 	defer db.Exec("DROP TABLE dbtools_test_verify_widgets")
 
-	report, err = Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err = Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("second Collect() returned error: %v", err)
 	}
@@ -92,14 +92,14 @@ func TestCollect_RevertedButStillExists(t *testing.T) {
 	}
 	defer db.Exec("DROP TABLE dbtools_test_verify_reverted")
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusReverted, "test"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusReverted, "test", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -129,14 +129,14 @@ func TestCollect_RevertedWithFileGoneIsNotDrift(t *testing.T) {
 	// drift: reverted already means "these objects shouldn't exist".
 	dir := t.TempDir()
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusReverted, "superseded by a rename, file no longer exists"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusReverted, "superseded by a rename, file no longer exists", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -165,14 +165,14 @@ func TestCollect_AppliedWithFileGoneIsStillDrift(t *testing.T) {
 	// must stay DRIFT even after the reverted-with-missing-file exemption.
 	dir := t.TempDir()
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "file missing, still claimed applied"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "file missing, still claimed applied", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -206,17 +206,17 @@ func TestCollect_CreatedThenDroppedByLaterMigrationIsNotDrift(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "creates the table"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "creates the table", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260102000000, ledger.StatusApplied, "drops the table"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260102000000, ledger.StatusApplied, "drops the table", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -252,14 +252,14 @@ func TestCollect_ReportsAllMissingObjectsInOneMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := mssqlengine.EnsureSchema(db); err != nil {
+	if err := mssqlengine.EnsureSchema(db, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "neither object was actually created"); err != nil {
+	if err := mssqlengine.SetStatus(db, 20260101000000, ledger.StatusApplied, "neither object was actually created", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, mssqlengine.MSSQL{}, dir, "test-target")
+	report, err := Collect(db, mssqlengine.MSSQL{}, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/internal/verify/dropped_recreate_test.go
+++ b/internal/verify/dropped_recreate_test.go
@@ -44,14 +44,14 @@ func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
 	}
 	defer db.Exec(`DROP TABLE dbtools_test_recreate_widgets`)
 
-	if err := eng.Ledger().SetStatus(db, 1, ledger.StatusApplied, "drops widgets"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 1, ledger.StatusApplied, "drops widgets", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := eng.Ledger().SetStatus(db, 2, ledger.StatusApplied, "re-creates widgets"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 2, ledger.StatusApplied, "re-creates widgets", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
 	if _, err := db.Exec(`DROP TABLE dbtools_test_recreate_widgets`); err != nil {
 		t.Fatal(err)
 	}
-	report, err = Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("second Collect() returned error: %v", err)
 	}
@@ -106,14 +106,14 @@ func TestCollect_SQLite_CreatedThenDroppedByLaterMigrationIsNotDrift(t *testing.
 		t.Fatal(err)
 	}
 
-	if err := eng.Ledger().SetStatus(db, 1, ledger.StatusApplied, "creates table"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 1, ledger.StatusApplied, "creates table", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
-	if err := eng.Ledger().SetStatus(db, 2, ledger.StatusApplied, "drops table"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 2, ledger.StatusApplied, "drops table", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/internal/verify/dropped_recreate_test.go
+++ b/internal/verify/dropped_recreate_test.go
@@ -35,7 +35,8 @@ func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
 		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
 		recorded_at TIMESTAMP NULL,
 		note TEXT NULL,
-		content_sha256 TEXT NULL)`); err != nil {
+		content_sha256 TEXT NULL,
+		hash_source TEXT NULL)`); err != nil {
 		t.Fatal(err)
 	}
 	// v1 drops (recorded), v2 re-creates (recorded) and the object exists.
@@ -102,7 +103,8 @@ func TestCollect_SQLite_CreatedThenDroppedByLaterMigrationIsNotDrift(t *testing.
 		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
 		recorded_at TIMESTAMP NULL,
 		note TEXT NULL,
-		content_sha256 TEXT NULL)`); err != nil {
+		content_sha256 TEXT NULL,
+		hash_source TEXT NULL)`); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/verify/dropped_recreate_test.go
+++ b/internal/verify/dropped_recreate_test.go
@@ -51,7 +51,7 @@ func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestCollect_DropThenRecreateIsNotPermanentDrift(t *testing.T) {
 	if _, err := db.Exec(`DROP TABLE dbtools_test_recreate_widgets`); err != nil {
 		t.Fatal(err)
 	}
-	report, err = Collect(db, eng, dir, "test-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("second Collect() returned error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCollect_SQLite_CreatedThenDroppedByLaterMigrationIsNotDrift(t *testing.
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/internal/verify/hash_drift_test.go
+++ b/internal/verify/hash_drift_test.go
@@ -51,7 +51,7 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := eng.Ledger().SetStatusWithHash(db, 20260101000000, ledger.StatusApplied, "applied via up/push", hash); err != nil {
+	if err := eng.Ledger().SetStatusWithHash(db, 20260101000000, ledger.StatusApplied, "applied via up/push", hash, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 	// The migration's object actually exists (it was really applied).
@@ -61,7 +61,7 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 	defer db.Exec(`DROP TABLE dbtools_test_hash_drift`)
 
 	// Verify clean before any edit.
-	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_drift (id INTEGER PRIMARY KEY);\nALTER TABLE dbtools_test_hash_drift ADD COLUMN extra TEXT;"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	report, err = Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() after edit returned error: %v", err)
 	}
@@ -128,11 +128,11 @@ func TestCollect_BackfilledRowsWithoutHashAreNotDrift(t *testing.T) {
 		t.Fatalf("creating table: %v", err)
 	}
 	defer db.Exec(`DROP TABLE dbtools_test_hash_backfill`)
-	if err := eng.Ledger().SetStatus(db, 20260101000000, ledger.StatusApplied, "backfilled: applied before ledger existed"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 20260101000000, ledger.StatusApplied, "backfilled: applied before ledger existed", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/internal/verify/hash_drift_test.go
+++ b/internal/verify/hash_drift_test.go
@@ -142,3 +142,48 @@ func TestCollect_BackfilledRowsWithoutHashAreNotDrift(t *testing.T) {
 		t.Fatalf("Collect() = %+v, want one OK entry (no hash baseline)", report.Entries)
 	}
 }
+
+func TestCollect_AdoptedRowsAreNotDrift(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "20260101000000_create_widgets.up.sql")
+	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_adopted (id INTEGER PRIMARY KEY);"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rawURL := "sqlite://" + filepath.Join(dir, "verify.db")
+	eng, err := engine.ForTarget("", rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS dbtools_migration_history (
+		version INTEGER NOT NULL PRIMARY KEY,
+		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
+		recorded_at TIMESTAMP NULL,
+		note TEXT NULL,
+		content_sha256 TEXT NULL,
+		hash_source TEXT NULL)`); err != nil {
+		t.Fatalf("creating ledger: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE dbtools_test_hash_adopted (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	defer db.Exec(`DROP TABLE dbtools_test_hash_adopted`)
+
+	if err := eng.Ledger().SetStatusAdopted(db, 20260101000000, "adopted from schema_migrations", "deliberatelywronghash", "dbtools_migration_history"); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "test-target")
+	if err != nil {
+		t.Fatalf("Collect() returned error: %v", err)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != "OK" {
+		t.Fatalf("Collect() = %+v, want one OK entry (adopted row skips hash check)", report.Entries)
+	}
+}

--- a/internal/verify/hash_drift_test.go
+++ b/internal/verify/hash_drift_test.go
@@ -61,7 +61,7 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 	defer db.Exec(`DROP TABLE dbtools_test_hash_drift`)
 
 	// Verify clean before any edit.
-	report, err := Collect(db, eng, dir, "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 	if err := os.WriteFile(file, []byte("CREATE TABLE dbtools_test_hash_drift (id INTEGER PRIMARY KEY);\nALTER TABLE dbtools_test_hash_drift ADD COLUMN extra TEXT;"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	report, err = Collect(db, eng, dir, "test-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() after edit returned error: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestCollect_BackfilledRowsWithoutHashAreNotDrift(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, "test-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "test-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/internal/verify/hash_drift_test.go
+++ b/internal/verify/hash_drift_test.go
@@ -41,7 +41,8 @@ func TestCollect_DetectsEditedMigrationAfterApply(t *testing.T) {
 		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
 		recorded_at TIMESTAMP NULL,
 		note TEXT NULL,
-		content_sha256 TEXT NULL)`); err != nil {
+		content_sha256 TEXT NULL,
+		hash_source TEXT NULL)`); err != nil {
 		t.Fatalf("creating ledger: %v", err)
 	}
 
@@ -121,7 +122,8 @@ func TestCollect_BackfilledRowsWithoutHashAreNotDrift(t *testing.T) {
 		status TEXT NOT NULL CHECK (status IN ('applied', 'reverted')),
 		recorded_at TIMESTAMP NULL,
 		note TEXT NULL,
-		content_sha256 TEXT NULL)`); err != nil {
+		content_sha256 TEXT NULL,
+		hash_source TEXT NULL)`); err != nil {
 		t.Fatalf("creating ledger: %v", err)
 	}
 	if _, err := db.Exec(`CREATE TABLE dbtools_test_hash_backfill (id INTEGER PRIMARY KEY)`); err != nil {

--- a/internal/verify/postgres_verify_integration_test.go
+++ b/internal/verify/postgres_verify_integration_test.go
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS dbtools_migration_history (
     status          VARCHAR(10)  NOT NULL CHECK (status IN ('applied', 'reverted')),
     recorded_at     TIMESTAMPTZ  NULL,
     note            VARCHAR(400) NULL,
-    content_sha256  CHAR(64)     NULL
+    content_sha256  CHAR(64)     NULL,
+    hash_source     VARCHAR(20)  NULL
 );`
 
 func TestCollect_Postgres_DetectsMissingObject(t *testing.T) {

--- a/internal/verify/postgres_verify_integration_test.go
+++ b/internal/verify/postgres_verify_integration_test.go
@@ -56,11 +56,11 @@ func TestCollect_Postgres_DetectsMissingObject(t *testing.T) {
 		t.Fatalf("ensuring ledger table: %v", err)
 	}
 	// Simulate recorded as applied, but table was not created in live DB
-	if err := eng.Ledger().SetStatus(db, 20260101000000, ledger.StatusApplied, "missing table simulation"); err != nil {
+	if err := eng.Ledger().SetStatus(db, 20260101000000, ledger.StatusApplied, "missing table simulation", "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
-	report, err := Collect(db, eng, dir, "pg-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "pg-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestCollect_Postgres_DetectsMissingObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	report, err = Collect(db, eng, dir, "pg-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "pg-target")
 	if err != nil {
 		t.Fatalf("second Collect() returned error: %v", err)
 	}
@@ -121,12 +121,12 @@ func TestCollect_Postgres_DetectsContentHashDrift(t *testing.T) {
 	// Record hash of original content in ledger
 	origSum := sha256.Sum256(originalContent)
 	origHash := hex.EncodeToString(origSum[:])
-	if err := eng.Ledger().SetStatusWithHash(db, 20260101000000, ledger.StatusApplied, "hash test", origHash); err != nil {
+	if err := eng.Ledger().SetStatusWithHash(db, 20260101000000, ledger.StatusApplied, "hash test", origHash, "dbtools_migration_history"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify reports OK initially
-	report, err := Collect(db, eng, dir, "pg-target")
+	report, err := Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "pg-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestCollect_Postgres_DetectsContentHashDrift(t *testing.T) {
 	}
 
 	// Collect should flag DRIFT due to file hash mismatch
-	report, err = Collect(db, eng, dir, "pg-target")
+	report, err = Collect(db, eng, dir, ".up.sql", "dbtools_migration_history", "pg-target")
 	if err != nil {
 		t.Fatalf("Collect() returned error: %v", err)
 	}

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -15,6 +15,7 @@ nuance than a table row can hold, read the matching file before using them:
 
 | Topic | File |
 |---|---|
+| `dbtools adopt` — importing incumbent migration ledgers (Flyway/EF/Knex/Alembic) | `adopt.md` |
 | `dbtools clone` masking rules, `[clone.mask]` config, `--where`/`--limit` | `clone.md` |
 | `dbtools doctor` — all 6 checks, exit-code meaning per check | `doctor.md` |
 | Exit-code contract (`plan`/`verify`/`up`/`down`) and CI/agent loop pattern | `ci-gate.md` |
@@ -34,6 +35,7 @@ nuance than a table row can hold, read the matching file before using them:
 | **reset** | Local-only: drops, recreates DB, replays all migrations, runs `seed.sql`. Supports mssql/postgres only — errors on a MySQL target. | `rollback`, `restore` |
 | **seed.sql** | Single optional root SQL file run automatically after `reset`. | Multiple seed files or fixture scripts |
 | **ledger** | `dbtools_migration_history` table tracking per-migration `applied`/`reverted` state. | Generic "history table" |
+| **adopt** | Imports existing migration history from another tool (Flyway, Knex, EF, Alembic, golang-migrate). | `import`, `migrate-from` |
 | **repair** | Corrects ledger status for target versions. Replaces deprecated `stamp`. | `stamp` (removed in v1) |
 | **clone** | Copies data from one target into another of the same engine, masking sensitive columns by default (`--no-mask` opts out). Data-only — schema must already match (both targets share one `migrations_dir`). | `sync`, `restore` |
 
@@ -45,6 +47,9 @@ dbtools init
 
 # Create new migration file ({timestamp}_{name}.up.sql)
 dbtools new <migration_name>
+
+# Import existing migration history from another runner
+dbtools adopt <target_name> [--yes] [--force] [--from-table X --version-column Y]
 
 # Apply pending migrations to target (default: local)
 dbtools up [--target local]
@@ -112,6 +117,12 @@ dbtools dashboard
 
 ```toml
 migrations_dir = "migrations"
+
+[ledger]
+table = "dbtools_migration_history" # optional; custom ledger table name
+
+[migrations]
+up_suffix = ".up.sql"               # optional; override to ".sql" for flat layouts
 
 [targets.local]
 url_env = "DBTOOLS_LOCAL_URL"

--- a/skills/using-dbtools/adopt.md
+++ b/skills/using-dbtools/adopt.md
@@ -1,0 +1,56 @@
+# dbtools adopt
+
+`dbtools adopt` imports an existing migration ledger from an incumbent tool (golang-migrate, Flyway, EF Core, Knex, Alembic, or a bespoke runner) into dbtools without re-running any migration SQL.
+
+## Usage
+
+```bash
+# Preview adoption plan (dry run, default)
+dbtools adopt <target>
+
+# Write imported records to the dbtools ledger and stamp cursor
+dbtools adopt <target> --yes
+
+# Proceed even if orphan records exist (source table rows with no matching file)
+dbtools adopt <target> --yes --force
+
+# Adopt from a bespoke or non-standard table
+dbtools adopt <target> --from-table custom_history --version-column version_num [--applied-at-column applied_on] --yes
+```
+
+## How It Works
+
+1. **Source Table Detection**:
+   When `--from-table` is omitted, dbtools automatically probes for candidate migration tables in order:
+   - `schema_migrations` (golang-migrate, Rails)
+   - `flyway_schema_history` (Flyway)
+   - `__EFMigrationsHistory` (Entity Framework Core)
+   - `knex_migrations` (Knex.js)
+   - `alembic_version` (Alembic)
+   - `SchemaVersions` (DbUp)
+
+2. **3-Way Diff**:
+   Compares source table records against local migration files in `migrations_dir`:
+   - **Matched**: Version present in both database and local directory -> imported.
+   - **Pending**: Migration file exists on disk, but not recorded in source table -> remains pending for future `dbtools up`/`push`.
+   - **Orphan**: Version recorded in source table, but no migration file on disk -> blocks adoption unless `--force` is passed.
+
+3. **Orphan Safety Gate**:
+   If orphan history rows are found, `dbtools adopt` exits with code `1` and writes nothing. Passing `--force` overrides the block and imports only the matched versions (orphans are skipped).
+
+4. **Hash Source (`adopted`)**:
+   Imported records are stored in the ledger with `hash_source = 'adopted'`. `dbtools doctor` and `dbtools verify` recognize these rows and skip content hash comparison (since historical file content was never directly observed at original execution time).
+
+## Configuration
+
+If your project uses custom table names or flat migration suffixes, configure them in `dbtools.toml`:
+
+```toml
+migrations_dir = "migrations"
+
+[ledger]
+table = "my_custom_migration_history" # Default: "dbtools_migration_history"
+
+[migrations]
+up_suffix = ".sql"                    # Default: ".up.sql" (supports ".sql" for flat layouts)
+```

--- a/skills/using-dbtools/adopt.md
+++ b/skills/using-dbtools/adopt.md
@@ -41,6 +41,17 @@ dbtools adopt <target> --from-table custom_history --version-column version_num 
 4. **Hash Source (`adopted`)**:
    Imported records are stored in the ledger with `hash_source = 'adopted'`. `dbtools doctor` and `dbtools verify` recognize these rows and skip content hash comparison (since historical file content was never directly observed at original execution time).
 
+### Alembic
+
+`alembic_version` is auto-detected, but `dbtools adopt` requires a numeric
+version per row (matching the `<version>_<name>` filename convention every
+other supported tool uses). Alembic's default `version_num` column stores a
+non-numeric revision hash (e.g. `ae1027a6acf1`), which does not parse as a
+version and adopt will fail with an explicit error rather than adopting a
+partial or incorrect ledger. If your Alembic setup already uses purely
+numeric revision IDs, adoption works normally; otherwise, use
+`dbtools repair` to construct the ledger by hand.
+
 ## Configuration
 
 If your project uses custom table names or flat migration suffixes, configure them in `dbtools.toml`:

--- a/skills/using-dbtools/adopt.md
+++ b/skills/using-dbtools/adopt.md
@@ -65,3 +65,5 @@ table = "my_custom_migration_history" # Default: "dbtools_migration_history"
 [migrations]
 up_suffix = ".sql"                    # Default: ".up.sql" (supports ".sql" for flat layouts)
 ```
+
+**Current limitation**: a custom `up_suffix` is honored by the read-only commands (`status`, `plan`, `doctor`, `verify`) and by `adopt` itself, but not yet by `up`/`push` — golang-migrate's own execution engine still requires the `.up.sql`/`.down.sql` convention, so `up`/`push` refuse to run with a non-default `up_suffix` rather than silently applying nothing.


### PR DESCRIPTION
## Summary

Implements `dbtools adopt` (closes #61), providing an on-ramp for databases already managed by other migration runners (golang-migrate, Flyway, EF Core, Knex, Alembic, or bespoke tools) into dbtools without re-running historical migration SQL.

### What's included:
- **`[ledger] table`**: Configurable migration ledger table name across all 4 engine dialects (MSSQL, PostgreSQL, MySQL, SQLite) with identifier validation.
- **`[migrations] up_suffix`**: Configurable up-migration filename suffix (e.g. `.sql` for flat `<version>_<name>.sql` layouts).
- **`hash_source` column**: Added `hash_source` column to the ledger schema (with idempotent ALTER migrations across all dialects) to mark rows imported via `adopt` as `hash_source = 'adopted'`.
- **`doctor` & `verify` updates**: Skip cryptographic hash comparison for `hash_source = 'adopted'` rows, reporting them as skipped rather than false drift.
- **`internal/adopt`**: Source table auto-detection (`schema_migrations`, `flyway_schema_history`, `__EFMigrationsHistory`, `knex_migrations`, `alembic_version`, `SchemaVersions`), row reading with flexible version parsing, and 3-way diffing (matched, pending, orphan).
- **`dbtools adopt <target>` command**:
  - Read-only dry run by default (`--yes` required to write).
  - Orphan safety check (`--force` required to proceed if database history contains versions missing on disk).
  - `--from-table`, `--version-column`, and `--applied-at-column` flags for bespoke source tables.
  - Updates ledger with `SetStatusAdopted` and stamps the migration cursor to the highest matched version.
- **Documentation**: Command reference in `README.md`, `skills/using-dbtools/SKILL.md`, and dedicated guide in `skills/using-dbtools/adopt.md`.

## Verification
- Unit tests across all packages (`go test ./...`).
- `scripts/dev-local.sh all` (build + lint + vet + unit tests + black-box CLI smoke test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `adopt` command to import existing migration history from supported tools and databases.
  * Added dry-run, confirmation, force, JSON output, and custom source-table/column options.
  * Added configurable migration filename suffixes and ledger table names.
  * Added safeguards and reporting for matched, pending, and orphan migrations.

* **Bug Fixes**
  * Improved migration discovery and drift checks when custom configuration is used.
  * Adopted migrations are handled appropriately during integrity verification.

* **Documentation**
  * Documented the new command, configuration options, supported migration sources, and safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->