### PR TITLE
feat: extend Introspect to a full structural catalog

### DIFF
--- a/internal/engine/mssqlengine/introspect.go
+++ b/internal/engine/mssqlengine/introspect.go
@@ -254,7 +254,7 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		return nil, nil, fmt.Errorf("iterating check constraints: %w", err)
 	}
 
-	// Indexes — excludes the PK-backing index (is_primary_key = 0).
+	// Indexes — excludes the PK-backing index and INCLUDE columns.
 	ixRows, err := db.Query(`
 		SELECT s.name, t.name, i.name, c.name, i.is_unique, ic.key_ordinal
 		FROM sys.indexes i
@@ -262,7 +262,7 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		JOIN sys.schemas s ON s.schema_id = t.schema_id
 		JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
 		JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
-		WHERE i.name IS NOT NULL AND i.is_primary_key = 0
+		WHERE i.name IS NOT NULL AND i.is_primary_key = 0 AND ic.is_included_column = 0
 		ORDER BY s.name, t.name, i.name, ic.key_ordinal`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("introspecting indexes: %w", err)

--- a/internal/engine/mssqlengine/introspect.go
+++ b/internal/engine/mssqlengine/introspect.go
@@ -52,7 +52,9 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			c.IS_NULLABLE,
 			c.CHARACTER_MAXIMUM_LENGTH,
 			c.NUMERIC_PRECISION,
-			c.NUMERIC_SCALE
+			c.NUMERIC_SCALE,
+			c.ORDINAL_POSITION,
+			c.COLUMN_DEFAULT
 		FROM INFORMATION_SCHEMA.TABLES t
 		JOIN INFORMATION_SCHEMA.COLUMNS c 
 			ON t.TABLE_SCHEMA = c.TABLE_SCHEMA 
@@ -75,6 +77,8 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 	for rows.Next() {
 		var schemaName, tableName, colName, dataType, isNullableStr string
 		var maxLen, precision, scale sql.NullInt64
+		var ordinalPos int
+		var columnDefault sql.NullString
 
 		if err := rows.Scan(
 			&schemaName,
@@ -85,6 +89,8 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			&maxLen,
 			&precision,
 			&scale,
+			&ordinalPos,
+			&columnDefault,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scanning column info: %w", err)
 		}
@@ -115,14 +121,16 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		}
 
 		col := generate.ColumnSchema{
-			Name:       colName,
-			PyName:     generate.SanitizeFieldName(colName),
-			DataType:   dataType,
-			PythonType: pythonType,
-			IsNullable: strings.ToUpper(isNullableStr) == "YES",
-			MaxLength:  maxLen,
-			Precision:  precision,
-			Scale:      scale,
+			Name:            colName,
+			PyName:          generate.SanitizeFieldName(colName),
+			DataType:        dataType,
+			PythonType:      pythonType,
+			IsNullable:      strings.ToUpper(isNullableStr) == "YES",
+			MaxLength:       maxLen,
+			Precision:       precision,
+			Scale:           scale,
+			OrdinalPosition: ordinalPos,
+			DefaultValue:    columnDefault,
 		}
 
 		tbl.Columns = append(tbl.Columns, col)
@@ -130,6 +138,169 @@ func Introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("iterating schema rows: %w", err)
+	}
+
+	// Primary keys, via sys.indexes/sys.index_columns (is_primary_key=1).
+	pkRows, err := db.Query(`
+		SELECT s.name, t.name, c.name
+		FROM sys.indexes i
+		JOIN sys.tables t ON t.object_id = i.object_id
+		JOIN sys.schemas s ON s.schema_id = t.schema_id
+		JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+		JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+		WHERE i.is_primary_key = 1`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting primary keys: %w", err)
+	}
+	pkColumns := make(map[string]map[string]bool)
+	for pkRows.Next() {
+		var schemaName, tableName, colName string
+		if err := pkRows.Scan(&schemaName, &tableName, &colName); err != nil {
+			pkRows.Close()
+			return nil, nil, fmt.Errorf("scanning primary key: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if pkColumns[fullKey] == nil {
+			pkColumns[fullKey] = make(map[string]bool)
+		}
+		pkColumns[fullKey][colName] = true
+	}
+	pkRows.Close()
+	if err := pkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating primary keys: %w", err)
+	}
+	for fullKey, tbl := range tableMap {
+		for i, col := range tbl.Columns {
+			if pkColumns[fullKey][col.Name] {
+				tbl.Columns[i].IsPrimaryKey = true
+			}
+		}
+	}
+
+	// Foreign keys.
+	fkRows, err := db.Query(`
+		SELECT s.name, t.name, fk.name, c.name, fkc.constraint_column_id,
+			rs.name, rt.name, rc.name
+		FROM sys.foreign_keys fk
+		JOIN sys.tables t ON t.object_id = fk.parent_object_id
+		JOIN sys.schemas s ON s.schema_id = t.schema_id
+		JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+		JOIN sys.columns c ON c.object_id = fkc.parent_object_id AND c.column_id = fkc.parent_column_id
+		JOIN sys.tables rt ON rt.object_id = fk.referenced_object_id
+		JOIN sys.schemas rs ON rs.schema_id = rt.schema_id
+		JOIN sys.columns rc ON rc.object_id = fkc.referenced_object_id AND rc.column_id = fkc.referenced_column_id
+		ORDER BY s.name, t.name, fk.name, fkc.constraint_column_id`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting foreign keys: %w", err)
+	}
+	fkMap := make(map[string]map[string]*generate.ForeignKeySchema)
+	fkOrder := make(map[string][]string)
+	for fkRows.Next() {
+		var schemaName, tableName, fkName, colName, refSchema, refTable, refColumn string
+		var colID int
+		if err := fkRows.Scan(&schemaName, &tableName, &fkName, &colName, &colID, &refSchema, &refTable, &refColumn); err != nil {
+			fkRows.Close()
+			return nil, nil, fmt.Errorf("scanning foreign key: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if fkMap[fullKey] == nil {
+			fkMap[fullKey] = make(map[string]*generate.ForeignKeySchema)
+		}
+		fk, exists := fkMap[fullKey][fkName]
+		if !exists {
+			fk = &generate.ForeignKeySchema{Name: fkName, RefSchema: refSchema, RefTable: refTable}
+			fkMap[fullKey][fkName] = fk
+			fkOrder[fullKey] = append(fkOrder[fullKey], fkName)
+		}
+		fk.Columns = append(fk.Columns, colName)
+		fk.RefColumns = append(fk.RefColumns, refColumn)
+	}
+	fkRows.Close()
+	if err := fkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating foreign keys: %w", err)
+	}
+	for fullKey, names := range fkOrder {
+		tbl, ok := tableMap[fullKey]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.ForeignKeys = append(tbl.ForeignKeys, *fkMap[fullKey][name])
+		}
+	}
+
+	// CHECK constraints.
+	ckRows, err := db.Query(`
+		SELECT s.name, t.name, cc.name, cc.definition
+		FROM sys.check_constraints cc
+		JOIN sys.tables t ON t.object_id = cc.parent_object_id
+		JOIN sys.schemas s ON s.schema_id = t.schema_id`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting check constraints: %w", err)
+	}
+	for ckRows.Next() {
+		var schemaName, tableName, constraintName, expr string
+		if err := ckRows.Scan(&schemaName, &tableName, &constraintName, &expr); err != nil {
+			ckRows.Close()
+			return nil, nil, fmt.Errorf("scanning check constraint: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if tbl, ok := tableMap[fullKey]; ok {
+			tbl.CheckConstraints = append(tbl.CheckConstraints, generate.CheckConstraintSchema{Name: constraintName, Expression: expr})
+		}
+	}
+	ckRows.Close()
+	if err := ckRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating check constraints: %w", err)
+	}
+
+	// Indexes — excludes the PK-backing index (is_primary_key = 0).
+	ixRows, err := db.Query(`
+		SELECT s.name, t.name, i.name, c.name, i.is_unique, ic.key_ordinal
+		FROM sys.indexes i
+		JOIN sys.tables t ON t.object_id = i.object_id
+		JOIN sys.schemas s ON s.schema_id = t.schema_id
+		JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+		JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+		WHERE i.name IS NOT NULL AND i.is_primary_key = 0
+		ORDER BY s.name, t.name, i.name, ic.key_ordinal`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting indexes: %w", err)
+	}
+	ixMap := make(map[string]map[string]*generate.IndexSchema)
+	ixOrder := make(map[string][]string)
+	for ixRows.Next() {
+		var schemaName, tableName, indexName, colName string
+		var unique bool
+		var ordinal int
+		if err := ixRows.Scan(&schemaName, &tableName, &indexName, &colName, &unique, &ordinal); err != nil {
+			ixRows.Close()
+			return nil, nil, fmt.Errorf("scanning index: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if ixMap[fullKey] == nil {
+			ixMap[fullKey] = make(map[string]*generate.IndexSchema)
+		}
+		idx, exists := ixMap[fullKey][indexName]
+		if !exists {
+			idx = &generate.IndexSchema{Name: indexName, Unique: unique}
+			ixMap[fullKey][indexName] = idx
+			ixOrder[fullKey] = append(ixOrder[fullKey], indexName)
+		}
+		idx.Columns = append(idx.Columns, colName)
+	}
+	ixRows.Close()
+	if err := ixRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating indexes: %w", err)
+	}
+	for fullKey, names := range ixOrder {
+		tbl, ok := tableMap[fullKey]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.Indexes = append(tbl.Indexes, *ixMap[fullKey][name])
+		}
 	}
 
 	result := make([]generate.TableSchema, 0, len(tableOrder))

--- a/internal/engine/mssqlengine/introspect_integration_test.go
+++ b/internal/engine/mssqlengine/introspect_integration_test.go
@@ -52,7 +52,7 @@ CREATE TABLE dbtools_it_orders (
 )`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status) INCLUDE (total)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +89,8 @@ CREATE TABLE dbtools_it_orders (
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique ||
+		strings.Join(orders.Indexes[0].Columns, ",") != "status" {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique on status with INCLUDE columns excluded", orders.Indexes)
 	}
 }

--- a/internal/engine/mssqlengine/introspect_integration_test.go
+++ b/internal/engine/mssqlengine/introspect_integration_test.go
@@ -24,13 +24,16 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 		t.Fatalf("Open() returned error: %v", err)
 	}
 	defer db.Close()
-	t.Cleanup(func() {
-		db.Exec(`DROP TABLE IF EXISTS orders`)
-		db.Exec(`DROP TABLE IF EXISTS customers`)
-	})
+
+	cleanup := func() {
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_orders`)
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_customers`)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
 
 	if _, err := db.Exec(`
-CREATE TABLE customers (
+CREATE TABLE dbtools_it_customers (
     id INT NOT NULL,
     email NVARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
@@ -38,18 +41,18 @@ CREATE TABLE customers (
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`
-CREATE TABLE orders (
+CREATE TABLE dbtools_it_orders (
     id INT NOT NULL,
     customer_id INT NOT NULL,
     status NVARCHAR(50) NOT NULL DEFAULT 'pending',
     total DECIMAL(10,2) NOT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
-    CONSTRAINT chk_total CHECK (total >= 0)
+    CONSTRAINT fk_it_customer FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers(id),
+    CONSTRAINT chk_it_total CHECK (total >= 0)
 )`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,12 +63,12 @@ CREATE TABLE orders (
 
 	var orders *generate.TableSchema
 	for i := range tables {
-		if tables[i].Name == "orders" {
+		if tables[i].Name == "dbtools_it_orders" {
 			orders = &tables[i]
 		}
 	}
 	if orders == nil {
-		t.Fatal("orders table not found")
+		t.Fatal("dbtools_it_orders table not found")
 	}
 
 	for _, c := range orders.Columns {
@@ -80,13 +83,13 @@ CREATE TABLE orders (
 		}
 	}
 
-	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
-		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to dbtools_it_customers", orders.ForeignKeys)
 	}
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
 	}
 }

--- a/internal/engine/mssqlengine/introspect_integration_test.go
+++ b/internal/engine/mssqlengine/introspect_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package mssqlengine
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+	"github.com/seanpham99/dbtools/internal/testdb"
+)
+
+func TestIntrospect_FullStructuralCatalog(t *testing.T) {
+	url := os.Getenv("DBTOOLS_TEST_MSSQL_URL")
+	if url == "" {
+		t.Skip("DBTOOLS_TEST_MSSQL_URL not set, skipping integration test")
+	}
+	if err := testdb.ResetTracking(url); err != nil {
+		t.Fatal(err)
+	}
+	db, err := Open(url)
+	if err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	defer db.Close()
+	t.Cleanup(func() {
+		db.Exec(`DROP TABLE IF EXISTS orders`)
+		db.Exec(`DROP TABLE IF EXISTS customers`)
+	})
+
+	if _, err := db.Exec(`
+CREATE TABLE customers (
+    id INT NOT NULL,
+    email NVARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE orders (
+    id INT NOT NULL,
+    customer_id INT NOT NULL,
+    status NVARCHAR(50) NOT NULL DEFAULT 'pending',
+    total DECIMAL(10,2) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
+    CONSTRAINT chk_total CHECK (total >= 0)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+		t.Fatal(err)
+	}
+
+	tables, _, err := Introspect(db, nil)
+	if err != nil {
+		t.Fatalf("Introspect() returned error: %v", err)
+	}
+
+	var orders *generate.TableSchema
+	for i := range tables {
+		if tables[i].Name == "orders" {
+			orders = &tables[i]
+		}
+	}
+	if orders == nil {
+		t.Fatal("orders table not found")
+	}
+
+	for _, c := range orders.Columns {
+		if c.Name == "id" && !c.IsPrimaryKey {
+			t.Error("id column: want IsPrimaryKey true")
+		}
+		if c.Name == "status" && (!c.DefaultValue.Valid || !strings.Contains(c.DefaultValue.String, "pending")) {
+			t.Errorf("status column DefaultValue = %+v, want it to mention 'pending'", c.DefaultValue)
+		}
+		if c.OrdinalPosition == 0 {
+			t.Errorf("column %s: OrdinalPosition = 0, want a real 1-based position", c.Name)
+		}
+	}
+
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	}
+	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
+		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
+	}
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	}
+}

--- a/internal/engine/mysqlengine/introspect.go
+++ b/internal/engine/mysqlengine/introspect.go
@@ -195,29 +195,9 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		}
 	}
 
-	// CHECK constraints (MySQL 8.0.16+).
-	ckRows, err := db.Query(`
-		SELECT tc.TABLE_NAME, cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
-		FROM information_schema.table_constraints tc
-		JOIN information_schema.check_constraints cc
-			ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
-		WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'CHECK'`)
-	if err != nil {
-		return nil, nil, fmt.Errorf("introspecting check constraints: %w", err)
-	}
-	for ckRows.Next() {
-		var tableName, constraintName, expr string
-		if err := ckRows.Scan(&tableName, &constraintName, &expr); err != nil {
-			ckRows.Close()
-			return nil, nil, fmt.Errorf("scanning check constraint: %w", err)
-		}
-		if tbl, ok := tableMap[tableName]; ok {
-			tbl.CheckConstraints = append(tbl.CheckConstraints, generate.CheckConstraintSchema{Name: constraintName, Expression: expr})
-		}
-	}
-	ckRows.Close()
-	if err := ckRows.Err(); err != nil {
-		return nil, nil, fmt.Errorf("iterating check constraints: %w", err)
+	// CHECK constraints, when supported (MySQL 8.0.16+).
+	if err := introspectCheckConstraints(db, tableMap); err != nil {
+		return nil, nil, err
 	}
 
 	// Indexes — excludes PRIMARY (MySQL's reserved name for the PK-backing index).
@@ -268,4 +248,40 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		result = append(result, *tableMap[name])
 	}
 	return result, unmapped, nil
+}
+
+func introspectCheckConstraints(db *sql.DB, tableMap map[string]*generate.TableSchema) error {
+	var hasCheckConstraints bool
+	if err := db.QueryRow(`
+		SELECT COUNT(*) > 0
+		FROM information_schema.tables
+		WHERE table_schema = 'information_schema' AND table_name = 'CHECK_CONSTRAINTS'`).Scan(&hasCheckConstraints); err != nil {
+		return fmt.Errorf("detecting check constraint support: %w", err)
+	}
+	if hasCheckConstraints {
+		ckRows, err := db.Query(`
+			SELECT tc.TABLE_NAME, cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+			FROM information_schema.table_constraints tc
+			JOIN information_schema.check_constraints cc
+				ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+			WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'CHECK'`)
+		if err != nil {
+			return fmt.Errorf("introspecting check constraints: %w", err)
+		}
+		for ckRows.Next() {
+			var tableName, constraintName, expr string
+			if err := ckRows.Scan(&tableName, &constraintName, &expr); err != nil {
+				ckRows.Close()
+				return fmt.Errorf("scanning check constraint: %w", err)
+			}
+			if tbl, ok := tableMap[tableName]; ok {
+				tbl.CheckConstraints = append(tbl.CheckConstraints, generate.CheckConstraintSchema{Name: constraintName, Expression: expr})
+			}
+		}
+		ckRows.Close()
+		if err := ckRows.Err(); err != nil {
+			return fmt.Errorf("iterating check constraints: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/engine/mysqlengine/introspect.go
+++ b/internal/engine/mysqlengine/introspect.go
@@ -54,7 +54,9 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			c.IS_NULLABLE,
 			c.CHARACTER_MAXIMUM_LENGTH,
 			c.NUMERIC_PRECISION,
-			c.NUMERIC_SCALE
+			c.NUMERIC_SCALE,
+			c.ORDINAL_POSITION,
+			c.COLUMN_DEFAULT
 		FROM information_schema.tables t
 		JOIN information_schema.columns c
 			ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME
@@ -75,8 +77,10 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 	for rows.Next() {
 		var schemaName, tableName, colName, dataType, isNullableStr string
 		var maxLen, precision, scale sql.NullInt64
+		var ordinalPos int
+		var columnDefault sql.NullString
 
-		if err := rows.Scan(&schemaName, &tableName, &colName, &dataType, &isNullableStr, &maxLen, &precision, &scale); err != nil {
+		if err := rows.Scan(&schemaName, &tableName, &colName, &dataType, &isNullableStr, &maxLen, &precision, &scale, &ordinalPos, &columnDefault); err != nil {
 			return nil, nil, fmt.Errorf("scanning column info: %w", err)
 		}
 
@@ -97,19 +101,166 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		}
 
 		tbl.Columns = append(tbl.Columns, generate.ColumnSchema{
-			Name:       colName,
-			PyName:     generate.SanitizeFieldName(colName),
-			DataType:   dataType,
-			PythonType: pythonType,
-			IsNullable: strings.ToUpper(isNullableStr) == "YES",
-			MaxLength:  maxLen,
-			Precision:  precision,
-			Scale:      scale,
+			Name:            colName,
+			PyName:          generate.SanitizeFieldName(colName),
+			DataType:        dataType,
+			PythonType:      pythonType,
+			IsNullable:      strings.ToUpper(isNullableStr) == "YES",
+			MaxLength:       maxLen,
+			Precision:       precision,
+			Scale:           scale,
+			OrdinalPosition: ordinalPos,
+			DefaultValue:    columnDefault,
 		})
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("iterating schema rows: %w", err)
+	}
+
+	// Primary keys.
+	pkRows, err := db.Query(`
+		SELECT TABLE_NAME, COLUMN_NAME
+		FROM information_schema.key_column_usage
+		WHERE TABLE_SCHEMA = DATABASE() AND CONSTRAINT_NAME = 'PRIMARY'`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting primary keys: %w", err)
+	}
+	pkColumns := make(map[string]map[string]bool)
+	for pkRows.Next() {
+		var tableName, colName string
+		if err := pkRows.Scan(&tableName, &colName); err != nil {
+			pkRows.Close()
+			return nil, nil, fmt.Errorf("scanning primary key: %w", err)
+		}
+		if pkColumns[tableName] == nil {
+			pkColumns[tableName] = make(map[string]bool)
+		}
+		pkColumns[tableName][colName] = true
+	}
+	pkRows.Close()
+	if err := pkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating primary keys: %w", err)
+	}
+	for tableName, tbl := range tableMap {
+		for i, col := range tbl.Columns {
+			if pkColumns[tableName][col.Name] {
+				tbl.Columns[i].IsPrimaryKey = true
+			}
+		}
+	}
+
+	// Foreign keys.
+	fkRows, err := db.Query(`
+		SELECT TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME, ORDINAL_POSITION,
+			REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+		FROM information_schema.key_column_usage
+		WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL
+		ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting foreign keys: %w", err)
+	}
+	fkMap := make(map[string]map[string]*generate.ForeignKeySchema)
+	fkOrder := make(map[string][]string)
+	for fkRows.Next() {
+		var tableName, constraintName, colName, refSchema, refTable, refColumn string
+		var ordinal int
+		if err := fkRows.Scan(&tableName, &constraintName, &colName, &ordinal, &refSchema, &refTable, &refColumn); err != nil {
+			fkRows.Close()
+			return nil, nil, fmt.Errorf("scanning foreign key: %w", err)
+		}
+		if fkMap[tableName] == nil {
+			fkMap[tableName] = make(map[string]*generate.ForeignKeySchema)
+		}
+		fk, exists := fkMap[tableName][constraintName]
+		if !exists {
+			fk = &generate.ForeignKeySchema{Name: constraintName, RefSchema: refSchema, RefTable: refTable}
+			fkMap[tableName][constraintName] = fk
+			fkOrder[tableName] = append(fkOrder[tableName], constraintName)
+		}
+		fk.Columns = append(fk.Columns, colName)
+		fk.RefColumns = append(fk.RefColumns, refColumn)
+	}
+	fkRows.Close()
+	if err := fkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating foreign keys: %w", err)
+	}
+	for tableName, names := range fkOrder {
+		tbl, ok := tableMap[tableName]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.ForeignKeys = append(tbl.ForeignKeys, *fkMap[tableName][name])
+		}
+	}
+
+	// CHECK constraints (MySQL 8.0.16+).
+	ckRows, err := db.Query(`
+		SELECT tc.TABLE_NAME, cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.check_constraints cc
+			ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+		WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'CHECK'`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting check constraints: %w", err)
+	}
+	for ckRows.Next() {
+		var tableName, constraintName, expr string
+		if err := ckRows.Scan(&tableName, &constraintName, &expr); err != nil {
+			ckRows.Close()
+			return nil, nil, fmt.Errorf("scanning check constraint: %w", err)
+		}
+		if tbl, ok := tableMap[tableName]; ok {
+			tbl.CheckConstraints = append(tbl.CheckConstraints, generate.CheckConstraintSchema{Name: constraintName, Expression: expr})
+		}
+	}
+	ckRows.Close()
+	if err := ckRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating check constraints: %w", err)
+	}
+
+	// Indexes — excludes PRIMARY (MySQL's reserved name for the PK-backing index).
+	ixRows, err := db.Query(`
+		SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX, NON_UNIQUE
+		FROM information_schema.statistics
+		WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME != 'PRIMARY'
+		ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting indexes: %w", err)
+	}
+	ixMap := make(map[string]map[string]*generate.IndexSchema)
+	ixOrder := make(map[string][]string)
+	for ixRows.Next() {
+		var tableName, indexName, colName string
+		var seq, nonUnique int
+		if err := ixRows.Scan(&tableName, &indexName, &colName, &seq, &nonUnique); err != nil {
+			ixRows.Close()
+			return nil, nil, fmt.Errorf("scanning index: %w", err)
+		}
+		if ixMap[tableName] == nil {
+			ixMap[tableName] = make(map[string]*generate.IndexSchema)
+		}
+		idx, exists := ixMap[tableName][indexName]
+		if !exists {
+			idx = &generate.IndexSchema{Name: indexName, Unique: nonUnique == 0}
+			ixMap[tableName][indexName] = idx
+			ixOrder[tableName] = append(ixOrder[tableName], indexName)
+		}
+		idx.Columns = append(idx.Columns, colName)
+	}
+	ixRows.Close()
+	if err := ixRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating indexes: %w", err)
+	}
+	for tableName, names := range ixOrder {
+		tbl, ok := tableMap[tableName]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.Indexes = append(tbl.Indexes, *ixMap[tableName][name])
+		}
 	}
 
 	result := make([]generate.TableSchema, 0, len(tableOrder))

--- a/internal/engine/mysqlengine/introspect_integration_test.go
+++ b/internal/engine/mysqlengine/introspect_integration_test.go
@@ -20,13 +20,16 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	t.Cleanup(func() {
-		db.Exec(`DROP TABLE IF EXISTS orders`)
-		db.Exec(`DROP TABLE IF EXISTS customers`)
-	})
+
+	cleanup := func() {
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_orders`)
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_customers`)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
 
 	if _, err := db.Exec(`
-CREATE TABLE customers (
+CREATE TABLE dbtools_it_customers (
     id INT NOT NULL,
     email VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
@@ -34,18 +37,18 @@ CREATE TABLE customers (
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`
-CREATE TABLE orders (
+CREATE TABLE dbtools_it_orders (
     id INT NOT NULL,
     customer_id INT NOT NULL,
     status VARCHAR(50) NOT NULL DEFAULT 'pending',
     total DECIMAL(10,2) NOT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
-    CONSTRAINT chk_total CHECK (total >= 0)
+    CONSTRAINT fk_it_customer FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers(id),
+    CONSTRAINT chk_it_total CHECK (total >= 0)
 ) ENGINE=InnoDB`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,12 +59,12 @@ CREATE TABLE orders (
 
 	var orders *generate.TableSchema
 	for i := range tables {
-		if tables[i].Name == "orders" {
+		if tables[i].Name == "dbtools_it_orders" {
 			orders = &tables[i]
 		}
 	}
 	if orders == nil {
-		t.Fatal("orders table not found")
+		t.Fatal("dbtools_it_orders table not found")
 	}
 
 	for _, c := range orders.Columns {
@@ -76,13 +79,13 @@ CREATE TABLE orders (
 		}
 	}
 
-	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
-		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to dbtools_it_customers", orders.ForeignKeys)
 	}
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
 	}
 }

--- a/internal/engine/mysqlengine/introspect_integration_test.go
+++ b/internal/engine/mysqlengine/introspect_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package mysqlengine
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+)
+
+func TestIntrospect_FullStructuralCatalog(t *testing.T) {
+	url := os.Getenv("DBTOOLS_TEST_MYSQL_URL")
+	if url == "" {
+		t.Skip("DBTOOLS_TEST_MYSQL_URL not set, skipping integration test")
+	}
+	db, err := Open(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	t.Cleanup(func() {
+		db.Exec(`DROP TABLE IF EXISTS orders`)
+		db.Exec(`DROP TABLE IF EXISTS customers`)
+	})
+
+	if _, err := db.Exec(`
+CREATE TABLE customers (
+    id INT NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE orders (
+    id INT NOT NULL,
+    customer_id INT NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    total DECIMAL(10,2) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
+    CONSTRAINT chk_total CHECK (total >= 0)
+) ENGINE=InnoDB`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+		t.Fatal(err)
+	}
+
+	tables, _, err := introspect(db, nil)
+	if err != nil {
+		t.Fatalf("introspect() returned error: %v", err)
+	}
+
+	var orders *generate.TableSchema
+	for i := range tables {
+		if tables[i].Name == "orders" {
+			orders = &tables[i]
+		}
+	}
+	if orders == nil {
+		t.Fatal("orders table not found")
+	}
+
+	for _, c := range orders.Columns {
+		if c.Name == "id" && !c.IsPrimaryKey {
+			t.Error("id column: want IsPrimaryKey true")
+		}
+		if c.Name == "status" && (!c.DefaultValue.Valid || !strings.Contains(c.DefaultValue.String, "pending")) {
+			t.Errorf("status column DefaultValue = %+v, want it to mention 'pending'", c.DefaultValue)
+		}
+		if c.OrdinalPosition == 0 {
+			t.Errorf("column %s: OrdinalPosition = 0, want a real 1-based position", c.Name)
+		}
+	}
+
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	}
+	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
+		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
+	}
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	}
+}

--- a/internal/engine/mysqlengine/introspect_integration_test.go
+++ b/internal/engine/mysqlengine/introspect_integration_test.go
@@ -85,7 +85,13 @@ CREATE TABLE dbtools_it_orders (
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	var statusIdx *generate.IndexSchema
+	for i := range orders.Indexes {
+		if orders.Indexes[i].Name == "idx_it_orders_status" {
+			statusIdx = &orders.Indexes[i]
+		}
+	}
+	if statusIdx == nil || !statusIdx.Unique || len(statusIdx.Columns) != 1 || statusIdx.Columns[0] != "status" {
+		t.Errorf("Indexes = %+v, want idx_it_orders_status, unique on status (PK-backing index excluded)", orders.Indexes)
 	}
 }

--- a/internal/engine/mysqlengine/introspect_integration_test.go
+++ b/internal/engine/mysqlengine/introspect_integration_test.go
@@ -90,6 +90,15 @@ CREATE TABLE dbtools_it_orders (
 		if orders.Indexes[i].Name == "idx_it_orders_status" {
 			statusIdx = &orders.Indexes[i]
 		}
+		// The PK-backing index is always named PRIMARY in MySQL — must
+		// never appear in Indexes (already represented via
+		// ColumnSchema.IsPrimaryKey). Asserted by name rather than an
+		// exact-count check, since InnoDB also auto-creates a secondary
+		// index on the FK column (customer_id) that legitimately belongs
+		// in this list.
+		if orders.Indexes[i].Name == "PRIMARY" {
+			t.Errorf("Indexes contains the PK-backing index %+v, want it excluded", orders.Indexes[i])
+		}
 	}
 	if statusIdx == nil || !statusIdx.Unique || len(statusIdx.Columns) != 1 || statusIdx.Columns[0] != "status" {
 		t.Errorf("Indexes = %+v, want idx_it_orders_status, unique on status (PK-backing index excluded)", orders.Indexes)

--- a/internal/engine/mysqlengine/introspect_test.go
+++ b/internal/engine/mysqlengine/introspect_test.go
@@ -1,6 +1,12 @@
 package mysqlengine
 
-import "testing"
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+	_ "modernc.org/sqlite"
+)
 
 func TestMapMySQLToPython(t *testing.T) {
 	tests := []struct {
@@ -30,5 +36,29 @@ func TestMapMySQLToPython(t *testing.T) {
 		if known != tt.expectKnow {
 			t.Errorf("MapMySQLToPython(%q) known = %v; want %v", tt.input, known, tt.expectKnow)
 		}
+	}
+}
+
+func TestIntrospectCheckConstraints_Unsupported(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`ATTACH DATABASE ':memory:' AS information_schema`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE information_schema.tables (table_schema TEXT, table_name TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	original := &generate.TableSchema{Name: "orders", Columns: []generate.ColumnSchema{{Name: "id"}}}
+	tableMap := map[string]*generate.TableSchema{"orders": original}
+	if err := introspectCheckConstraints(db, tableMap); err != nil {
+		t.Fatalf("introspectCheckConstraints() returned error for unsupported metadata: %v", err)
+	}
+	if tableMap["orders"] != original || len(original.Columns) != 1 || len(original.CheckConstraints) != 0 {
+		t.Errorf("tableMap = %+v, want previously collected schema data preserved", tableMap)
 	}
 }

--- a/internal/engine/postgresengine/introspect.go
+++ b/internal/engine/postgresengine/introspect.go
@@ -59,7 +59,9 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			c.is_nullable,
 			c.character_maximum_length,
 			c.numeric_precision,
-			c.numeric_scale
+			c.numeric_scale,
+			c.ordinal_position,
+			c.column_default
 		FROM information_schema.tables t
 		JOIN information_schema.columns c
 			ON t.table_schema = c.table_schema
@@ -82,8 +84,10 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 	for rows.Next() {
 		var schemaName, tableName, colName, dataType, isNullableStr string
 		var maxLen, precision, scale sql.NullInt64
+		var ordinalPos int
+		var columnDefault sql.NullString
 
-		if err := rows.Scan(&schemaName, &tableName, &colName, &dataType, &isNullableStr, &maxLen, &precision, &scale); err != nil {
+		if err := rows.Scan(&schemaName, &tableName, &colName, &dataType, &isNullableStr, &maxLen, &precision, &scale, &ordinalPos, &columnDefault); err != nil {
 			return nil, nil, fmt.Errorf("scanning column info: %w", err)
 		}
 
@@ -105,19 +109,186 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		}
 
 		tbl.Columns = append(tbl.Columns, generate.ColumnSchema{
-			Name:       colName,
-			PyName:     generate.SanitizeFieldName(colName),
-			DataType:   dataType,
-			PythonType: pythonType,
-			IsNullable: strings.ToUpper(isNullableStr) == "YES",
-			MaxLength:  maxLen,
-			Precision:  precision,
-			Scale:      scale,
+			Name:            colName,
+			PyName:          generate.SanitizeFieldName(colName),
+			DataType:        dataType,
+			PythonType:      pythonType,
+			IsNullable:      strings.ToUpper(isNullableStr) == "YES",
+			MaxLength:       maxLen,
+			Precision:       precision,
+			Scale:           scale,
+			OrdinalPosition: ordinalPos,
+			DefaultValue:    columnDefault,
 		})
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("iterating schema rows: %w", err)
+	}
+
+	// Primary keys.
+	pkRows, err := db.Query(`
+		SELECT tc.table_schema, tc.table_name, kcu.column_name
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+			ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+		WHERE tc.constraint_type = 'PRIMARY KEY'`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting primary keys: %w", err)
+	}
+	pkColumns := make(map[string]map[string]bool) // fullKey -> column name -> true
+	for pkRows.Next() {
+		var schemaName, tableName, colName string
+		if err := pkRows.Scan(&schemaName, &tableName, &colName); err != nil {
+			pkRows.Close()
+			return nil, nil, fmt.Errorf("scanning primary key: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if pkColumns[fullKey] == nil {
+			pkColumns[fullKey] = make(map[string]bool)
+		}
+		pkColumns[fullKey][colName] = true
+	}
+	pkRows.Close()
+	if err := pkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating primary keys: %w", err)
+	}
+	for fullKey, tbl := range tableMap {
+		for i, col := range tbl.Columns {
+			if pkColumns[fullKey][col.Name] {
+				tbl.Columns[i].IsPrimaryKey = true
+			}
+		}
+	}
+
+	// Foreign keys.
+	fkRows, err := db.Query(`
+		SELECT tc.table_schema, tc.table_name, tc.constraint_name, kcu.column_name, kcu.ordinal_position,
+			ccu.table_schema, ccu.table_name, ccu.column_name
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kcu
+			ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+		JOIN information_schema.constraint_column_usage ccu
+			ON tc.constraint_name = ccu.constraint_name
+		WHERE tc.constraint_type = 'FOREIGN KEY'
+		ORDER BY tc.table_schema, tc.table_name, tc.constraint_name, kcu.ordinal_position`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting foreign keys: %w", err)
+	}
+	fkMap := make(map[string]map[string]*generate.ForeignKeySchema) // fullKey -> constraint name -> FK
+	var fkOrder = make(map[string][]string)
+	for fkRows.Next() {
+		var schemaName, tableName, constraintName, colName, refSchema, refTable, refColumn string
+		var ordinal int
+		if err := fkRows.Scan(&schemaName, &tableName, &constraintName, &colName, &ordinal, &refSchema, &refTable, &refColumn); err != nil {
+			fkRows.Close()
+			return nil, nil, fmt.Errorf("scanning foreign key: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if fkMap[fullKey] == nil {
+			fkMap[fullKey] = make(map[string]*generate.ForeignKeySchema)
+		}
+		fk, exists := fkMap[fullKey][constraintName]
+		if !exists {
+			fk = &generate.ForeignKeySchema{Name: constraintName, RefSchema: refSchema, RefTable: refTable}
+			fkMap[fullKey][constraintName] = fk
+			fkOrder[fullKey] = append(fkOrder[fullKey], constraintName)
+		}
+		fk.Columns = append(fk.Columns, colName)
+		fk.RefColumns = append(fk.RefColumns, refColumn)
+	}
+	fkRows.Close()
+	if err := fkRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating foreign keys: %w", err)
+	}
+	for fullKey, names := range fkOrder {
+		tbl, ok := tableMap[fullKey]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.ForeignKeys = append(tbl.ForeignKeys, *fkMap[fullKey][name])
+		}
+	}
+
+	// CHECK constraints.
+	ckRows, err := db.Query(`
+		SELECT tc.table_schema, tc.table_name, tc.constraint_name, cc.check_clause
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.check_constraints cc
+			ON tc.constraint_schema = cc.constraint_schema AND tc.constraint_name = cc.constraint_name
+		WHERE tc.constraint_type = 'CHECK'
+			AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting check constraints: %w", err)
+	}
+	for ckRows.Next() {
+		var schemaName, tableName, constraintName, expr string
+		if err := ckRows.Scan(&schemaName, &tableName, &constraintName, &expr); err != nil {
+			ckRows.Close()
+			return nil, nil, fmt.Errorf("scanning check constraint: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if tbl, ok := tableMap[fullKey]; ok {
+			tbl.CheckConstraints = append(tbl.CheckConstraints, generate.CheckConstraintSchema{Name: constraintName, Expression: expr})
+		}
+	}
+	ckRows.Close()
+	if err := ckRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating check constraints: %w", err)
+	}
+
+	// Indexes — excludes the primary key's backing index (already
+	// represented via ColumnSchema.IsPrimaryKey) by joining against
+	// pg_constraint and filtering out any index that backs a PK.
+	ixRows, err := db.Query(`
+		SELECT n.nspname, t.relname, i.relname, a.attname, ix.indisunique,
+			array_position(ix.indkey, a.attnum)
+		FROM pg_index ix
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_class t ON t.oid = ix.indrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+		WHERE t.relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+			AND NOT ix.indisprimary
+		ORDER BY n.nspname, t.relname, i.relname, array_position(ix.indkey, a.attnum)`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting indexes: %w", err)
+	}
+	ixMap := make(map[string]map[string]*generate.IndexSchema)
+	ixOrder := make(map[string][]string)
+	for ixRows.Next() {
+		var schemaName, tableName, indexName, colName string
+		var unique bool
+		var pos int
+		if err := ixRows.Scan(&schemaName, &tableName, &indexName, &colName, &unique, &pos); err != nil {
+			ixRows.Close()
+			return nil, nil, fmt.Errorf("scanning index: %w", err)
+		}
+		fullKey := fmt.Sprintf("%s.%s", schemaName, tableName)
+		if ixMap[fullKey] == nil {
+			ixMap[fullKey] = make(map[string]*generate.IndexSchema)
+		}
+		idx, exists := ixMap[fullKey][indexName]
+		if !exists {
+			idx = &generate.IndexSchema{Name: indexName, Unique: unique}
+			ixMap[fullKey][indexName] = idx
+			ixOrder[fullKey] = append(ixOrder[fullKey], indexName)
+		}
+		idx.Columns = append(idx.Columns, colName)
+	}
+	ixRows.Close()
+	if err := ixRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating indexes: %w", err)
+	}
+	for fullKey, names := range ixOrder {
+		tbl, ok := tableMap[fullKey]
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			tbl.Indexes = append(tbl.Indexes, *ixMap[fullKey][name])
+		}
 	}
 
 	result := make([]generate.TableSchema, 0, len(tableOrder))

--- a/internal/engine/postgresengine/introspect.go
+++ b/internal/engine/postgresengine/introspect.go
@@ -164,12 +164,21 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 	// Foreign keys.
 	fkRows, err := db.Query(`
 		SELECT tc.table_schema, tc.table_name, tc.constraint_name, kcu.column_name, kcu.ordinal_position,
-			ccu.table_schema, ccu.table_name, ccu.column_name
+			ukcu.table_schema, ukcu.table_name, ukcu.column_name
 		FROM information_schema.table_constraints tc
 		JOIN information_schema.key_column_usage kcu
-			ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
-		JOIN information_schema.constraint_column_usage ccu
-			ON tc.constraint_name = ccu.constraint_name
+			ON tc.constraint_catalog = kcu.constraint_catalog
+			AND tc.constraint_schema = kcu.constraint_schema
+			AND tc.constraint_name = kcu.constraint_name
+		JOIN information_schema.referential_constraints rc
+			ON tc.constraint_catalog = rc.constraint_catalog
+			AND tc.constraint_schema = rc.constraint_schema
+			AND tc.constraint_name = rc.constraint_name
+		JOIN information_schema.key_column_usage ukcu
+			ON rc.unique_constraint_catalog = ukcu.constraint_catalog
+			AND rc.unique_constraint_schema = ukcu.constraint_schema
+			AND rc.unique_constraint_name = ukcu.constraint_name
+			AND kcu.position_in_unique_constraint = ukcu.ordinal_position
 		WHERE tc.constraint_type = 'FOREIGN KEY'
 		ORDER BY tc.table_schema, tc.table_name, tc.constraint_name, kcu.ordinal_position`)
 	if err != nil {
@@ -240,19 +249,21 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 	}
 
 	// Indexes — excludes the primary key's backing index (already
-	// represented via ColumnSchema.IsPrimaryKey) by joining against
-	// pg_constraint and filtering out any index that backs a PK.
+	// represented via ColumnSchema.IsPrimaryKey) and limits indkey to
+	// indnkeyatts so INCLUDE columns are omitted.
 	ixRows, err := db.Query(`
 		SELECT n.nspname, t.relname, i.relname, a.attname, ix.indisunique,
-			array_position(ix.indkey, a.attnum)
+			key.ordinality
 		FROM pg_index ix
 		JOIN pg_class i ON i.oid = ix.indexrelid
 		JOIN pg_class t ON t.oid = ix.indrelid
 		JOIN pg_namespace n ON n.oid = t.relnamespace
-		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+		JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS key(attnum, ordinality)
+			ON key.ordinality <= ix.indnkeyatts
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = key.attnum
 		WHERE t.relkind = 'r' AND n.nspname NOT IN ('pg_catalog', 'information_schema')
 			AND NOT ix.indisprimary
-		ORDER BY n.nspname, t.relname, i.relname, array_position(ix.indkey, a.attnum)`)
+		ORDER BY n.nspname, t.relname, i.relname, key.ordinality`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("introspecting indexes: %w", err)
 	}

--- a/internal/engine/postgresengine/introspect.go
+++ b/internal/engine/postgresengine/introspect.go
@@ -218,7 +218,8 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		JOIN information_schema.check_constraints cc
 			ON tc.constraint_schema = cc.constraint_schema AND tc.constraint_name = cc.constraint_name
 		WHERE tc.constraint_type = 'CHECK'
-			AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')`)
+			AND tc.table_schema NOT IN ('pg_catalog', 'information_schema')
+			AND cc.check_clause NOT LIKE '%IS NOT NULL'`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("introspecting check constraints: %w", err)
 	}

--- a/internal/engine/postgresengine/introspect_integration_test.go
+++ b/internal/engine/postgresengine/introspect_integration_test.go
@@ -20,13 +20,16 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	t.Cleanup(func() {
-		db.Exec(`DROP TABLE IF EXISTS orders`)
-		db.Exec(`DROP TABLE IF EXISTS customers`)
-	})
+
+	cleanup := func() {
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_orders`)
+		db.Exec(`DROP TABLE IF EXISTS dbtools_it_customers`)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
 
 	if _, err := db.Exec(`
-CREATE TABLE customers (
+CREATE TABLE dbtools_it_customers (
     id INT NOT NULL,
     email TEXT NOT NULL,
     PRIMARY KEY (id)
@@ -34,18 +37,18 @@ CREATE TABLE customers (
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`
-CREATE TABLE orders (
+CREATE TABLE dbtools_it_orders (
     id INT NOT NULL,
     customer_id INT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     total NUMERIC(10,2) NOT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
-    CONSTRAINT chk_total CHECK (total >= 0)
+    CONSTRAINT fk_it_customer FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers(id),
+    CONSTRAINT chk_it_total CHECK (total >= 0)
 )`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,12 +59,12 @@ CREATE TABLE orders (
 
 	var orders *generate.TableSchema
 	for i := range tables {
-		if tables[i].Name == "orders" {
+		if tables[i].Name == "dbtools_it_orders" {
 			orders = &tables[i]
 		}
 	}
 	if orders == nil {
-		t.Fatal("orders table not found")
+		t.Fatal("dbtools_it_orders table not found")
 	}
 
 	for _, c := range orders.Columns {
@@ -76,13 +79,13 @@ CREATE TABLE orders (
 		}
 	}
 
-	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
-		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to dbtools_it_customers", orders.ForeignKeys)
 	}
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
 	}
 }

--- a/internal/engine/postgresengine/introspect_integration_test.go
+++ b/internal/engine/postgresengine/introspect_integration_test.go
@@ -31,8 +31,9 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 	if _, err := db.Exec(`
 CREATE TABLE dbtools_it_customers (
     id INT NOT NULL,
+	tenant_id INT NOT NULL,
     email TEXT NOT NULL,
-    PRIMARY KEY (id)
+	PRIMARY KEY (id, tenant_id)
 )`); err != nil {
 		t.Fatal(err)
 	}
@@ -40,15 +41,16 @@ CREATE TABLE dbtools_it_customers (
 CREATE TABLE dbtools_it_orders (
     id INT NOT NULL,
     customer_id INT NOT NULL,
+	tenant_id INT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     total NUMERIC(10,2) NOT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT fk_it_customer FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers(id),
+	CONSTRAINT fk_it_customer FOREIGN KEY (customer_id, tenant_id) REFERENCES dbtools_it_customers(id, tenant_id),
     CONSTRAINT chk_it_total CHECK (total >= 0)
 )`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status) INCLUDE (total)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,13 +81,16 @@ CREATE TABLE dbtools_it_orders (
 		}
 	}
 
-	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" {
-		t.Errorf("ForeignKeys = %+v, want one FK to dbtools_it_customers", orders.ForeignKeys)
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" ||
+		strings.Join(orders.ForeignKeys[0].Columns, ",") != "customer_id,tenant_id" ||
+		strings.Join(orders.ForeignKeys[0].RefColumns, ",") != "id,tenant_id" {
+		t.Errorf("ForeignKeys = %+v, want one positionally aligned composite FK to dbtools_it_customers", orders.ForeignKeys)
 	}
 	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
 		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique ||
+		strings.Join(orders.Indexes[0].Columns, ",") != "status" {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique on status with INCLUDE columns excluded", orders.Indexes)
 	}
 }

--- a/internal/engine/postgresengine/introspect_integration_test.go
+++ b/internal/engine/postgresengine/introspect_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package postgresengine
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+)
+
+func TestIntrospect_FullStructuralCatalog(t *testing.T) {
+	url := os.Getenv("DBTOOLS_TEST_POSTGRES_URL")
+	if url == "" {
+		t.Skip("DBTOOLS_TEST_POSTGRES_URL not set, skipping integration test")
+	}
+	db, err := Postgres{}.Open(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	t.Cleanup(func() {
+		db.Exec(`DROP TABLE IF EXISTS orders`)
+		db.Exec(`DROP TABLE IF EXISTS customers`)
+	})
+
+	if _, err := db.Exec(`
+CREATE TABLE customers (
+    id INT NOT NULL,
+    email TEXT NOT NULL,
+    PRIMARY KEY (id)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE orders (
+    id INT NOT NULL,
+    customer_id INT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    total NUMERIC(10,2) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
+    CONSTRAINT chk_total CHECK (total >= 0)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+		t.Fatal(err)
+	}
+
+	tables, _, err := introspect(db, nil)
+	if err != nil {
+		t.Fatalf("introspect() returned error: %v", err)
+	}
+
+	var orders *generate.TableSchema
+	for i := range tables {
+		if tables[i].Name == "orders" {
+			orders = &tables[i]
+		}
+	}
+	if orders == nil {
+		t.Fatal("orders table not found")
+	}
+
+	for _, c := range orders.Columns {
+		if c.Name == "id" && !c.IsPrimaryKey {
+			t.Error("id column: want IsPrimaryKey true")
+		}
+		if c.Name == "status" && (!c.DefaultValue.Valid || !strings.Contains(c.DefaultValue.String, "pending")) {
+			t.Errorf("status column DefaultValue = %+v, want it to mention 'pending'", c.DefaultValue)
+		}
+		if c.OrdinalPosition == 0 {
+			t.Errorf("column %s: OrdinalPosition = 0, want a real 1-based position", c.Name)
+		}
+	}
+
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	}
+	if len(orders.CheckConstraints) != 1 || !strings.Contains(orders.CheckConstraints[0].Expression, "total") {
+		t.Errorf("CheckConstraints = %+v, want one mentioning total", orders.CheckConstraints)
+	}
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique (PK-backing index excluded)", orders.Indexes)
+	}
+}

--- a/internal/engine/sqliteengine/introspect.go
+++ b/internal/engine/sqliteengine/introspect.go
@@ -104,12 +104,13 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 				unmapped = append(unmapped, fmt.Sprintf("%s.%s.%s: %s", DefaultSchema, name, colName, declaredType))
 			}
 
+			integerPrimaryKey := pk > 0 && strings.EqualFold(strings.TrimSpace(declaredType), "INTEGER")
 			tbl.Columns = append(tbl.Columns, generate.ColumnSchema{
 				Name:            colName,
 				PyName:          generate.SanitizeFieldName(colName),
 				DataType:        declaredType,
 				PythonType:      pythonType,
-				IsNullable:      notNull == 0 && pk == 0, // INTEGER PRIMARY KEY is implicitly NOT NULL
+				IsNullable:      notNull == 0 && !integerPrimaryKey,
 				OrdinalPosition: cid + 1,
 				DefaultValue:    dflt,
 				IsPrimaryKey:    pk > 0,
@@ -129,7 +130,8 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		var fkOrder []int
 		for fkRows.Next() {
 			var id, seq int
-			var refTable, fromCol, toCol string
+			var refTable, fromCol string
+			var toCol sql.NullString
 			var onUpdate, onDelete, match string
 			if err := fkRows.Scan(&id, &seq, &refTable, &fromCol, &toCol, &onUpdate, &onDelete, &match); err != nil {
 				fkRows.Close()
@@ -142,7 +144,7 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 				fkOrder = append(fkOrder, id)
 			}
 			fk.Columns = append(fk.Columns, fromCol)
-			fk.RefColumns = append(fk.RefColumns, toCol)
+			fk.RefColumns = append(fk.RefColumns, toCol.String)
 		}
 		fkRows.Close()
 		if err := fkRows.Err(); err != nil {
@@ -164,7 +166,8 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 		var ixRows []ixRow
 		for ixListRows.Next() {
 			var seq int
-			var idxName, origin string
+			var idxName sql.NullString
+			var origin string
 			var unique, partial int
 			if err := ixListRows.Scan(&seq, &idxName, &unique, &origin, &partial); err != nil {
 				ixListRows.Close()
@@ -175,7 +178,7 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			if origin == "pk" {
 				continue
 			}
-			ixRows = append(ixRows, ixRow{name: idxName, unique: unique == 1, origin: origin})
+			ixRows = append(ixRows, ixRow{name: idxName.String, unique: unique == 1, origin: origin})
 		}
 		ixListRows.Close()
 		if err := ixListRows.Err(); err != nil {

--- a/internal/engine/sqliteengine/introspect.go
+++ b/internal/engine/sqliteengine/introspect.go
@@ -105,11 +105,14 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			}
 
 			tbl.Columns = append(tbl.Columns, generate.ColumnSchema{
-				Name:       colName,
-				PyName:     generate.SanitizeFieldName(colName),
-				DataType:   declaredType,
-				PythonType: pythonType,
-				IsNullable: notNull == 0 && pk == 0, // INTEGER PRIMARY KEY is implicitly NOT NULL
+				Name:            colName,
+				PyName:          generate.SanitizeFieldName(colName),
+				DataType:        declaredType,
+				PythonType:      pythonType,
+				IsNullable:      notNull == 0 && pk == 0, // INTEGER PRIMARY KEY is implicitly NOT NULL
+				OrdinalPosition: cid + 1,
+				DefaultValue:    dflt,
+				IsPrimaryKey:    pk > 0,
 			})
 		}
 		if err := colRows.Err(); err != nil {
@@ -117,6 +120,89 @@ func introspect(db *sql.DB, excludeList []string) ([]generate.TableSchema, []str
 			return nil, nil, fmt.Errorf("iterating columns of %s: %w", name, err)
 		}
 		colRows.Close()
+
+		fkRows, err := db.Query(fmt.Sprintf(`PRAGMA foreign_key_list("%s")`, strings.ReplaceAll(name, `"`, `""`)))
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading foreign keys of %s: %w", name, err)
+		}
+		fkMap := make(map[int]*generate.ForeignKeySchema)
+		var fkOrder []int
+		for fkRows.Next() {
+			var id, seq int
+			var refTable, fromCol, toCol string
+			var onUpdate, onDelete, match string
+			if err := fkRows.Scan(&id, &seq, &refTable, &fromCol, &toCol, &onUpdate, &onDelete, &match); err != nil {
+				fkRows.Close()
+				return nil, nil, fmt.Errorf("scanning foreign key of %s: %w", name, err)
+			}
+			fk, exists := fkMap[id]
+			if !exists {
+				fk = &generate.ForeignKeySchema{Name: fmt.Sprintf("fk_%d", id), RefSchema: DefaultSchema, RefTable: refTable}
+				fkMap[id] = fk
+				fkOrder = append(fkOrder, id)
+			}
+			fk.Columns = append(fk.Columns, fromCol)
+			fk.RefColumns = append(fk.RefColumns, toCol)
+		}
+		fkRows.Close()
+		if err := fkRows.Err(); err != nil {
+			return nil, nil, fmt.Errorf("iterating foreign keys of %s: %w", name, err)
+		}
+		for _, id := range fkOrder {
+			tbl.ForeignKeys = append(tbl.ForeignKeys, *fkMap[id])
+		}
+
+		ixListRows, err := db.Query(fmt.Sprintf(`PRAGMA index_list("%s")`, strings.ReplaceAll(name, `"`, `""`)))
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading indexes of %s: %w", name, err)
+		}
+		type ixRow struct {
+			name   string
+			unique bool
+			origin string
+		}
+		var ixRows []ixRow
+		for ixListRows.Next() {
+			var seq int
+			var idxName, origin string
+			var unique, partial int
+			if err := ixListRows.Scan(&seq, &idxName, &unique, &origin, &partial); err != nil {
+				ixListRows.Close()
+				return nil, nil, fmt.Errorf("scanning index list of %s: %w", name, err)
+			}
+			// origin 'pk' is the implicit PK-backing index — already
+			// represented via ColumnSchema.IsPrimaryKey, excluded here.
+			if origin == "pk" {
+				continue
+			}
+			ixRows = append(ixRows, ixRow{name: idxName, unique: unique == 1, origin: origin})
+		}
+		ixListRows.Close()
+		if err := ixListRows.Err(); err != nil {
+			return nil, nil, fmt.Errorf("iterating index list of %s: %w", name, err)
+		}
+		for _, ix := range ixRows {
+			infoRows, err := db.Query(fmt.Sprintf(`PRAGMA index_info("%s")`, strings.ReplaceAll(ix.name, `"`, `""`)))
+			if err != nil {
+				return nil, nil, fmt.Errorf("reading index info of %s: %w", ix.name, err)
+			}
+			idx := generate.IndexSchema{Name: ix.name, Unique: ix.unique}
+			for infoRows.Next() {
+				var seqno, cid int
+				var colName string
+				if err := infoRows.Scan(&seqno, &cid, &colName); err != nil {
+					infoRows.Close()
+					return nil, nil, fmt.Errorf("scanning index info of %s: %w", ix.name, err)
+				}
+				idx.Columns = append(idx.Columns, colName)
+			}
+			infoRows.Close()
+			if err := infoRows.Err(); err != nil {
+				return nil, nil, fmt.Errorf("iterating index info of %s: %w", ix.name, err)
+			}
+			tbl.Indexes = append(tbl.Indexes, idx)
+		}
+
 		result = append(result, tbl)
 	}
 	return result, unmapped, nil

--- a/internal/engine/sqliteengine/introspect_test.go
+++ b/internal/engine/sqliteengine/introspect_test.go
@@ -15,19 +15,19 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 	}
 	defer db.Close()
 
-	if _, err := db.Exec(`CREATE TABLE customers (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`); err != nil {
+	if _, err := db.Exec(`CREATE TABLE dbtools_it_customers (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`
-CREATE TABLE orders (
+CREATE TABLE dbtools_it_orders (
     id INTEGER PRIMARY KEY,
     customer_id INTEGER NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
-    FOREIGN KEY (customer_id) REFERENCES customers(id)
+    FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers(id)
 )`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_it_orders_status ON dbtools_it_orders (status)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -38,12 +38,12 @@ CREATE TABLE orders (
 
 	var orders *generate.TableSchema
 	for i := range tables {
-		if tables[i].Name == "orders" {
+		if tables[i].Name == "dbtools_it_orders" {
 			orders = &tables[i]
 		}
 	}
 	if orders == nil {
-		t.Fatal("orders table not found")
+		t.Fatal("dbtools_it_orders table not found")
 	}
 
 	for _, c := range orders.Columns {
@@ -58,11 +58,11 @@ CREATE TABLE orders (
 		}
 	}
 
-	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
-		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "dbtools_it_customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to dbtools_it_customers", orders.ForeignKeys)
 	}
-	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
-		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique", orders.Indexes)
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_it_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_it_orders_status, unique", orders.Indexes)
 	}
 	if len(orders.CheckConstraints) != 0 {
 		t.Errorf("CheckConstraints = %+v, want always empty for SQLite", orders.CheckConstraints)

--- a/internal/engine/sqliteengine/introspect_test.go
+++ b/internal/engine/sqliteengine/introspect_test.go
@@ -1,0 +1,70 @@
+package sqliteengine
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+)
+
+func TestIntrospect_FullStructuralCatalog(t *testing.T) {
+	db, err := SQLite{}.Open("sqlite://" + filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE customers (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    customer_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    FOREIGN KEY (customer_id) REFERENCES customers(id)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX idx_orders_status ON orders (status)`); err != nil {
+		t.Fatal(err)
+	}
+
+	tables, _, err := introspect(db, nil)
+	if err != nil {
+		t.Fatalf("introspect() returned error: %v", err)
+	}
+
+	var orders *generate.TableSchema
+	for i := range tables {
+		if tables[i].Name == "orders" {
+			orders = &tables[i]
+		}
+	}
+	if orders == nil {
+		t.Fatal("orders table not found")
+	}
+
+	for _, c := range orders.Columns {
+		if c.Name == "id" && !c.IsPrimaryKey {
+			t.Error("id column: want IsPrimaryKey true")
+		}
+		if c.Name == "status" && (!c.DefaultValue.Valid || !strings.Contains(c.DefaultValue.String, "pending")) {
+			t.Errorf("status column DefaultValue = %+v, want it to mention 'pending'", c.DefaultValue)
+		}
+		if c.OrdinalPosition == 0 {
+			t.Errorf("column %s: OrdinalPosition = 0, want a real 1-based position", c.Name)
+		}
+	}
+
+	if len(orders.ForeignKeys) != 1 || orders.ForeignKeys[0].RefTable != "customers" {
+		t.Errorf("ForeignKeys = %+v, want one FK to customers", orders.ForeignKeys)
+	}
+	if len(orders.Indexes) != 1 || orders.Indexes[0].Name != "idx_orders_status" || !orders.Indexes[0].Unique {
+		t.Errorf("Indexes = %+v, want exactly idx_orders_status, unique", orders.Indexes)
+	}
+	if len(orders.CheckConstraints) != 0 {
+		t.Errorf("CheckConstraints = %+v, want always empty for SQLite", orders.CheckConstraints)
+	}
+}

--- a/internal/engine/sqliteengine/introspect_test.go
+++ b/internal/engine/sqliteengine/introspect_test.go
@@ -18,6 +18,12 @@ func TestIntrospect_FullStructuralCatalog(t *testing.T) {
 	if _, err := db.Exec(`CREATE TABLE dbtools_it_customers (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := db.Exec(`CREATE TABLE dbtools_it_text_keys (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE dbtools_it_implicit_fk (customer_id INTEGER, FOREIGN KEY (customer_id) REFERENCES dbtools_it_customers)`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := db.Exec(`
 CREATE TABLE dbtools_it_orders (
     id INTEGER PRIMARY KEY,
@@ -36,10 +42,17 @@ CREATE TABLE dbtools_it_orders (
 		t.Fatalf("introspect() returned error: %v", err)
 	}
 
-	var orders *generate.TableSchema
+	var orders, customers, textKeys, implicitFK *generate.TableSchema
 	for i := range tables {
-		if tables[i].Name == "dbtools_it_orders" {
+		switch tables[i].Name {
+		case "dbtools_it_orders":
 			orders = &tables[i]
+		case "dbtools_it_customers":
+			customers = &tables[i]
+		case "dbtools_it_text_keys":
+			textKeys = &tables[i]
+		case "dbtools_it_implicit_fk":
+			implicitFK = &tables[i]
 		}
 	}
 	if orders == nil {
@@ -66,5 +79,14 @@ CREATE TABLE dbtools_it_orders (
 	}
 	if len(orders.CheckConstraints) != 0 {
 		t.Errorf("CheckConstraints = %+v, want always empty for SQLite", orders.CheckConstraints)
+	}
+	if customers == nil || len(customers.Columns) == 0 || customers.Columns[0].IsNullable {
+		t.Errorf("INTEGER PRIMARY KEY column = %+v, want non-nullable", customers)
+	}
+	if textKeys == nil || len(textKeys.Columns) == 0 || !textKeys.Columns[0].IsNullable {
+		t.Errorf("TEXT PRIMARY KEY column = %+v, want nullable without NOT NULL", textKeys)
+	}
+	if implicitFK == nil || len(implicitFK.ForeignKeys) != 1 || len(implicitFK.ForeignKeys[0].RefColumns) != 1 || implicitFK.ForeignKeys[0].RefColumns[0] != "" {
+		t.Errorf("implicit parent-key ForeignKeys = %+v, want one nullable referenced column represented as empty", implicitFK)
 	}
 }

--- a/internal/generate/introspect.go
+++ b/internal/generate/introspect.go
@@ -14,12 +14,51 @@ type ColumnSchema struct {
 	MaxLength  sql.NullInt64
 	Precision  sql.NullInt64
 	Scale      sql.NullInt64
+	// OrdinalPosition is the column's 1-based position in the table.
+	OrdinalPosition int
+	// DefaultValue is the raw dialect-native default expression text
+	// ("" / invalid if none). Never compared across dialects — only
+	// used to detect drift within the same database.
+	DefaultValue sql.NullString
+	// IsPrimaryKey is true if this column participates in the table's
+	// primary key (composite or single-column).
+	IsPrimaryKey bool
+}
+
+// IndexSchema represents one non-primary-key index. A primary key's
+// backing index is never listed here — it's already represented by
+// ColumnSchema.IsPrimaryKey on its member columns.
+type IndexSchema struct {
+	Name    string
+	Columns []string // ordered
+	Unique  bool
+}
+
+// ForeignKeySchema represents one foreign key constraint.
+type ForeignKeySchema struct {
+	Name       string
+	Columns    []string // ordered, this table's side
+	RefSchema  string
+	RefTable   string
+	RefColumns []string // ordered, referenced table's side
+}
+
+// CheckConstraintSchema represents one CHECK constraint. Always empty for
+// SQLite tables — SQLite has no queryable CHECK-constraint catalog, only
+// the raw CREATE TABLE text, and dbtools deliberately does not parse DDL
+// text to approximate this (see the design spec).
+type CheckConstraintSchema struct {
+	Name       string
+	Expression string
 }
 
 // TableSchema represents a table or view's metadata across database engines.
 type TableSchema struct {
-	Schema    string
-	Name      string
-	ClassName string
-	Columns   []ColumnSchema
+	Schema           string
+	Name             string
+	ClassName        string
+	Columns          []ColumnSchema
+	Indexes          []IndexSchema
+	ForeignKeys      []ForeignKeySchema
+	CheckConstraints []CheckConstraintSchema
 }


### PR DESCRIPTION
## Summary

Extends `eng.Introspect()` across all 4 dialects (Postgres, MySQL, MSSQL, SQLite) to catalog primary keys, foreign keys, indexes, defaults, CHECK constraints, and column ordinal positions (issue #62, sub-project A of 2).

- **Shared types (`internal/generate/introspect.go`)**: extended `TableSchema` and `ColumnSchema` with `Indexes`, `ForeignKeys`, `CheckConstraints`, `OrdinalPosition`, `DefaultValue`, and `IsPrimaryKey`.
- **Postgres (`internal/engine/postgresengine`)**: PK, FK, CHECK, and indexes cataloged via `information_schema` and `pg_catalog`.
- **MySQL (`internal/engine/mysqlengine`)**: PK, FK, CHECK, and indexes cataloged via `information_schema`.
- **MSSQL (`internal/engine/mssqlengine`)**: PK, FK, CHECK, and indexes cataloged via `sys.*` and `INFORMATION_SCHEMA`.
- **SQLite (`internal/engine/sqliteengine`)**: PK, FK, indexes, and defaults cataloged via PRAGMA statements (CHECK constraints unsupported, documented and explicit).

## Verification
- Local build, lint (`gofmt`, `go vet`), unit tests, and smoke test passed via `scripts/dev-local.sh all`.
- Integration tests added for each dialect asserting structural catalog output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced schema introspection for SQL Server, MySQL, PostgreSQL, and SQLite.
  * Column details now include ordinal positions, default values, and primary-key status.
  * Table details now include indexes, foreign keys, and check constraints.
  * Added support for composite relationship metadata and unique index information.
* **Tests**
  * Added comprehensive integration and functional coverage validating structural catalog details across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->