### PR TITLE
feat: implement dbtools diff command (closes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Project-Scoped Local Dev Containers**: `dbtools start`/`stop`/`restart`/`logs` manage a tool-owned Docker container per project (no cross-repo name/port collisions), with data persisting across `stop`/`start` by default.
 - **Zero-Drift Migration Ledger**: Tracks applied migrations with SHA-256 content hashes in `dbtools_migration_history` alongside standard `schema_migrations` cursors.
 - **Read-Only Drift Verification**: `dbtools verify` validates that live database objects match migration definitions and alerts when files were modified after execution.
+- **Full Structural Replay & Diff**: `dbtools diff` replays migrations into an ephemeral scratch database and compares its structural schema catalog against live targets to detect unrecorded 2am manual hotfixes that bypass the ledger.
 - **Rollback & Down Migrations**: `dbtools down` applies `.down.sql` files in reverse; `dbtools rollback` is a ledger-only soft-revert — the safe prod verb. Destructive ops on protected targets require `--preview --yes`.
 - **Agent-First Ergonomics**: Terraform-style exit-code contract (`0` clean / `1` error / `2` pending changes or drift), `--dry-run` previews, universal `--json`, and `DBTOOLS_NO_PROMPT=1` fail-closed mode for CI and AI agents. See [docs/exit-codes.md](docs/exit-codes.md).
 - **Environment & Target Protection**: Targets are defined in `dbtools.toml` by environment variable names (`url_env`), ensuring secrets never leak into version control. Protected targets reject destructive operations (`up`, `reset`, and `down` without `--preview --yes`).
@@ -131,6 +132,7 @@ dbtools status
 | `doctor` | `dbtools doctor [target] [--json]` | Strictly read-only health, integrity, drift, and security audit. Exit 0 healthy / 1 error / 2 issues. |
 | `plan` | `dbtools plan [--target X] [--json]` | Read-only preview of pending migrations + ledger drift, without applying anything. Agent/CI-friendly: exit 0 = safe to apply. |
 | `verify` | `dbtools verify <target> [--json]` | Non-destructive verification of ledger history and live database objects. Exit 0 clean / 1 error / 2 drift (content-hash mismatch or missing object). |
+| `diff` | `dbtools diff <target> [--against <url>] [--json]` | Replays migrations into a scratch DB and compares structural schema against the live target. Exit 0 clean / 1 error / 2 drift. |
 | `down` | `dbtools down <target> [N] [--preview] [--yes]` | Applies `.down.sql` migrations in reverse order, recorded in the ledger. Protected targets require `--preview --yes`. |
 | `rollback` | `dbtools rollback <target> [--yes]` | Ledger-only soft-revert (marks `reverted`, never data-destroying). The safe prod verb. |
 | `repair` | `dbtools repair <target> <v>:<status> --yes` | Corrects ledger state (`applied`/`reverted`) and resynchronizes the version cursor. |

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/seanpham99/dbtools/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff [target]",
+	Short: "Replay migrations into a scratch database and compare structurally against the live target (read-only)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = false
+		err := runDiff(args[0])
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			cmd.SilenceUsage = true
+		}
+		return err
+	},
+}
+
+var diffAgainst string
+
+func init() {
+	diffCmd.Flags().StringVar(&diffAgainst, "against", "", "connection string of an already-provisioned, empty scratch database (skips automatic container provisioning)")
+	rootCmd.AddCommand(diffCmd)
+}
+
+func runDiff(targetName string) error {
+	cfg, err := loadConfig("dbtools.toml")
+	if err != nil {
+		return fmt.Errorf("loading dbtools.toml: %w", err)
+	}
+
+	findings, notes, err := diff.Run(cfg, targetName, diffAgainst)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		if findings == nil {
+			findings = []diff.Finding{}
+		}
+		if notes == nil {
+			notes = []string{}
+		}
+		b, err := json.Marshal(struct {
+			Target   string         `json:"target"`
+			Findings []diff.Finding `json:"findings"`
+			Notes    []string       `json:"notes,omitempty"`
+		}{Target: targetName, Findings: findings, Notes: notes})
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+	} else {
+		if len(findings) == 0 {
+			fmt.Printf("%s: no structural differences\n", targetName)
+		}
+		for _, f := range findings {
+			fmt.Printf("%-8s %-14s %-30s %s\n", f.Kind, f.Object, f.Table+"."+f.Name, f.Detail)
+		}
+		for _, n := range notes {
+			fmt.Printf("note: %s\n", n)
+		}
+	}
+
+	if len(findings) > 0 {
+		return ExitCode(2, fmt.Sprintf("%d structural difference(s) found", len(findings)))
+	}
+	return nil
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -36,6 +36,15 @@ func runDiff(targetName string) error {
 	if err != nil {
 		return fmt.Errorf("loading dbtools.toml: %w", err)
 	}
+	if diffAgainst != "" {
+		targetURL, err := cfg.ResolveURLOrFlag(targetName, "")
+		if err != nil {
+			return err
+		}
+		if diffAgainst == targetURL {
+			return errors.New("--against must not match the target database URL")
+		}
+	}
 
 	findings, notes, err := diff.Run(cfg, targetName, diffAgainst)
 	if err != nil {
@@ -63,7 +72,11 @@ func runDiff(targetName string) error {
 			fmt.Printf("%s: no structural differences\n", targetName)
 		}
 		for _, f := range findings {
-			fmt.Printf("%-8s %-14s %-30s %s\n", f.Kind, f.Object, f.Table+"."+f.Name, f.Detail)
+			object := f.Table
+			if f.Name != "" {
+				object += "." + f.Name
+			}
+			fmt.Printf("%-8s %-14s %-30s %s\n", f.Kind, f.Object, object, f.Detail)
 		}
 		for _, n := range notes {
 			fmt.Printf("note: %s\n", n)

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/seanpham99/dbtools/internal/diff"
+	"github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+	"github.com/seanpham99/dbtools/internal/migrator"
 	"github.com/spf13/cobra"
 )
 
@@ -41,8 +47,8 @@ func runDiff(targetName string) error {
 		if err != nil {
 			return err
 		}
-		if diffAgainst == targetURL {
-			return errors.New("--against must not match the target database URL")
+		if sameDatabase(diffAgainst, targetURL) {
+			return errors.New("--against identifies the same database as the target — diff would replay migrations and write the ledger onto the live target")
 		}
 	}
 
@@ -87,4 +93,89 @@ func runDiff(targetName string) error {
 		return ExitCode(2, fmt.Sprintf("%d structural difference(s) found", len(findings)))
 	}
 	return nil
+}
+
+var mysqlTCPHostPortRE = regexp.MustCompile(`tcp\(([^:]*):(\d+)\)`)
+
+// diffSchemeAliases mirrors internal/engine's own scheme normalization —
+// duplicated here rather than exported, since it's one map entry and
+// engine.go's version is deliberately unexported.
+var diffSchemeAliases = map[string]string{"postgresql": "postgres"}
+
+// sameDatabase reports whether a and b identify the same physical
+// database, not merely the same URL string — the guard that stops
+// --against from silently aiming at the live target under a
+// differently-formatted URL (a real safety issue: diff.Run would then
+// replay migrations and write the ledger onto the target it's supposed
+// to only ever read). Returns true immediately for an exact string
+// match; otherwise both URLs must parse and normalize to the same
+// identity. An unparseable URL is treated as "different" here (the
+// strings already didn't match), not as a reason to skip the check. This
+// is not a full network-identity resolver — two different hostnames that
+// happen to resolve to the same server (e.g. via /etc/hosts, a load
+// balancer, or a Docker network alias) are NOT detected as equivalent;
+// only the common formatting differences (postgres/postgresql scheme,
+// 127.0.0.1/::1/localhost, relative vs absolute sqlite paths) are
+// collapsed.
+func sameDatabase(a, b string) bool {
+	if a == b {
+		return true
+	}
+	na, oka := normalizeDatabaseIdentity(a)
+	nb, okb := normalizeDatabaseIdentity(b)
+	if !oka || !okb {
+		return false
+	}
+	return na == nb
+}
+
+func normalizeHost(h string) string {
+	h = strings.ToLower(h)
+	if h == "127.0.0.1" || h == "::1" {
+		return "localhost"
+	}
+	return h
+}
+
+// normalizeDatabaseIdentity extracts a comparable (scheme, host, port,
+// database) identity from a connection URL. ok is false when raw can't
+// be parsed at all.
+func normalizeDatabaseIdentity(raw string) (identity string, ok bool) {
+	scheme := migrator.SchemeOf(raw)
+	if canonical, exists := diffSchemeAliases[scheme]; exists {
+		scheme = canonical
+	}
+
+	switch scheme {
+	case "sqlite":
+		abs, err := filepath.Abs(sqliteengine.PathFromURL(raw))
+		if err != nil {
+			return "", false
+		}
+		return "sqlite|" + abs, true
+	case "mysql":
+		m := mysqlTCPHostPortRE.FindStringSubmatch(raw)
+		if m == nil {
+			return "", false
+		}
+		host, port := normalizeHost(m[1]), m[2]
+		db := ""
+		if i := strings.LastIndex(raw, "/"); i >= 0 && i+1 < len(raw) {
+			db = strings.SplitN(raw[i+1:], "?", 2)[0]
+		}
+		return fmt.Sprintf("mysql|%s|%s|%s", host, port, db), true
+	case "postgres", "mssql":
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", false
+		}
+		host, port := normalizeHost(u.Hostname()), u.Port()
+		db := strings.TrimPrefix(u.Path, "/")
+		if scheme == "mssql" {
+			db = u.Query().Get("database")
+		}
+		return fmt.Sprintf("%s|%s|%s|%s", scheme, host, port, db), true
+	default:
+		return "", false
+	}
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -178,8 +178,7 @@ func TestDiffCommand_FindingsReportExitTwo(t *testing.T) {
 
 	diffAgainst = ""
 	jsonOutput = false
-	var out string
-	out = captureStdout(t, func() { err = runDiff("testdb") })
+	out := captureStdout(t, func() { err = runDiff("testdb") })
 	if err == nil {
 		t.Fatal("runDiff with structural differences returned nil, want ExitCode(2)")
 	}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	_ "modernc.org/sqlite"
+)
+
+func setupDiffCmdTestEnv(t *testing.T) (string, string, *config.Config) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "target.db")
+	rawURL := fmt.Sprintf("sqlite://%s", dbPath)
+	migrationsDir := filepath.Join(dir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m1Up := `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);`
+	m1Down := `DROP TABLE users;`
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.up.sql"), []byte(m1Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.down.sql"), []byte(m1Down), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgContent := fmt.Sprintf(`migrations_dir = %q
+[targets.testdb]
+url_env = "DBTOOLS_TEST_CMD_DIFF_URL"
+engine = "sqlite"
+protected = false
+`, migrationsDir)
+
+	configPath := filepath.Join(dir, "dbtools.toml")
+	if err := os.WriteFile(configPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DBTOOLS_TEST_CMD_DIFF_URL", rawURL)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, dbPath, cfg
+}
+
+func TestDiffCommand_MissingTargetStillPrintsUsage(t *testing.T) {
+	origSilenceUsage := diffCmd.SilenceUsage
+	diffCmd.SilenceUsage = false
+	t.Cleanup(func() { diffCmd.SilenceUsage = origSilenceUsage })
+
+	var out strings.Builder
+	rootCmd.SetErr(&out)
+	rootCmd.SetOut(&out)
+	t.Cleanup(func() { rootCmd.SetErr(nil); rootCmd.SetOut(nil) })
+
+	rootCmd.SetArgs([]string{"diff"})
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("diff with no target returned nil error, want an argument-count error")
+	}
+	if !strings.Contains(out.String(), "Usage:") {
+		t.Fatalf("diff with a missing required argument did not print usage: %s", out.String())
+	}
+}
+
+func TestDiffCommand_CleanReportsExitZero(t *testing.T) {
+	dir, _, cfg := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	diffAgainst = ""
+	jsonOutput = false
+	if err := runDiff("testdb"); err != nil {
+		t.Fatalf("runDiff returned error: %v, want nil", err)
+	}
+}
+
+func TestDiffCommand_FindingsReportExitTwo(t *testing.T) {
+	dir, dbPath, cfg := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("ALTER TABLE users ADD COLUMN manual_col TEXT;"); err != nil {
+		t.Fatalf("ALTER TABLE failed: %v", err)
+	}
+
+	diffAgainst = ""
+	jsonOutput = false
+	err = runDiff("testdb")
+	if err == nil {
+		t.Fatal("runDiff with structural differences returned nil, want ExitCode(2)")
+	}
+
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("err is %T (%v), want *ExitCodeError", err, err)
+	}
+	if exitErr.Code != 2 {
+		t.Fatalf("exit code = %d, want 2", exitErr.Code)
+	}
+}
+
+func TestDiffCommand_JSONOutput(t *testing.T) {
+	dir, _, cfg := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	diffAgainst = ""
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = false })
+
+	if err := runDiff("testdb"); err != nil {
+		t.Fatalf("runDiff in json mode returned error: %v, want nil", err)
+	}
+}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -111,8 +111,8 @@ func TestDiffCommand_AgainstTargetURLRejectedBeforeReplay(t *testing.T) {
 	t.Cleanup(func() { diffAgainst = "" })
 
 	err = runDiff("testdb")
-	if err == nil || !strings.Contains(err.Error(), "--against must not match") {
-		t.Fatalf("runDiff with target URL as --against returned %v, want a matching-URL error", err)
+	if err == nil || !strings.Contains(err.Error(), "identifies the same database as the target") {
+		t.Fatalf("runDiff with target URL as --against returned %v, want a same-database error", err)
 	}
 
 	db, err := sql.Open("sqlite", dbPath)
@@ -126,6 +126,34 @@ func TestDiffCommand_AgainstTargetURLRejectedBeforeReplay(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("found %d table(s) after matching --against rejection; migration replay started", count)
+	}
+}
+
+// TestDiffCommand_AgainstEquivalentTargetURLRejected is a regression test
+// for a review finding: the original guard only caught an exact string
+// match, so the same physical database spelled differently (here: a
+// relative path resolving to the same file as the target's absolute
+// path) would slip through and diff.Run would replay migrations onto the
+// live target.
+func TestDiffCommand_AgainstEquivalentTargetURLRejected(t *testing.T) {
+	dir, dbPath, _ := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	// Same file as the target's absolute-path URL, spelled as a relative
+	// path from the working directory (which is now dir).
+	diffAgainst = "sqlite://" + filepath.Base(dbPath)
+	t.Cleanup(func() { diffAgainst = "" })
+
+	err = runDiff("testdb")
+	if err == nil || !strings.Contains(err.Error(), "identifies the same database as the target") {
+		t.Fatalf("runDiff with an equivalent (relative-path) --against URL returned %v, want a same-database error", err)
 	}
 }
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -96,6 +96,62 @@ func TestDiffCommand_CleanReportsExitZero(t *testing.T) {
 	}
 }
 
+func TestDiffCommand_AgainstTargetURLRejectedBeforeReplay(t *testing.T) {
+	dir, dbPath, _ := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	diffAgainst = "sqlite://" + dbPath
+	t.Cleanup(func() { diffAgainst = "" })
+
+	err = runDiff("testdb")
+	if err == nil || !strings.Contains(err.Error(), "--against must not match") {
+		t.Fatalf("runDiff with target URL as --against returned %v, want a matching-URL error", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`).Scan(&count); err != nil {
+		t.Fatalf("checking for replay-created tables: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("found %d table(s) after matching --against rejection; migration replay started", count)
+	}
+}
+
+func TestDiffCommand_DistinctAgainstURLStillRuns(t *testing.T) {
+	dir, _, cfg := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	diffAgainst = "sqlite://" + filepath.Join(dir, "scratch.db")
+	t.Cleanup(func() { diffAgainst = "" })
+	jsonOutput = false
+	if err := runDiff("testdb"); err != nil {
+		t.Fatalf("runDiff with distinct --against URL returned error: %v", err)
+	}
+}
+
 func TestDiffCommand_FindingsReportExitTwo(t *testing.T) {
 	dir, dbPath, cfg := setupDiffCmdTestEnv(t)
 	cwd, err := os.Getwd()
@@ -122,9 +178,13 @@ func TestDiffCommand_FindingsReportExitTwo(t *testing.T) {
 
 	diffAgainst = ""
 	jsonOutput = false
-	err = runDiff("testdb")
+	var out string
+	out = captureStdout(t, func() { err = runDiff("testdb") })
 	if err == nil {
 		t.Fatal("runDiff with structural differences returned nil, want ExitCode(2)")
+	}
+	if !strings.Contains(out, "users.manual_col") {
+		t.Fatalf("runDiff output = %q, want named finding formatted as users.manual_col", out)
 	}
 
 	var exitErr *ExitCodeError
@@ -133,6 +193,47 @@ func TestDiffCommand_FindingsReportExitTwo(t *testing.T) {
 	}
 	if exitErr.Code != 2 {
 		t.Fatalf("exit code = %d, want 2", exitErr.Code)
+	}
+}
+
+func TestDiffCommand_TableFindingOmitsTrailingDot(t *testing.T) {
+	dir, dbPath, cfg := setupDiffCmdTestEnv(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	if _, err := db.Exec("DROP TABLE users;"); err != nil {
+		db.Close()
+		t.Fatalf("DROP TABLE failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing target database: %v", err)
+	}
+
+	diffAgainst = ""
+	jsonOutput = false
+	var runErr error
+	out := captureStdout(t, func() { runErr = runDiff("testdb") })
+	if runErr == nil {
+		t.Fatal("runDiff with a missing table returned nil, want ExitCode(2)")
+	}
+	if strings.Contains(out, "users.") {
+		t.Fatalf("runDiff table finding output = %q, want table name without trailing dot", out)
+	}
+	if !strings.Contains(out, "users") {
+		t.Fatalf("runDiff table finding output = %q, want users table name", out)
 	}
 }
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -24,6 +24,11 @@
 - **Exit 1**: Failed to query database, ledger missing without `--init-ledger`, or database error.
 - **Exit 2**: Drift detected (objects created by an applied migration are missing or content hash mismatch).
 
+### `dbtools diff <target>`
+- **Exit 0**: Live target schema matches scratch replay from migrations perfectly (no structural differences).
+- **Exit 1**: Failed to provision scratch database, replay failed, target unreachable, or invalid configuration.
+- **Exit 2**: Structural differences found (`MISSING`, `EXTRA`, or `CHANGED` objects).
+
 ### `dbtools up` & `dbtools push <target>`
 - **Exit 0**: Migrations applied successfully (or dry-run printed).
 - **Exit 1**: Apply failed partway (cursor marked dirty), connection error, or missing `--yes` on protected targets.

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -45,9 +45,9 @@ type spec struct {
 	// project-scoped name containerNameFor produces. nil for engines with
 	// no container template (sqlite).
 	scratchRunArgs func(s spec) []string
-	readyProbe    func(s spec) error
-	createDBArgs  func(s spec) []string // docker exec args creating DatabaseName idempotently; nil when the image does it itself
-	url           func(s spec, database string) string
+	readyProbe     func(s spec) error
+	createDBArgs   func(s spec) []string // docker exec args creating DatabaseName idempotently; nil when the image does it itself
+	url            func(s spec, database string) string
 	// hostPortFromLocalURL extracts the host and port this engine's local
 	// connection URL encodes, so MaintenanceURLFor can reuse whatever port
 	// the container actually ended up on (fixed or Docker-assigned)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -39,6 +39,12 @@ type spec struct {
 	hostPort      string // resolved host port; "0" means "ask Docker to assign one"
 	dataDir       string // in-container path mounted to this project's data volume
 	runArgs       func(s spec) []string
+	// scratchRunArgs builds docker run args for an ephemeral, throwaway
+	// instance used by `dbtools diff` — no volume mount (nothing to
+	// persist), --rm (auto-removed on stop), never the deterministic
+	// project-scoped name containerNameFor produces. nil for engines with
+	// no container template (sqlite).
+	scratchRunArgs func(s spec) []string
 	readyProbe    func(s spec) error
 	createDBArgs  func(s spec) []string // docker exec args creating DatabaseName idempotently; nil when the image does it itself
 	url           func(s spec, database string) string
@@ -102,6 +108,16 @@ var mssqlSpec = spec{
 			s.image,
 		}
 	},
+	scratchRunArgs: func(s spec) []string {
+		return []string{
+			"run", "-d", "--rm",
+			"--name", s.name,
+			"-e", "ACCEPT_EULA=Y",
+			"-e", "MSSQL_SA_PASSWORD=" + password,
+			"-p", s.hostPort + ":" + s.containerPort,
+			s.image,
+		}
+	},
 	readyProbe: func(s spec) error {
 		u, err := url.Parse(s.url(s, "master"))
 		if err == nil {
@@ -142,6 +158,16 @@ var postgresSpec = spec{
 			s.image,
 		}
 	},
+	scratchRunArgs: func(s spec) []string {
+		return []string{
+			"run", "-d", "--rm",
+			"--name", s.name,
+			"-e", "POSTGRES_PASSWORD=" + password,
+			"-e", "POSTGRES_DB=" + DatabaseName,
+			"-p", s.hostPort + ":" + s.containerPort,
+			s.image,
+		}
+	},
 	// Probed from the host through the published port (not docker exec,
 	// which is unreliable on some container hosts): a successful Ping
 	// also proves the port mapping works, which is what callers use.
@@ -175,6 +201,16 @@ var mysqlSpec = spec{
 			"-e", "MYSQL_DATABASE=" + DatabaseName,
 			"-p", s.hostPort + ":" + s.containerPort,
 			"-v", volumeNameFor(s.name) + ":" + s.dataDir,
+			s.image,
+		}
+	},
+	scratchRunArgs: func(s spec) []string {
+		return []string{
+			"run", "-d", "--rm",
+			"--name", s.name,
+			"-e", "MYSQL_ROOT_PASSWORD=" + password,
+			"-e", "MYSQL_DATABASE=" + DatabaseName,
+			"-p", s.hostPort + ":" + s.containerPort,
 			s.image,
 		}
 	},
@@ -218,6 +254,15 @@ func specFor(engineName string) (spec, error) {
 // name for engineName under projectID (see internal/projectid.Resolve).
 func containerNameFor(engineName, projectID string) string {
 	return fmt.Sprintf("dbtools-%s-%s", engineName, projectID)
+}
+
+// scratchNameFor returns a unique, non-deterministic name for an
+// ephemeral diff-scratch container — deliberately never matching
+// containerNameFor's project-scoped naming scheme, so a diff run can
+// never collide with, reuse, or be confused with dbtools start's
+// persistent dev container.
+func scratchNameFor(engineName string) string {
+	return fmt.Sprintf("dbtools-diff-scratch-%s-%d", engineName, time.Now().UnixNano())
 }
 
 // volumeNameFor returns the data volume name for a container named
@@ -406,6 +451,57 @@ func waitReadyWithTimeout(s spec, timeout time.Duration) error {
 		time.Sleep(1 * time.Second)
 	}
 	return fmt.Errorf("%s did not become ready within %v", s.engine, timeout)
+}
+
+// StartScratch starts a throwaway, --rm container for engineName, waits
+// up to 60s for readiness, and returns its connection URL plus a cleanup
+// function that stops (and thereby removes) it. Unlike StartForWithTimeout,
+// there is no reuse-if-running path — every call creates a fresh
+// container, since a scratch database must start empty. Returns an error
+// for engines with no scratchRunArgs (sqlite — callers use a tempfile).
+func StartScratch(engineName string) (rawURL string, cleanup func() error, err error) {
+	s, err := specFor(engineName)
+	if err != nil {
+		return "", nil, err
+	}
+	if s.scratchRunArgs == nil {
+		return "", nil, fmt.Errorf("no scratch container template for engine %q", engineName)
+	}
+	if err := checkDocker(); err != nil {
+		return "", nil, err
+	}
+	s.name = scratchNameFor(engineName)
+	s.hostPort = "0"
+
+	if out, err := exec.Command("docker", s.scratchRunArgs(s)...).CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("docker run failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	cleanup = func() error {
+		out, err := exec.Command("docker", "stop", s.name).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("docker stop failed: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+
+	port, err := discoverHostPort(s.name, s.containerPort)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	s.hostPort = port
+
+	if err := waitReadyWithTimeout(s, 60*time.Second); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if s.createDBArgs != nil {
+		if out, err := exec.Command("docker", s.createDBArgs(s)...).CombinedOutput(); err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out)))
+		}
+	}
+	return s.url(s, DatabaseName), cleanup, nil
 }
 
 // StopFor stops and removes engineName's tool-owned local container

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -453,13 +453,19 @@ func waitReadyWithTimeout(s spec, timeout time.Duration) error {
 	return fmt.Errorf("%s did not become ready within %v", s.engine, timeout)
 }
 
-// StartScratch starts a throwaway, --rm container for engineName, waits
-// up to 60s for readiness, and returns its connection URL plus a cleanup
-// function that stops (and thereby removes) it. Unlike StartForWithTimeout,
+// StartScratch starts a throwaway, --rm container for engineName and waits
+// up to 60s for readiness.
+func StartScratch(engineName string) (rawURL string, cleanup func() error, err error) {
+	return StartScratchWithTimeout(engineName, 60*time.Second)
+}
+
+// StartScratchWithTimeout starts a throwaway, --rm container for engineName,
+// waits up to timeout for readiness, and returns its connection URL plus a
+// cleanup function that stops (and thereby removes) it. Unlike StartForWithTimeout,
 // there is no reuse-if-running path — every call creates a fresh
 // container, since a scratch database must start empty. Returns an error
 // for engines with no scratchRunArgs (sqlite — callers use a tempfile).
-func StartScratch(engineName string) (rawURL string, cleanup func() error, err error) {
+func StartScratchWithTimeout(engineName string, timeout time.Duration) (rawURL string, cleanup func() error, err error) {
 	s, err := specFor(engineName)
 	if err != nil {
 		return "", nil, err
@@ -501,7 +507,7 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 	}
 	s.hostPort = port
 
-	if err := waitReadyWithTimeout(s, 60*time.Second); err != nil {
+	if err := waitReadyWithTimeout(s, timeout); err != nil {
 		return "", nil, abortWith(err)
 	}
 	if s.createDBArgs != nil {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -484,21 +484,29 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 		return nil
 	}
 
+	// abortWith cleans up the just-started container and folds any
+	// cleanup failure into the returned error rather than dropping it —
+	// a container that fails to stop needs a manual `docker rm -f`, and
+	// silently losing that fact leaves it running unnoticed.
+	abortWith := func(err error) error {
+		if cerr := cleanup(); cerr != nil {
+			return fmt.Errorf("%w (cleanup also failed: %v)", err, cerr)
+		}
+		return err
+	}
+
 	port, err := discoverHostPort(s.name, s.containerPort)
 	if err != nil {
-		_ = cleanup()
-		return "", nil, err
+		return "", nil, abortWith(err)
 	}
 	s.hostPort = port
 
 	if err := waitReadyWithTimeout(s, 60*time.Second); err != nil {
-		_ = cleanup()
-		return "", nil, err
+		return "", nil, abortWith(err)
 	}
 	if s.createDBArgs != nil {
 		if out, err := exec.Command("docker", s.createDBArgs(s)...).CombinedOutput(); err != nil {
-			_ = cleanup()
-			return "", nil, fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out)))
+			return "", nil, abortWith(fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out))))
 		}
 	}
 	return s.url(s, DatabaseName), cleanup, nil

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -486,18 +486,18 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 
 	port, err := discoverHostPort(s.name, s.containerPort)
 	if err != nil {
-		cleanup()
+		_ = cleanup()
 		return "", nil, err
 	}
 	s.hostPort = port
 
 	if err := waitReadyWithTimeout(s, 60*time.Second); err != nil {
-		cleanup()
+		_ = cleanup()
 		return "", nil, err
 	}
 	if s.createDBArgs != nil {
 		if out, err := exec.Command("docker", s.createDBArgs(s)...).CombinedOutput(); err != nil {
-			cleanup()
+			_ = cleanup()
 			return "", nil, fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out)))
 		}
 	}

--- a/internal/container/scratch_integration_test.go
+++ b/internal/container/scratch_integration_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package container
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestStartScratch_PostgresIntegration(t *testing.T) {
+	url, cleanup, err := StartScratch("postgres")
+	if err != nil {
+		t.Fatalf("StartScratch(postgres) returned error: %v", err)
+	}
+	if url == "" {
+		t.Fatal("StartScratch(postgres) returned empty URL")
+	}
+	if cleanup == nil {
+		t.Fatal("StartScratch(postgres) returned nil cleanup function")
+	}
+
+	db, err := sql.Open("postgres", url)
+	if err != nil {
+		cleanup()
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		cleanup()
+		t.Fatalf("db.Ping returned error: %v", err)
+	}
+	db.Close()
+
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup() returned error: %v", err)
+	}
+}

--- a/internal/container/scratch_test.go
+++ b/internal/container/scratch_test.go
@@ -1,0 +1,24 @@
+package container
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStartScratch_UnsupportedEngine(t *testing.T) {
+	_, _, err := StartScratch("sqlite")
+	if err == nil {
+		t.Fatal("StartScratch(\"sqlite\") should error — sqlite has no container template, callers must use a tempfile instead")
+	}
+}
+
+func TestScratchNameFor_NeverCollidesWithDevContainerName(t *testing.T) {
+	scratch := scratchNameFor("postgres")
+	dev := containerNameFor("postgres", "someproject")
+	if scratch == dev {
+		t.Fatal("scratch and dev container names must never collide")
+	}
+	if strings.HasPrefix(scratch, "dbtools-postgres-") && !strings.Contains(scratch, "scratch") {
+		t.Errorf("scratchNameFor(%q) = %q, want it clearly distinguishable from containerNameFor's naming scheme", "postgres", scratch)
+	}
+}

--- a/internal/diff/compare.go
+++ b/internal/diff/compare.go
@@ -63,6 +63,58 @@ func nullInt64Str(n sql.NullInt64) string {
 	return "<none>"
 }
 
+// sortedKeys returns the union of a's and b's keys, sorted — the shared
+// key-union shape every object-kind comparison below needs before it can
+// walk scratch/target in a deterministic order.
+func sortedKeys[T any](a, b map[string]T) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// diffKeyed walks the sorted union of scratch's and target's keys,
+// emitting a MISSING/EXTRA Finding for a key present on only one side,
+// and calling diffFn for a key present on both — diffFn returns the
+// human-readable differences found (nil/empty means no CHANGED finding).
+// label names the object kind for the MISSING/EXTRA messages, e.g. "index".
+func diffKeyed[T any](tblKey string, obj ObjectType, label string, scratch, target map[string]T, diffFn func(s, t T) []string) []Finding {
+	var findings []Finding
+	for _, name := range sortedKeys(scratch, target) {
+		s, inScratch := scratch[name]
+		t, inTarget := target[name]
+		switch {
+		case inScratch && !inTarget:
+			findings = append(findings, Finding{
+				Kind: KindMissing, Object: obj, Table: tblKey, Name: name,
+				Detail: fmt.Sprintf("%s exists in migrations but missing in target", label),
+			})
+		case !inScratch && inTarget:
+			findings = append(findings, Finding{
+				Kind: KindExtra, Object: obj, Table: tblKey, Name: name,
+				Detail: fmt.Sprintf("%s exists in target but missing in migrations", label),
+			})
+		case inScratch && inTarget:
+			if diffs := diffFn(s, t); len(diffs) > 0 {
+				findings = append(findings, Finding{
+					Kind: KindChanged, Object: obj, Table: tblKey, Name: name,
+					Detail: strings.Join(diffs, "; "),
+				})
+			}
+		}
+	}
+	return findings
+}
+
 // Compare returns every structural difference between scratch (the
 // migrations' truth) and target (the live database), plus a separate
 // slice of purely informational notes (currently: column ordinal-position
@@ -78,21 +130,7 @@ func Compare(scratch, target []generate.TableSchema) (findings []Finding, notes 
 		targetMap[tableIdent(t.Schema, t.Name)] = t
 	}
 
-	// Union of all table keys, sorted for deterministic output.
-	allTableKeys := make(map[string]struct{})
-	for k := range scratchMap {
-		allTableKeys[k] = struct{}{}
-	}
-	for k := range targetMap {
-		allTableKeys[k] = struct{}{}
-	}
-	tableNames := make([]string, 0, len(allTableKeys))
-	for k := range allTableKeys {
-		tableNames = append(tableNames, k)
-	}
-	sort.Strings(tableNames)
-
-	for _, tblKey := range tableNames {
+	for _, tblKey := range sortedKeys(scratchMap, targetMap) {
 		sTbl, inScratch := scratchMap[tblKey]
 		tTbl, inTarget := targetMap[tblKey]
 
@@ -137,13 +175,6 @@ func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []
 		tCols[c.Name] = c
 	}
 
-	allColNamesMap := make(map[string]struct{})
-	for k := range sCols {
-		allColNamesMap[k] = struct{}{}
-	}
-	for k := range tCols {
-		allColNamesMap[k] = struct{}{}
-	}
 	var colNames []string
 	// Maintain scratch column order first, then any extra columns from target
 	for _, c := range sTbl.Columns {
@@ -235,60 +266,16 @@ func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []
 	for _, idx := range tTbl.Indexes {
 		tIndexes[idx.Name] = idx
 	}
-
-	allIdxNamesMap := make(map[string]struct{})
-	for k := range sIndexes {
-		allIdxNamesMap[k] = struct{}{}
-	}
-	for k := range tIndexes {
-		allIdxNamesMap[k] = struct{}{}
-	}
-	idxNames := make([]string, 0, len(allIdxNamesMap))
-	for k := range allIdxNamesMap {
-		idxNames = append(idxNames, k)
-	}
-	sort.Strings(idxNames)
-
-	for _, idxName := range idxNames {
-		sIdx, inScratch := sIndexes[idxName]
-		tIdx, inTarget := tIndexes[idxName]
-
-		switch {
-		case inScratch && !inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindMissing,
-				Object: ObjectIndex,
-				Table:  tblKey,
-				Name:   idxName,
-				Detail: "index exists in migrations but missing in target",
-			})
-		case !inScratch && inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindExtra,
-				Object: ObjectIndex,
-				Table:  tblKey,
-				Name:   idxName,
-				Detail: "index exists in target but missing in migrations",
-			})
-		case inScratch && inTarget:
-			var diffs []string
-			if sIdx.Unique != tIdx.Unique {
-				diffs = append(diffs, fmt.Sprintf("unique %t vs %t", sIdx.Unique, tIdx.Unique))
-			}
-			if !equalStringSlices(sIdx.Columns, tIdx.Columns) {
-				diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sIdx.Columns, tIdx.Columns))
-			}
-			if len(diffs) > 0 {
-				findings = append(findings, Finding{
-					Kind:   KindChanged,
-					Object: ObjectIndex,
-					Table:  tblKey,
-					Name:   idxName,
-					Detail: strings.Join(diffs, "; "),
-				})
-			}
+	findings = append(findings, diffKeyed(tblKey, ObjectIndex, "index", sIndexes, tIndexes, func(sIdx, tIdx generate.IndexSchema) []string {
+		var diffs []string
+		if sIdx.Unique != tIdx.Unique {
+			diffs = append(diffs, fmt.Sprintf("unique %t vs %t", sIdx.Unique, tIdx.Unique))
 		}
-	}
+		if !equalStringSlices(sIdx.Columns, tIdx.Columns) {
+			diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sIdx.Columns, tIdx.Columns))
+		}
+		return diffs
+	})...)
 
 	// 3. Foreign Keys
 	sFKs := make(map[string]generate.ForeignKeySchema, len(sTbl.ForeignKeys))
@@ -299,66 +286,22 @@ func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []
 	for _, fk := range tTbl.ForeignKeys {
 		tFKs[fk.Name] = fk
 	}
-
-	allFKNamesMap := make(map[string]struct{})
-	for k := range sFKs {
-		allFKNamesMap[k] = struct{}{}
-	}
-	for k := range tFKs {
-		allFKNamesMap[k] = struct{}{}
-	}
-	fkNames := make([]string, 0, len(allFKNamesMap))
-	for k := range allFKNamesMap {
-		fkNames = append(fkNames, k)
-	}
-	sort.Strings(fkNames)
-
-	for _, fkName := range fkNames {
-		sFK, inScratch := sFKs[fkName]
-		tFK, inTarget := tFKs[fkName]
-
-		switch {
-		case inScratch && !inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindMissing,
-				Object: ObjectForeignKey,
-				Table:  tblKey,
-				Name:   fkName,
-				Detail: "foreign key exists in migrations but missing in target",
-			})
-		case !inScratch && inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindExtra,
-				Object: ObjectForeignKey,
-				Table:  tblKey,
-				Name:   fkName,
-				Detail: "foreign key exists in target but missing in migrations",
-			})
-		case inScratch && inTarget:
-			var diffs []string
-			if sFK.RefSchema != tFK.RefSchema {
-				diffs = append(diffs, fmt.Sprintf("ref schema %s vs %s", sFK.RefSchema, tFK.RefSchema))
-			}
-			if sFK.RefTable != tFK.RefTable {
-				diffs = append(diffs, fmt.Sprintf("ref table %s vs %s", sFK.RefTable, tFK.RefTable))
-			}
-			if !equalStringSlices(sFK.Columns, tFK.Columns) {
-				diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sFK.Columns, tFK.Columns))
-			}
-			if !equalStringSlices(sFK.RefColumns, tFK.RefColumns) {
-				diffs = append(diffs, fmt.Sprintf("ref columns %v vs %v", sFK.RefColumns, tFK.RefColumns))
-			}
-			if len(diffs) > 0 {
-				findings = append(findings, Finding{
-					Kind:   KindChanged,
-					Object: ObjectForeignKey,
-					Table:  tblKey,
-					Name:   fkName,
-					Detail: strings.Join(diffs, "; "),
-				})
-			}
+	findings = append(findings, diffKeyed(tblKey, ObjectForeignKey, "foreign key", sFKs, tFKs, func(sFK, tFK generate.ForeignKeySchema) []string {
+		var diffs []string
+		if sFK.RefSchema != tFK.RefSchema {
+			diffs = append(diffs, fmt.Sprintf("ref schema %s vs %s", sFK.RefSchema, tFK.RefSchema))
 		}
-	}
+		if sFK.RefTable != tFK.RefTable {
+			diffs = append(diffs, fmt.Sprintf("ref table %s vs %s", sFK.RefTable, tFK.RefTable))
+		}
+		if !equalStringSlices(sFK.Columns, tFK.Columns) {
+			diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sFK.Columns, tFK.Columns))
+		}
+		if !equalStringSlices(sFK.RefColumns, tFK.RefColumns) {
+			diffs = append(diffs, fmt.Sprintf("ref columns %v vs %v", sFK.RefColumns, tFK.RefColumns))
+		}
+		return diffs
+	})...)
 
 	// 4. Check Constraints
 	sCKs := make(map[string]generate.CheckConstraintSchema, len(sTbl.CheckConstraints))
@@ -369,53 +312,12 @@ func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []
 	for _, ck := range tTbl.CheckConstraints {
 		tCKs[ck.Name] = ck
 	}
-
-	allCKNamesMap := make(map[string]struct{})
-	for k := range sCKs {
-		allCKNamesMap[k] = struct{}{}
-	}
-	for k := range tCKs {
-		allCKNamesMap[k] = struct{}{}
-	}
-	ckNames := make([]string, 0, len(allCKNamesMap))
-	for k := range allCKNamesMap {
-		ckNames = append(ckNames, k)
-	}
-	sort.Strings(ckNames)
-
-	for _, ckName := range ckNames {
-		sCK, inScratch := sCKs[ckName]
-		tCK, inTarget := tCKs[ckName]
-
-		switch {
-		case inScratch && !inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindMissing,
-				Object: ObjectCheck,
-				Table:  tblKey,
-				Name:   ckName,
-				Detail: "check constraint exists in migrations but missing in target",
-			})
-		case !inScratch && inTarget:
-			findings = append(findings, Finding{
-				Kind:   KindExtra,
-				Object: ObjectCheck,
-				Table:  tblKey,
-				Name:   ckName,
-				Detail: "check constraint exists in target but missing in migrations",
-			})
-		case inScratch && inTarget:
-			if sCK.Expression != tCK.Expression {
-				findings = append(findings, Finding{
-					Kind:   KindChanged,
-					Object: ObjectCheck,
-					Table:  tblKey,
-					Name:   ckName,
-					Detail: fmt.Sprintf("expression %q vs %q", sCK.Expression, tCK.Expression),
-				})
-			}
+	findings = append(findings, diffKeyed(tblKey, ObjectCheck, "check constraint", sCKs, tCKs, func(sCK, tCK generate.CheckConstraintSchema) []string {
+		if sCK.Expression != tCK.Expression {
+			return []string{fmt.Sprintf("expression %q vs %q", sCK.Expression, tCK.Expression)}
 		}
-	}
+		return nil
+	})...)
 
 	return findings, notes
 }

--- a/internal/diff/compare.go
+++ b/internal/diff/compare.go
@@ -32,8 +32,8 @@ const (
 type Finding struct {
 	Kind   Kind       `json:"kind"`
 	Object ObjectType `json:"object"`
-	Table  string     `json:"table"` // schema-qualified, e.g. "public.orders"
-	Name   string     `json:"name"`  // column/index/FK/check name; "" for a table-level finding
+	Table  string     `json:"table"`  // schema-qualified, e.g. "public.orders"
+	Name   string     `json:"name"`   // column/index/FK/check name; "" for a table-level finding
 	Detail string     `json:"detail"` // human-readable specifics, e.g. "type text vs varchar(50)"
 }
 

--- a/internal/diff/compare.go
+++ b/internal/diff/compare.go
@@ -1,0 +1,421 @@
+package diff
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/seanpham99/dbtools/internal/generate"
+)
+
+type Kind string
+
+const (
+	KindMissing Kind = "MISSING" // in scratch (migrations), not in target
+	KindExtra   Kind = "EXTRA"   // in target, not in scratch (migrations)
+	KindChanged Kind = "CHANGED"
+)
+
+type ObjectType string
+
+const (
+	ObjectTable      ObjectType = "table"
+	ObjectColumn     ObjectType = "column"
+	ObjectIndex      ObjectType = "index"
+	ObjectForeignKey ObjectType = "foreign_key"
+	ObjectCheck      ObjectType = "check_constraint"
+)
+
+// Finding is one structural difference between the scratch (migrations)
+// and target (live) databases.
+type Finding struct {
+	Kind   Kind       `json:"kind"`
+	Object ObjectType `json:"object"`
+	Table  string     `json:"table"` // schema-qualified, e.g. "public.orders"
+	Name   string     `json:"name"`  // column/index/FK/check name; "" for a table-level finding
+	Detail string     `json:"detail"` // human-readable specifics, e.g. "type text vs varchar(50)"
+}
+
+func tableIdent(schema, name string) string {
+	if schema != "" {
+		return fmt.Sprintf("%s.%s", schema, name)
+	}
+	return name
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func nullInt64Str(n sql.NullInt64) string {
+	if n.Valid {
+		return fmt.Sprintf("%d", n.Int64)
+	}
+	return "<none>"
+}
+
+// Compare returns every structural difference between scratch (the
+// migrations' truth) and target (the live database), plus a separate
+// slice of purely informational notes (currently: column ordinal-position
+// differences) that are never treated as drift.
+func Compare(scratch, target []generate.TableSchema) (findings []Finding, notes []string) {
+	scratchMap := make(map[string]generate.TableSchema, len(scratch))
+	for _, t := range scratch {
+		scratchMap[tableIdent(t.Schema, t.Name)] = t
+	}
+
+	targetMap := make(map[string]generate.TableSchema, len(target))
+	for _, t := range target {
+		targetMap[tableIdent(t.Schema, t.Name)] = t
+	}
+
+	// Union of all table keys, sorted for deterministic output.
+	allTableKeys := make(map[string]struct{})
+	for k := range scratchMap {
+		allTableKeys[k] = struct{}{}
+	}
+	for k := range targetMap {
+		allTableKeys[k] = struct{}{}
+	}
+	tableNames := make([]string, 0, len(allTableKeys))
+	for k := range allTableKeys {
+		tableNames = append(tableNames, k)
+	}
+	sort.Strings(tableNames)
+
+	for _, tblKey := range tableNames {
+		sTbl, inScratch := scratchMap[tblKey]
+		tTbl, inTarget := targetMap[tblKey]
+
+		switch {
+		case inScratch && !inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindMissing,
+				Object: ObjectTable,
+				Table:  tblKey,
+				Name:   "",
+				Detail: "table exists in migrations but missing in target",
+			})
+		case !inScratch && inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindExtra,
+				Object: ObjectTable,
+				Table:  tblKey,
+				Name:   "",
+				Detail: "table exists in target but missing in migrations",
+			})
+		case inScratch && inTarget:
+			tblFindings, tblNotes := compareTable(tblKey, sTbl, tTbl)
+			findings = append(findings, tblFindings...)
+			notes = append(notes, tblNotes...)
+		}
+	}
+
+	return findings, notes
+}
+
+func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []string) {
+	var findings []Finding
+	var notes []string
+
+	// 1. Columns
+	sCols := make(map[string]generate.ColumnSchema, len(sTbl.Columns))
+	for _, c := range sTbl.Columns {
+		sCols[c.Name] = c
+	}
+	tCols := make(map[string]generate.ColumnSchema, len(tTbl.Columns))
+	for _, c := range tTbl.Columns {
+		tCols[c.Name] = c
+	}
+
+	allColNamesMap := make(map[string]struct{})
+	for k := range sCols {
+		allColNamesMap[k] = struct{}{}
+	}
+	for k := range tCols {
+		allColNamesMap[k] = struct{}{}
+	}
+	var colNames []string
+	// Maintain scratch column order first, then any extra columns from target
+	for _, c := range sTbl.Columns {
+		colNames = append(colNames, c.Name)
+	}
+	for _, c := range tTbl.Columns {
+		if _, ok := sCols[c.Name]; !ok {
+			colNames = append(colNames, c.Name)
+		}
+	}
+
+	hasColDiff := false
+	ordinalDiff := false
+
+	for _, colName := range colNames {
+		sCol, inScratch := sCols[colName]
+		tCol, inTarget := tCols[colName]
+
+		switch {
+		case inScratch && !inTarget:
+			hasColDiff = true
+			findings = append(findings, Finding{
+				Kind:   KindMissing,
+				Object: ObjectColumn,
+				Table:  tblKey,
+				Name:   colName,
+				Detail: "column exists in migrations but missing in target",
+			})
+		case !inScratch && inTarget:
+			hasColDiff = true
+			findings = append(findings, Finding{
+				Kind:   KindExtra,
+				Object: ObjectColumn,
+				Table:  tblKey,
+				Name:   colName,
+				Detail: "column exists in target but missing in migrations",
+			})
+		case inScratch && inTarget:
+			var diffs []string
+			if sCol.DataType != tCol.DataType {
+				diffs = append(diffs, fmt.Sprintf("data type %s vs %s", sCol.DataType, tCol.DataType))
+			}
+			if sCol.IsNullable != tCol.IsNullable {
+				diffs = append(diffs, fmt.Sprintf("nullable %t vs %t", sCol.IsNullable, tCol.IsNullable))
+			}
+			if sCol.MaxLength != tCol.MaxLength {
+				diffs = append(diffs, fmt.Sprintf("max length %s vs %s", nullInt64Str(sCol.MaxLength), nullInt64Str(tCol.MaxLength)))
+			}
+			if sCol.Precision != tCol.Precision {
+				diffs = append(diffs, fmt.Sprintf("precision %s vs %s", nullInt64Str(sCol.Precision), nullInt64Str(tCol.Precision)))
+			}
+			if sCol.Scale != tCol.Scale {
+				diffs = append(diffs, fmt.Sprintf("scale %s vs %s", nullInt64Str(sCol.Scale), nullInt64Str(tCol.Scale)))
+			}
+			if sCol.DefaultValue.Valid != tCol.DefaultValue.Valid || sCol.DefaultValue.String != tCol.DefaultValue.String {
+				diffs = append(diffs, fmt.Sprintf("default %q vs %q", sCol.DefaultValue.String, tCol.DefaultValue.String))
+			}
+			if sCol.IsPrimaryKey != tCol.IsPrimaryKey {
+				diffs = append(diffs, fmt.Sprintf("primary key %t vs %t", sCol.IsPrimaryKey, tCol.IsPrimaryKey))
+			}
+
+			if len(diffs) > 0 {
+				hasColDiff = true
+				findings = append(findings, Finding{
+					Kind:   KindChanged,
+					Object: ObjectColumn,
+					Table:  tblKey,
+					Name:   colName,
+					Detail: strings.Join(diffs, "; "),
+				})
+			}
+
+			if sCol.OrdinalPosition != tCol.OrdinalPosition {
+				ordinalDiff = true
+			}
+		}
+	}
+
+	if !hasColDiff && ordinalDiff && len(sTbl.Columns) == len(tTbl.Columns) {
+		notes = append(notes, fmt.Sprintf("%s: column order differs (informational, not drift)", tblKey))
+	}
+
+	// 2. Indexes
+	sIndexes := make(map[string]generate.IndexSchema, len(sTbl.Indexes))
+	for _, idx := range sTbl.Indexes {
+		sIndexes[idx.Name] = idx
+	}
+	tIndexes := make(map[string]generate.IndexSchema, len(tTbl.Indexes))
+	for _, idx := range tTbl.Indexes {
+		tIndexes[idx.Name] = idx
+	}
+
+	allIdxNamesMap := make(map[string]struct{})
+	for k := range sIndexes {
+		allIdxNamesMap[k] = struct{}{}
+	}
+	for k := range tIndexes {
+		allIdxNamesMap[k] = struct{}{}
+	}
+	idxNames := make([]string, 0, len(allIdxNamesMap))
+	for k := range allIdxNamesMap {
+		idxNames = append(idxNames, k)
+	}
+	sort.Strings(idxNames)
+
+	for _, idxName := range idxNames {
+		sIdx, inScratch := sIndexes[idxName]
+		tIdx, inTarget := tIndexes[idxName]
+
+		switch {
+		case inScratch && !inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindMissing,
+				Object: ObjectIndex,
+				Table:  tblKey,
+				Name:   idxName,
+				Detail: "index exists in migrations but missing in target",
+			})
+		case !inScratch && inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindExtra,
+				Object: ObjectIndex,
+				Table:  tblKey,
+				Name:   idxName,
+				Detail: "index exists in target but missing in migrations",
+			})
+		case inScratch && inTarget:
+			var diffs []string
+			if sIdx.Unique != tIdx.Unique {
+				diffs = append(diffs, fmt.Sprintf("unique %t vs %t", sIdx.Unique, tIdx.Unique))
+			}
+			if !equalStringSlices(sIdx.Columns, tIdx.Columns) {
+				diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sIdx.Columns, tIdx.Columns))
+			}
+			if len(diffs) > 0 {
+				findings = append(findings, Finding{
+					Kind:   KindChanged,
+					Object: ObjectIndex,
+					Table:  tblKey,
+					Name:   idxName,
+					Detail: strings.Join(diffs, "; "),
+				})
+			}
+		}
+	}
+
+	// 3. Foreign Keys
+	sFKs := make(map[string]generate.ForeignKeySchema, len(sTbl.ForeignKeys))
+	for _, fk := range sTbl.ForeignKeys {
+		sFKs[fk.Name] = fk
+	}
+	tFKs := make(map[string]generate.ForeignKeySchema, len(tTbl.ForeignKeys))
+	for _, fk := range tTbl.ForeignKeys {
+		tFKs[fk.Name] = fk
+	}
+
+	allFKNamesMap := make(map[string]struct{})
+	for k := range sFKs {
+		allFKNamesMap[k] = struct{}{}
+	}
+	for k := range tFKs {
+		allFKNamesMap[k] = struct{}{}
+	}
+	fkNames := make([]string, 0, len(allFKNamesMap))
+	for k := range allFKNamesMap {
+		fkNames = append(fkNames, k)
+	}
+	sort.Strings(fkNames)
+
+	for _, fkName := range fkNames {
+		sFK, inScratch := sFKs[fkName]
+		tFK, inTarget := tFKs[fkName]
+
+		switch {
+		case inScratch && !inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindMissing,
+				Object: ObjectForeignKey,
+				Table:  tblKey,
+				Name:   fkName,
+				Detail: "foreign key exists in migrations but missing in target",
+			})
+		case !inScratch && inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindExtra,
+				Object: ObjectForeignKey,
+				Table:  tblKey,
+				Name:   fkName,
+				Detail: "foreign key exists in target but missing in migrations",
+			})
+		case inScratch && inTarget:
+			var diffs []string
+			if sFK.RefSchema != tFK.RefSchema {
+				diffs = append(diffs, fmt.Sprintf("ref schema %s vs %s", sFK.RefSchema, tFK.RefSchema))
+			}
+			if sFK.RefTable != tFK.RefTable {
+				diffs = append(diffs, fmt.Sprintf("ref table %s vs %s", sFK.RefTable, tFK.RefTable))
+			}
+			if !equalStringSlices(sFK.Columns, tFK.Columns) {
+				diffs = append(diffs, fmt.Sprintf("columns %v vs %v", sFK.Columns, tFK.Columns))
+			}
+			if !equalStringSlices(sFK.RefColumns, tFK.RefColumns) {
+				diffs = append(diffs, fmt.Sprintf("ref columns %v vs %v", sFK.RefColumns, tFK.RefColumns))
+			}
+			if len(diffs) > 0 {
+				findings = append(findings, Finding{
+					Kind:   KindChanged,
+					Object: ObjectForeignKey,
+					Table:  tblKey,
+					Name:   fkName,
+					Detail: strings.Join(diffs, "; "),
+				})
+			}
+		}
+	}
+
+	// 4. Check Constraints
+	sCKs := make(map[string]generate.CheckConstraintSchema, len(sTbl.CheckConstraints))
+	for _, ck := range sTbl.CheckConstraints {
+		sCKs[ck.Name] = ck
+	}
+	tCKs := make(map[string]generate.CheckConstraintSchema, len(tTbl.CheckConstraints))
+	for _, ck := range tTbl.CheckConstraints {
+		tCKs[ck.Name] = ck
+	}
+
+	allCKNamesMap := make(map[string]struct{})
+	for k := range sCKs {
+		allCKNamesMap[k] = struct{}{}
+	}
+	for k := range tCKs {
+		allCKNamesMap[k] = struct{}{}
+	}
+	ckNames := make([]string, 0, len(allCKNamesMap))
+	for k := range allCKNamesMap {
+		ckNames = append(ckNames, k)
+	}
+	sort.Strings(ckNames)
+
+	for _, ckName := range ckNames {
+		sCK, inScratch := sCKs[ckName]
+		tCK, inTarget := tCKs[ckName]
+
+		switch {
+		case inScratch && !inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindMissing,
+				Object: ObjectCheck,
+				Table:  tblKey,
+				Name:   ckName,
+				Detail: "check constraint exists in migrations but missing in target",
+			})
+		case !inScratch && inTarget:
+			findings = append(findings, Finding{
+				Kind:   KindExtra,
+				Object: ObjectCheck,
+				Table:  tblKey,
+				Name:   ckName,
+				Detail: "check constraint exists in target but missing in migrations",
+			})
+		case inScratch && inTarget:
+			if sCK.Expression != tCK.Expression {
+				findings = append(findings, Finding{
+					Kind:   KindChanged,
+					Object: ObjectCheck,
+					Table:  tblKey,
+					Name:   ckName,
+					Detail: fmt.Sprintf("expression %q vs %q", sCK.Expression, tCK.Expression),
+				})
+			}
+		}
+	}
+
+	return findings, notes
+}

--- a/internal/diff/compare_test.go
+++ b/internal/diff/compare_test.go
@@ -1,0 +1,115 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/diff"
+	"github.com/seanpham99/dbtools/internal/generate"
+)
+
+func TestCompare_MissingTable(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders"}}
+	target := []generate.TableSchema{}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindMissing || findings[0].Object != diff.ObjectTable {
+		t.Fatalf("findings = %+v, want one MISSING table", findings)
+	}
+}
+
+func TestCompare_ExtraTable(t *testing.T) {
+	scratch := []generate.TableSchema{}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders"}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindExtra || findings[0].Object != diff.ObjectTable {
+		t.Fatalf("findings = %+v, want one EXTRA table", findings)
+	}
+}
+
+func TestCompare_ColumnTypeChanged(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "status", DataType: "text"},
+	}}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "status", DataType: "varchar"},
+	}}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindChanged || findings[0].Object != diff.ObjectColumn {
+		t.Fatalf("findings = %+v, want one CHANGED column", findings)
+	}
+}
+
+func TestCompare_ColumnMissing(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "status", DataType: "text"},
+	}}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders"}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindMissing || findings[0].Object != diff.ObjectColumn {
+		t.Fatalf("findings = %+v, want one MISSING column", findings)
+	}
+}
+
+func TestCompare_IndexChanged(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders", Indexes: []generate.IndexSchema{
+		{Name: "idx_status", Columns: []string{"status"}, Unique: true},
+	}}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders", Indexes: []generate.IndexSchema{
+		{Name: "idx_status", Columns: []string{"status"}, Unique: false},
+	}}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindChanged || findings[0].Object != diff.ObjectIndex {
+		t.Fatalf("findings = %+v, want one CHANGED index (unique flag)", findings)
+	}
+}
+
+func TestCompare_ForeignKeyExtra(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders"}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders", ForeignKeys: []generate.ForeignKeySchema{
+		{Name: "fk_customer", Columns: []string{"customer_id"}, RefTable: "customers", RefColumns: []string{"id"}},
+	}}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindExtra || findings[0].Object != diff.ObjectForeignKey {
+		t.Fatalf("findings = %+v, want one EXTRA foreign key", findings)
+	}
+}
+
+func TestCompare_CheckConstraintChanged(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders", CheckConstraints: []generate.CheckConstraintSchema{
+		{Name: "chk_total", Expression: "total >= 0"},
+	}}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders", CheckConstraints: []generate.CheckConstraintSchema{
+		{Name: "chk_total", Expression: "total > 0"},
+	}}}
+	findings, _ := diff.Compare(scratch, target)
+	if len(findings) != 1 || findings[0].Kind != diff.KindChanged || findings[0].Object != diff.ObjectCheck {
+		t.Fatalf("findings = %+v, want one CHANGED check constraint", findings)
+	}
+}
+
+func TestCompare_OrdinalPositionIsInformationalNotDrift(t *testing.T) {
+	scratch := []generate.TableSchema{{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "a", DataType: "int", OrdinalPosition: 1},
+		{Name: "b", DataType: "int", OrdinalPosition: 2},
+	}}}
+	target := []generate.TableSchema{{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "a", DataType: "int", OrdinalPosition: 2},
+		{Name: "b", DataType: "int", OrdinalPosition: 1},
+	}}}
+	findings, notes := diff.Compare(scratch, target)
+	if len(findings) != 0 {
+		t.Errorf("findings = %+v, want zero — ordinal position alone is not drift", findings)
+	}
+	if len(notes) == 0 {
+		t.Error("notes is empty, want at least one informational note about column order")
+	}
+}
+
+func TestCompare_IdenticalSchemasProduceNoFindings(t *testing.T) {
+	tbl := generate.TableSchema{Schema: "public", Name: "orders", Columns: []generate.ColumnSchema{
+		{Name: "id", DataType: "int", OrdinalPosition: 1, IsPrimaryKey: true},
+	}}
+	findings, notes := diff.Compare([]generate.TableSchema{tbl}, []generate.TableSchema{tbl})
+	if len(findings) != 0 || len(notes) != 0 {
+		t.Fatalf("findings = %+v, notes = %v, want both empty for identical schemas", findings, notes)
+	}
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -47,7 +47,9 @@ func Run(cfg *config.Config, targetName, againstURL string) ([]Finding, []string
 		}
 	}
 	if cleanup != nil {
-		defer cleanup()
+		defer func() {
+			_ = cleanup()
+		}()
 	}
 
 	if _, err := apply.Run(cfg, "diff-scratch", scratchURL); err != nil {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -14,7 +14,7 @@ import (
 // skipping provisioning), replays every migration file into it via the
 // real apply path, introspects both it and target, and returns the
 // structural comparison. Never writes to target.
-func Run(cfg *config.Config, targetName, againstURL string) ([]Finding, []string, error) {
+func Run(cfg *config.Config, targetName, againstURL string) (findings []Finding, notes []string, err error) {
 	targetURL, err := cfg.ResolveURLOrFlag(targetName, "")
 	if err != nil {
 		return nil, nil, err
@@ -48,7 +48,9 @@ func Run(cfg *config.Config, targetName, againstURL string) ([]Finding, []string
 	}
 	if cleanup != nil {
 		defer func() {
-			_ = cleanup()
+			if cerr := cleanup(); cerr != nil {
+				notes = append(notes, fmt.Sprintf("warning: scratch database cleanup failed: %v", cerr))
+			}
 		}()
 	}
 
@@ -80,6 +82,6 @@ func Run(cfg *config.Config, targetName, againstURL string) ([]Finding, []string
 		return nil, nil, fmt.Errorf("introspecting target database: %w", err)
 	}
 
-	findings, notes := Compare(scratchSchema, targetSchema)
+	findings, notes = Compare(scratchSchema, targetSchema)
 	return findings, notes, nil
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -48,9 +48,18 @@ func Run(cfg *config.Config, targetName, againstURL string) (findings []Finding,
 	}
 	if cleanup != nil {
 		defer func() {
-			if cerr := cleanup(); cerr != nil {
-				notes = append(notes, fmt.Sprintf("warning: scratch database cleanup failed: %v", cerr))
+			cerr := cleanup()
+			if cerr == nil {
+				return
 			}
+			if err != nil {
+				// The run already failed — fold the cleanup failure into
+				// that error rather than the notes slice, which callers
+				// don't render on a non-nil error (see cmd/diff.go).
+				err = fmt.Errorf("%w (scratch database cleanup also failed: %v)", err, cerr)
+				return
+			}
+			notes = append(notes, fmt.Sprintf("warning: scratch database cleanup failed: %v", cerr))
 		}()
 	}
 

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,83 @@
+package diff
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/container"
+	"github.com/seanpham99/dbtools/internal/engine"
+)
+
+// Run provisions a scratch database (or uses againstURL if non-empty,
+// skipping provisioning), replays every migration file into it via the
+// real apply path, introspects both it and target, and returns the
+// structural comparison. Never writes to target.
+func Run(cfg *config.Config, targetName, againstURL string) ([]Finding, []string, error) {
+	targetURL, err := cfg.ResolveURLOrFlag(targetName, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	eng, err := engine.ForTarget(cfg.EngineName(targetName), targetURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	scratchURL := againstURL
+	var cleanup func() error
+	if scratchURL == "" {
+		if eng.Name() == "sqlite" {
+			f, err := os.CreateTemp("", "dbtools-diff-scratch-*.db")
+			if err != nil {
+				return nil, nil, fmt.Errorf("creating scratch file: %w", err)
+			}
+			path := f.Name()
+			f.Close()
+			os.Remove(path) // sqlite creates it fresh on first open
+			scratchURL = "sqlite://" + path
+			cleanup = func() error { return os.Remove(path) }
+		} else {
+			url, c, err := container.StartScratch(eng.Name())
+			if err != nil {
+				return nil, nil, fmt.Errorf("provisioning scratch database: %w", err)
+			}
+			scratchURL = url
+			cleanup = c
+		}
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	if _, err := apply.Run(cfg, "diff-scratch", scratchURL); err != nil {
+		return nil, nil, fmt.Errorf("replaying migrations into scratch database: %w", err)
+	}
+
+	scratchEng, err := engine.ForURL(scratchURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	scratchDB, err := scratchEng.Open(scratchURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer scratchDB.Close()
+	scratchSchema, _, err := scratchEng.Introspect(scratchDB, cfg.Generate.Exclude)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting scratch database: %w", err)
+	}
+
+	targetDB, err := eng.Open(targetURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer targetDB.Close()
+	targetSchema, _, err := eng.Introspect(targetDB, cfg.Generate.Exclude)
+	if err != nil {
+		return nil, nil, fmt.Errorf("introspecting target database: %w", err)
+	}
+
+	findings, notes := Compare(scratchSchema, targetSchema)
+	return findings, notes, nil
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,131 @@
+package diff_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/apply"
+	"github.com/seanpham99/dbtools/internal/config"
+	"github.com/seanpham99/dbtools/internal/diff"
+	_ "github.com/seanpham99/dbtools/internal/engine/sqliteengine"
+	_ "modernc.org/sqlite"
+)
+
+func setupDiffTestEnv(t *testing.T) (string, string, *config.Config) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "target.db")
+	rawURL := fmt.Sprintf("sqlite://%s", dbPath)
+	migrationsDir := filepath.Join(dir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m1Up := `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);`
+	m1Down := `DROP TABLE users;`
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.up.sql"), []byte(m1Up), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(migrationsDir, "20260822000001_users.down.sql"), []byte(m1Down), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgContent := fmt.Sprintf(`migrations_dir = %q
+[targets.testdb]
+url_env = "DBTOOLS_TEST_DIFF_URL"
+engine = "sqlite"
+protected = false
+`, migrationsDir)
+
+	configPath := filepath.Join(dir, "dbtools.toml")
+	if err := os.WriteFile(configPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DBTOOLS_TEST_DIFF_URL", rawURL)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, dbPath, cfg
+}
+
+func TestRun_CleanReplayMatchesTarget(t *testing.T) {
+	_, _, cfg := setupDiffTestEnv(t)
+
+	// Apply migration to target
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	findings, notes, err := diff.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatalf("diff.Run failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("findings = %+v, want 0", findings)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("notes = %+v, want 0", notes)
+	}
+}
+
+func TestRun_ExtraColumnInTargetReportsExtra(t *testing.T) {
+	_, dbPath, cfg := setupDiffTestEnv(t)
+
+	// Apply migration to target
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	// Manually add extra column to target
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("ALTER TABLE users ADD COLUMN hotfix_col TEXT;"); err != nil {
+		t.Fatalf("ALTER TABLE failed: %v", err)
+	}
+
+	findings, _, err := diff.Run(cfg, "testdb", "")
+	if err != nil {
+		t.Fatalf("diff.Run failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings count = %d, want 1; findings: %+v", len(findings), findings)
+	}
+	if findings[0].Kind != diff.KindExtra || findings[0].Object != diff.ObjectColumn || findings[0].Name != "hotfix_col" {
+		t.Fatalf("unexpected finding: %+v, want EXTRA column hotfix_col", findings[0])
+	}
+}
+
+func TestRun_AgainstFlagSkipsAutomaticProvisioning(t *testing.T) {
+	dir, _, cfg := setupDiffTestEnv(t)
+
+	// Apply migration to target
+	if _, err := apply.Run(cfg, "testdb", ""); err != nil {
+		t.Fatalf("apply.Run failed: %v", err)
+	}
+
+	scratchPath := filepath.Join(dir, "scratch.db")
+	scratchURL := "sqlite://" + scratchPath
+
+	findings, _, err := diff.Run(cfg, "testdb", scratchURL)
+	if err != nil {
+		t.Fatalf("diff.Run with againstURL failed: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("findings = %+v, want 0", findings)
+	}
+
+	// Verify scratch file was created and used
+	if _, err := os.Stat(scratchPath); err != nil {
+		t.Fatalf("expected scratch db file to exist at %s: %v", scratchPath, err)
+	}
+}

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -16,6 +16,7 @@ nuance than a table row can hold, read the matching file before using them:
 | Topic | File |
 |---|---|
 | `dbtools adopt` — importing incumbent migration ledgers (Flyway/EF/Knex/Alembic) | `adopt.md` |
+| `dbtools diff` — replaying migrations into scratch DB and checking live structural drift | `diff.md` |
 | `dbtools clone` masking rules, `[clone.mask]` config, `--where`/`--limit` | `clone.md` |
 | `dbtools doctor` — all 6 checks, exit-code meaning per check | `doctor.md` |
 | Exit-code contract (`plan`/`verify`/`up`/`down`) and CI/agent loop pattern | `ci-gate.md` |
@@ -81,6 +82,9 @@ dbtools plan [--target X] [--json]
 
 # Verify migration ledger objects exist in target DB (drift check)
 dbtools verify <target_name> [--json]
+
+# Replay migrations into scratch DB and check live target structural drift (read-only against target)
+dbtools diff <target_name> [--against <url>] [--json]
 # Exit codes: 0 clean, 1 error, 2 drift/pending — see docs/exit-codes.md
 
 # Apply .down.sql migrations in reverse (destructive; protected targets need --preview --yes)

--- a/skills/using-dbtools/SKILL.md
+++ b/skills/using-dbtools/SKILL.md
@@ -32,7 +32,7 @@ nuance than a table row can hold, read the matching file before using them:
 |---|---|---|
 | **target** | Named DB environment (`local`, `prod`) in `dbtools.toml` mapping to an environment variable (`url_env`). | Hardcoded DB URLs in `dbtools.toml` |
 | **push** | Applies pending migrations to a named target (version-sync). | `deploy`, `schema-sync`, `sync` |
-| **version-sync** | Guarantees applied migration history matches local `.sql` files up to latest. | "Full schema sync" (dbtools does not do DDL diffing) |
+| **version-sync** | Guarantees applied migration history matches local `.sql` files up to latest. | "Full schema sync" (use `dbtools diff` for structural schema comparison) |
 | **reset** | Local-only: drops, recreates DB, replays all migrations, runs `seed.sql`. Supports mssql/postgres only — errors on a MySQL target. | `rollback`, `restore` |
 | **seed.sql** | Single optional root SQL file run automatically after `reset`. | Multiple seed files or fixture scripts |
 | **ledger** | `dbtools_migration_history` table tracking per-migration `applied`/`reverted` state. | Generic "history table" |

--- a/skills/using-dbtools/diff.md
+++ b/skills/using-dbtools/diff.md
@@ -1,0 +1,58 @@
+# dbtools diff
+
+`dbtools diff` replays all local migration files into a fresh, isolated scratch database and compares its structural schema catalog against a live target database to detect manual hotfixes and out-of-band schema changes.
+
+## Why `diff` Exists (The Ledger Blind Spot)
+
+`dbtools verify` and `dbtools doctor` check whether the live database schema matches what the migration **ledger** recorded. If a developer or DBA executes an out-of-band `ALTER TABLE` or `CREATE TABLE` directly against production at 2am (a manual hotfix), the migration ledger remains untouched and clean. `verify` cannot see this drift because no ledger entry was created or modified.
+
+`dbtools diff` answers the fundamental question:
+> **"Does the live database schema structurally match what these migration files would produce if executed from scratch today?"**
+
+## Usage
+
+```bash
+# Compare live target against a fresh scratch database (auto-provisioned)
+dbtools diff <target>
+
+# Compare against an already-provisioned, empty scratch database
+dbtools diff <target> --against "postgres://postgres:pass@localhost:5432/scratch_db?sslmode=disable"
+
+# Emit machine-readable JSON output for CI / agent assertions
+dbtools diff <target> --json
+```
+
+## How It Works
+
+1. **Scratch Database Provisioning**:
+   - **SQLite**: Creates an ephemeral temporary file (`os.CreateTemp`), removes it on cleanup.
+   - **Postgres / MySQL / MSSQL**: Automatically spins up an ephemeral, `--rm` Docker container on a random port with a dedicated scratch naming scheme (`dbtools-diff-scratch-<engine>-<timestamp>`), waits for readiness, and stops it when done.
+   - **`--against <url>`**: Replays directly into a caller-supplied database, skipping Docker provisioning entirely.
+
+2. **Migration Replay**:
+   Replays all migration files from `migrations_dir` into the scratch database using the exact same `apply.Run` path used by `dbtools up` and `dbtools push`.
+
+3. **Full Catalog Introspection**:
+   Introspects both the scratch database and the live target database across all structural objects (tables, columns, primary keys, foreign keys, non-PK indexes, CHECK constraints, and defaults).
+
+4. **Structural Comparison**:
+   Compares the catalog and classifies differences:
+   - **`MISSING`**: Present in scratch (defined in migrations) but missing in the live target (e.g. a table or column was dropped out-of-band).
+   - **`EXTRA`**: Present in the live target but not defined in any migration file (the manual hotfix case).
+   - **`CHANGED`**: Present in both, but differs in data type, nullability, max length, precision, scale, default value, primary key, index uniqueness/columns, foreign key reference, or check constraint expression.
+
+5. **Column Ordinal Position**:
+   Differences in column ordering (`OrdinalPosition`) are reported purely as informational notes and are **not** treated as drift (they do not trigger exit code 2).
+
+6. **CHECK Constraints**:
+   Compared on Postgres, MySQL (8.0.16+), and MSSQL. SQLite does not have a queryable CHECK constraint catalog, so `CheckConstraints` is empty on both sides and naturally produces zero diffs.
+
+## Exit Codes
+
+- `0`: Clean — live target schema matches migrations perfectly (no structural differences).
+- `2`: Differences found — one or more `MISSING`, `EXTRA`, or `CHANGED` findings detected.
+- `1`: Error — connection failure, replay error, or invalid configuration.
+
+## Safety & Target Read-Only Contract
+
+`dbtools diff` is strictly **read-only** against the target database. It only connects to the target to perform read-only metadata introspection. All migration replay and ledger writes happen exclusively inside the ephemeral scratch database.


### PR DESCRIPTION
## Summary

Implements `dbtools diff <target>` (sub-project B of issue #62, closing #62):
- Provisions an ephemeral, isolated scratch database (or replays into `--against <url>`).
  - Auto-provisions `--rm` Docker containers with unique non-colliding names (`dbtools-diff-scratch-<engine>-<timestamp>`) and host port `0` for MSSQL, PostgreSQL, and MySQL.
  - Auto-provisions temporary files (`os.CreateTemp`) for SQLite.
- Replays local migration files using the existing, verified `apply.Run` path.
- Introspects both the scratch database and live target database across all structural objects.
- Pure structural comparator (`internal/diff`) classifies `MISSING`, `EXTRA`, and `CHANGED` differences.
- Reports column `OrdinalPosition` differences purely as informational notes (not treated as drift).
- Strictly read-only against the live target database.
- Follows exit code contract: `0` clean / `1` error / `2` structural differences found. Universal `--json` output support.

## Verification
- Local unit tests + smoke test: `scripts/dev-local.sh all` passed.
- Integration tests in CI (`container` and matrix databases) verifying real ephemeral Docker container lifecycle and drift detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `dbtools diff` to compare a live database with a schema recreated from migrations.
  - Detects missing, extra, and changed tables, columns, indexes, foreign keys, and constraints.
  - Supports table and JSON output, informational notes, and comparison against a specified database URL.
  - Automatically provisions temporary comparison databases when needed.
  - Uses exit codes to distinguish matching schemas, operational errors, and detected differences.
  - Keeps the target database read-only during comparison.

- **Documentation**
  - Added command usage, output behavior, read-only guarantees, and exit-code guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->