### PR TITLE
fix: cursor collision, diff false positives, squash dump portability, doctor usage

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -19,11 +20,28 @@ var doctorCmd = &cobra.Command{
 	Short: "Perform read-only health and security checks on target databases",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Reset explicitly: cmd is a package-level singleton, so a prior
+		// invocation's outcome would otherwise leak into every later one in
+		// the same process. Same pattern as plan/verify/diff.
+		cmd.SilenceUsage = false
+		cmd.SilenceErrors = false
 		target := ""
 		if len(args) > 0 {
 			target = args[0]
 		}
-		return runDoctor(target)
+		err := runDoctor(target)
+		// Exit 1 (target unreachable) and exit 2 (issues detected) are both
+		// documented outcomes of a correct run. doctor has already printed a
+		// per-check report ending in "Result: ...", so the usage block and a
+		// second rendering of the error add nothing. An actual
+		// invalid-flag/argument error, which cobra routes through this same
+		// path without an ExitCodeError, still shows both.
+		var exitErr *ExitCodeError
+		if errors.As(err, &exitErr) {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+		}
+		return err
 	},
 }
 

--- a/cmd/squash.go
+++ b/cmd/squash.go
@@ -8,6 +8,7 @@ import (
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/logger"
 	"github.com/seanpham99/dbtools/internal/migrator"
+	"github.com/seanpham99/dbtools/internal/scratchdb"
 	"github.com/seanpham99/dbtools/internal/squash"
 	"github.com/spf13/cobra"
 )
@@ -64,7 +65,16 @@ func runSquash(targetName string) error {
 		upto = versions[len(versions)-1]
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, migrationsDir, upSuffix, upto)
+	// Pin the scratch databases to the target's major version. Best-effort:
+	// if the target is unreachable we still build the plan, since squash
+	// itself only writes files and the scratch databases are throwaway.
+	targetMajor := ""
+	if targetDB, derr := eng.Open(url); derr == nil {
+		targetMajor = scratchdb.ServerMajor(targetDB, eng.Name())
+		targetDB.Close()
+	}
+
+	plan, err := squash.BuildPlan(cfg, eng, migrationsDir, upSuffix, upto, targetMajor)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	toml "github.com/pelletier/go-toml/v2"
+	"github.com/seanpham99/dbtools/internal/dburl"
 	"github.com/seanpham99/dbtools/internal/ledger"
 )
 
@@ -83,6 +84,19 @@ type LedgerConfig struct {
 	// incumbent migration tool's table (e.g. "schema_migrations") instead
 	// of dbtools' own "dbtools_migration_history".
 	Table string `toml:"table"`
+
+	// CursorTable overrides the *version cursor* table — golang-migrate's
+	// single-row (version, dirty) table, which is a different thing from
+	// Table above and defaults to golang-migrate's own "schema_migrations".
+	//
+	// Set this when an incumbent tool already owns a table of that name.
+	// "schema_migrations" is what golang-migrate, Rails, Supabase and many
+	// hand-rolled runners all call their ledger, and those tables are not
+	// shaped like golang-migrate's — a text version column and no "dirty"
+	// column is the common case. Pointing the cursor elsewhere
+	// (cursor_table = "dbtools_schema_version") lets dbtools coexist with
+	// the incumbent rather than colliding with it.
+	CursorTable string `toml:"cursor_table"`
 }
 
 // MigrationsConfig configures how migration files on disk are recognized.
@@ -98,6 +112,19 @@ const (
 	DefaultMigrationsDir = "migrations"
 	DefaultUpSuffix      = ".up.sql"
 	DefaultLedgerTable   = "dbtools_migration_history"
+
+	// DefaultCursorTable is golang-migrate's own default version-cursor
+	// table name. It is deliberately left as-is rather than namespaced:
+	// every database dbtools has already migrated keeps its cursor here,
+	// and silently moving it would make dbtools believe nothing had been
+	// applied and try to replay the entire history. Users who collide with
+	// an incumbent table of the same name set [ledger] cursor_table.
+	DefaultCursorTable = "schema_migrations"
+
+	// FallbackCursorTable is where the cursor moves when the ledger has
+	// been pointed at DefaultCursorTable, so the two never share a name.
+	// It is also the value the collision diagnostic suggests.
+	FallbackCursorTable = "dbtools_schema_version"
 )
 
 // ResolveDefaults fills in the standard default for any of migrationsDir,
@@ -145,6 +172,26 @@ func Load(path string) (*Config, error) {
 	if err := ledger.ValidateTableName(cfg.Ledger.Table); err != nil {
 		return nil, fmt.Errorf("dbtools.toml: %w", err)
 	}
+	if cfg.Ledger.CursorTable == "" {
+		// An unset cursor_table normally keeps golang-migrate's default.
+		// The exception is a config that points the *ledger* at that same
+		// name — the documented way to coexist with an incumbent tool. Two
+		// differently-shaped tables cannot share one name, so move the
+		// cursor aside rather than making the user discover the conflict
+		// through a driver error about a missing "dirty" column.
+		if cfg.Ledger.Table == DefaultCursorTable {
+			cfg.Ledger.CursorTable = FallbackCursorTable
+		} else {
+			cfg.Ledger.CursorTable = DefaultCursorTable
+		}
+	}
+	if err := ledger.ValidateTableName(cfg.Ledger.CursorTable); err != nil {
+		return nil, fmt.Errorf("dbtools.toml: cursor_table: %w", err)
+	}
+	if cfg.Ledger.CursorTable == cfg.Ledger.Table {
+		return nil, fmt.Errorf("dbtools.toml: [ledger] table and cursor_table are both %q — "+
+			"they are two different tables with incompatible shapes and cannot share a name", cfg.Ledger.Table)
+	}
 	// Default exclude list to internal tool tables unless the key was set at all
 	// (including explicitly to an empty list, which means "exclude nothing").
 	if cfg.Generate.Exclude == nil {
@@ -152,9 +199,21 @@ func Load(path string) (*Config, error) {
 		if cfg.Ledger.Table != DefaultLedgerTable {
 			exclude = append(exclude, cfg.Ledger.Table)
 		}
+		if cfg.Ledger.CursorTable != DefaultCursorTable {
+			exclude = append(exclude, cfg.Ledger.CursorTable)
+		}
 		cfg.Generate.Exclude = exclude
 	}
 	return cfg, nil
+}
+
+// CursorTableName returns the configured version-cursor table, defaulting
+// for a Config that was built in memory rather than through Load.
+func (c *Config) CursorTableName() string {
+	if c.Ledger.CursorTable == "" {
+		return DefaultCursorTable
+	}
+	return c.Ledger.CursorTable
 }
 
 // ResolveURL returns the connection string for targetName by reading the
@@ -169,7 +228,7 @@ func (c *Config) ResolveURL(targetName string) (string, error) {
 	if url == "" {
 		return "", &UnsetEnvError{Target: targetName, URLEnv: t.URLEnv}
 	}
-	return url, nil
+	return c.withCursorTable(url), nil
 }
 
 // ResolveURLOrFlag returns the connection string for targetName, preferring
@@ -179,9 +238,27 @@ func (c *Config) ResolveURL(targetName string) (string, error) {
 // pass them straight through as flags).
 func (c *Config) ResolveURLOrFlag(targetName, urlFlag string) (string, error) {
 	if urlFlag != "" {
-		return urlFlag, nil
+		return c.withCursorTable(urlFlag), nil
 	}
 	return c.ResolveURL(targetName)
+}
+
+// withCursorTable annotates rawURL with golang-migrate's
+// x-migrations-table parameter when a non-default cursor table is
+// configured. golang-migrate reads it to decide which table holds the
+// version cursor; every other consumer of the URL must strip it first
+// (see dburl.StripCustomParams), because it is not a real connection
+// parameter and drivers reject it.
+//
+// Carrying it on the URL rather than threading a parameter through the
+// dozen call sites of migrator.Open keeps one source of truth for "which
+// cursor table", at the cost of that stripping discipline.
+func (c *Config) withCursorTable(rawURL string) string {
+	cursor := c.CursorTableName()
+	if cursor == DefaultCursorTable || rawURL == "" {
+		return rawURL
+	}
+	return dburl.WithParam(rawURL, "x-migrations-table", cursor)
 }
 
 // EngineName returns the engine configured for targetName, or "" when

--- a/internal/config/cursor_test.go
+++ b/internal/config/cursor_test.go
@@ -1,0 +1,100 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/config"
+)
+
+func loadCfg(t *testing.T, body string) *config.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dbtools.toml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg
+}
+
+// Unset cursor_table keeps golang-migrate's default, so every database
+// dbtools has already migrated still finds its cursor where it left it.
+func TestCursorTable_DefaultsToGolangMigrate(t *testing.T) {
+	cfg := loadCfg(t, "migrations_dir = \"m\"\n")
+	if got := cfg.CursorTableName(); got != config.DefaultCursorTable {
+		t.Errorf("CursorTableName() = %q, want %q", got, config.DefaultCursorTable)
+	}
+}
+
+// Pointing the ledger at schema_migrations is the documented way to coexist
+// with an incumbent tool. The cursor cannot also live there, so it moves.
+func TestCursorTable_MovesAsideWhenLedgerTakesTheName(t *testing.T) {
+	cfg := loadCfg(t, "migrations_dir = \"m\"\n[ledger]\ntable = \"schema_migrations\"\n")
+	if got := cfg.CursorTableName(); got != config.FallbackCursorTable {
+		t.Errorf("CursorTableName() = %q, want %q", got, config.FallbackCursorTable)
+	}
+}
+
+func TestCursorTable_ExplicitOverrideWins(t *testing.T) {
+	cfg := loadCfg(t, "migrations_dir = \"m\"\n[ledger]\ncursor_table = \"my_cursor\"\n")
+	if got := cfg.CursorTableName(); got != "my_cursor" {
+		t.Errorf("CursorTableName() = %q, want %q", got, "my_cursor")
+	}
+}
+
+// Two differently-shaped tables cannot share one name.
+func TestCursorTable_RejectsExplicitCollision(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dbtools.toml")
+	body := "migrations_dir = \"m\"\n[ledger]\ntable = \"same\"\ncursor_table = \"same\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.Load(path); err == nil {
+		t.Fatal("Load() succeeded with ledger table == cursor table, want error")
+	}
+}
+
+// A configured cursor must reach golang-migrate, and must not reach the
+// database driver (lib/pq rejects unknown query parameters).
+func TestResolveURL_CarriesCursorTable(t *testing.T) {
+	t.Setenv("CURSOR_TEST_URL", "postgres://u:p@h:5432/db?sslmode=disable")
+	cfg := loadCfg(t, "migrations_dir = \"m\"\n[ledger]\ncursor_table = \"dbtools_schema_version\"\n"+
+		"[targets.local]\nurl_env = \"CURSOR_TEST_URL\"\n")
+	url, err := cfg.ResolveURL("local")
+	if err != nil {
+		t.Fatalf("ResolveURL: %v", err)
+	}
+	if want := "x-migrations-table=dbtools_schema_version"; !contains(url, want) {
+		t.Errorf("ResolveURL() = %q, want it to carry %q", url, want)
+	}
+}
+
+// The default cursor adds nothing to the URL, so existing setups keep
+// byte-identical connection strings.
+func TestResolveURL_DefaultCursorLeavesURLUntouched(t *testing.T) {
+	raw := "postgres://u:p@h:5432/db?sslmode=disable"
+	t.Setenv("CURSOR_TEST_URL", raw)
+	cfg := loadCfg(t, "migrations_dir = \"m\"\n[targets.local]\nurl_env = \"CURSOR_TEST_URL\"\n")
+	url, err := cfg.ResolveURL("local")
+	if err != nil {
+		t.Fatalf("ResolveURL: %v", err)
+	}
+	if url != raw {
+		t.Errorf("ResolveURL() = %q, want it unchanged (%q)", url, raw)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -459,6 +459,14 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 	return StartScratchWithTimeout(engineName, 60*time.Second)
 }
 
+// StartScratchMajor is StartScratch pinned to a server major version, so a
+// scratch database can be made to match the target it will be compared
+// against. An empty or unrecognised major falls back to the engine's default
+// image. See ScratchImageFor for why the match matters.
+func StartScratchMajor(engineName, major string) (rawURL string, cleanup func() error, err error) {
+	return startScratch(engineName, major, 60*time.Second)
+}
+
 // StartScratchWithTimeout starts a throwaway, --rm container for engineName,
 // waits up to timeout for readiness, and returns its connection URL plus a
 // cleanup function that stops (and thereby removes) it. Unlike StartForWithTimeout,
@@ -466,6 +474,53 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 // container, since a scratch database must start empty. Returns an error
 // for engines with no scratchRunArgs (sqlite — callers use a tempfile).
 func StartScratchWithTimeout(engineName string, timeout time.Duration) (rawURL string, cleanup func() error, err error) {
+	return startScratch(engineName, "", timeout)
+}
+
+// ScratchImageFor returns the image to run a scratch container of engineName
+// on, pinned to major when that is a plausible major version.
+//
+// Matching the target's major version matters because catalog rendering is
+// not stable across majors, and a scratch/target mismatch shows up as drift
+// that does not exist. Postgres 16 renders a CHECK constraint's
+// information_schema.check_clause as "((total_jobs >= 0))" where 17 renders
+// "(total_jobs >= 0)" — identical constraints, one paren apart, on every
+// CHECK in the schema. Against a default-image scratch database, that alone
+// produced dozens of false-positive findings for every user not already on
+// the default major.
+func ScratchImageFor(engineName, major string) string {
+	if !plausibleMajor(major) {
+		return ""
+	}
+	switch engineName {
+	case "postgres":
+		return "postgres:" + major + "-alpine"
+	case "mysql":
+		return "mysql:" + major
+	default:
+		// mssql tags are not major-version-shaped (2019-latest,
+		// 2022-latest), so leave the default image alone rather than
+		// guess a tag that will fail to pull.
+		return ""
+	}
+}
+
+// plausibleMajor reports whether v looks like a version tag component, so a
+// malformed or hostile server_version string cannot be interpolated into a
+// docker image reference.
+func plausibleMajor(v string) bool {
+	if v == "" || len(v) > 2 {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] < '0' || v[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func startScratch(engineName, major string, timeout time.Duration) (rawURL string, cleanup func() error, err error) {
 	s, err := specFor(engineName)
 	if err != nil {
 		return "", nil, err
@@ -475,6 +530,9 @@ func StartScratchWithTimeout(engineName string, timeout time.Duration) (rawURL s
 	}
 	if err := checkDocker(); err != nil {
 		return "", nil, err
+	}
+	if img := ScratchImageFor(engineName, major); img != "" {
+		s.image = img
 	}
 	s.name = scratchNameFor(engineName)
 	s.hostPort = "0"

--- a/internal/container/scratchimage_test.go
+++ b/internal/container/scratchimage_test.go
@@ -1,0 +1,42 @@
+package container
+
+import "testing"
+
+// A scratch database on a different major than the target renders catalog
+// metadata differently, which diff reports as drift that does not exist.
+func TestScratchImageFor(t *testing.T) {
+	cases := []struct {
+		engine, major, want string
+	}{
+		{"postgres", "16", "postgres:16-alpine"},
+		{"postgres", "17", "postgres:17-alpine"},
+		{"mysql", "8", "mysql:8"},
+		// No major detected: caller falls back to the spec's default image.
+		{"postgres", "", ""},
+		// mssql tags are not major-shaped (2022-latest), so don't guess.
+		{"mssql", "16", ""},
+		{"sqlite", "3", ""},
+	}
+	for _, c := range cases {
+		if got := ScratchImageFor(c.engine, c.major); got != c.want {
+			t.Errorf("ScratchImageFor(%q, %q) = %q, want %q", c.engine, c.major, got, c.want)
+		}
+	}
+}
+
+// The major is interpolated into a docker image reference, so anything that
+// is not a plain one- or two-digit number must be refused rather than
+// passed through.
+func TestPlausibleMajor_RejectsNonNumeric(t *testing.T) {
+	bad := []string{"", "16.14", "latest", "16-alpine", "../evil", "999", "1a", " 16"}
+	for _, v := range bad {
+		if plausibleMajor(v) {
+			t.Errorf("plausibleMajor(%q) = true, want false", v)
+		}
+	}
+	for _, v := range []string{"8", "16", "17", "18"} {
+		if !plausibleMajor(v) {
+			t.Errorf("plausibleMajor(%q) = false, want true", v)
+		}
+	}
+}

--- a/internal/dburl/dburl.go
+++ b/internal/dburl/dburl.go
@@ -1,0 +1,73 @@
+// Package dburl manipulates database connection URLs around
+// golang-migrate's custom "x-" query parameters.
+//
+// golang-migrate reads its own options (x-migrations-table,
+// x-statement-timeout, ...) from the connection URL's query string.
+// Database drivers do not know those options and reject them:
+// lib/pq fails a connection carrying x-migrations-table with
+//
+//	pq: unrecognized configuration parameter "x-migrations-table"
+//
+// so any code path that opens its own connection from a URL that
+// golang-migrate also consumes has to strip them first. That is every
+// dbtools engine Open, and it is why the parameter cannot simply be
+// documented as a user-supplied workaround.
+package dburl
+
+import (
+	"net/url"
+	"strings"
+)
+
+// CustomParamPrefix is golang-migrate's namespace for its own options.
+const CustomParamPrefix = "x-"
+
+// StripCustomParams returns rawURL without any x- query parameters, so it
+// is safe to hand to a database driver. URLs it cannot parse are returned
+// unchanged: MySQL DSNs in tcp(host:port) form are not RFC 3986 URLs, and
+// the mysql driver handles its own parameters anyway.
+func StripCustomParams(rawURL string) string {
+	if !strings.Contains(rawURL, CustomParamPrefix) {
+		return rawURL
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	stripped := false
+	for k := range q {
+		if strings.HasPrefix(strings.ToLower(k), CustomParamPrefix) {
+			q.Del(k)
+			stripped = true
+		}
+	}
+	if !stripped {
+		return rawURL
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// WithParam returns rawURL with key=value set in its query string,
+// replacing any existing value. A URL that cannot be parsed is returned
+// unchanged rather than corrupted.
+func WithParam(rawURL, key, value string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// Param returns the value of key in rawURL's query string, or "".
+func Param(rawURL, key string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get(key)
+}

--- a/internal/dburl/dburl_test.go
+++ b/internal/dburl/dburl_test.go
@@ -1,0 +1,42 @@
+package dburl
+
+import "testing"
+
+// lib/pq validates unknown query parameters as server settings, so a URL
+// still carrying golang-migrate's x- options fails to connect with
+// `unrecognized configuration parameter "x-migrations-table"`.
+func TestStripCustomParams(t *testing.T) {
+	cases := map[string]string{
+		"postgres://u:p@h:5432/db?sslmode=disable&x-migrations-table=t": "postgres://u:p@h:5432/db?sslmode=disable",
+		"postgres://u:p@h:5432/db?x-migrations-table=t":                 "postgres://u:p@h:5432/db",
+		"postgres://u:p@h:5432/db?sslmode=disable":                      "postgres://u:p@h:5432/db?sslmode=disable",
+		"postgres://u:p@h:5432/db":                                      "postgres://u:p@h:5432/db",
+	}
+	for in, want := range cases {
+		if got := StripCustomParams(in); got != want {
+			t.Errorf("StripCustomParams(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// MySQL DSNs use tcp(host:port), which is not an RFC 3986 URL. Returning
+// them unchanged is correct — the mysql driver owns its own parameters.
+func TestStripCustomParams_LeavesUnparseableUnchanged(t *testing.T) {
+	in := "mysql://user:pass@tcp(127.0.0.1:3306)/db?x-migrations-table=t"
+	if got := StripCustomParams(in); got != in {
+		t.Errorf("StripCustomParams(%q) = %q, want it unchanged", in, got)
+	}
+}
+
+func TestWithParamRoundTrips(t *testing.T) {
+	got := WithParam("postgres://h/db?sslmode=disable", "x-migrations-table", "dbtools_schema_version")
+	if v := Param(got, "x-migrations-table"); v != "dbtools_schema_version" {
+		t.Errorf("Param after WithParam = %q, want %q", v, "dbtools_schema_version")
+	}
+	if v := Param(got, "sslmode"); v != "disable" {
+		t.Errorf("WithParam dropped an existing parameter: sslmode = %q", v)
+	}
+	if got := StripCustomParams(got); Param(got, "x-migrations-table") != "" {
+		t.Errorf("StripCustomParams did not remove the parameter WithParam added: %q", got)
+	}
+}

--- a/internal/diff/compare.go
+++ b/internal/diff/compare.go
@@ -313,11 +313,73 @@ func compareTable(tblKey string, sTbl, tTbl generate.TableSchema) ([]Finding, []
 		tCKs[ck.Name] = ck
 	}
 	findings = append(findings, diffKeyed(tblKey, ObjectCheck, "check constraint", sCKs, tCKs, func(sCK, tCK generate.CheckConstraintSchema) []string {
-		if sCK.Expression != tCK.Expression {
+		if !equalExpressions(sCK.Expression, tCK.Expression) {
 			return []string{fmt.Sprintf("expression %q vs %q", sCK.Expression, tCK.Expression)}
 		}
 		return nil
 	})...)
 
 	return findings, notes
+}
+
+// equalExpressions compares two catalog-rendered SQL expressions for
+// semantic equality, ignoring the two things the server is free to vary:
+// redundant outer parentheses and whitespace.
+//
+// The server decides how to print a stored parse tree, and that rendering is
+// not stable. Postgres 16 renders a CHECK constraint as "((total_jobs >= 0))"
+// where 17 renders "(total_jobs >= 0)" for the identical constraint. diff
+// pins its scratch database to the target's major version to avoid that
+// class entirely (see scratchdb.ProvisionMajor), so this is the second line
+// of defence: point releases, --against databases the caller provisioned
+// themselves, and future rendering changes can all still put a cosmetic
+// difference in front of the comparison.
+//
+// It normalises only formatting. Any difference in operators, literals, or
+// identifiers survives and is still reported.
+func equalExpressions(a, b string) bool {
+	return a == b || normalizeExpression(a) == normalizeExpression(b)
+}
+
+// normalizeExpression strips balanced outer parentheses and collapses
+// whitespace runs to a single space.
+func normalizeExpression(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	for len(s) >= 2 && s[0] == '(' && s[len(s)-1] == ')' && outerParensBalanced(s) {
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
+	return s
+}
+
+// outerParensBalanced reports whether s's first parenthesis is closed by its
+// last one, so they can be stripped as a redundant wrapper. It is false for
+// "(a) AND (b)", where the outer pair is not a wrapper at all and removing
+// the ends would corrupt the expression.
+//
+// Parentheses inside string literals are skipped: '(' is a legitimate
+// character in a CHECK against text, and counting it would mis-balance.
+func outerParensBalanced(s string) bool {
+	depth := 0
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '\'':
+			// '' inside a quoted literal is an escaped quote, not a close.
+			if inQuote && i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				continue
+			}
+			inQuote = !inQuote
+		case inQuote:
+			continue
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+			if depth == 0 && i != len(s)-1 {
+				return false
+			}
+		}
+	}
+	return depth == 0 && !inQuote
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -23,7 +23,18 @@ func Run(cfg *config.Config, targetName, againstURL string) (findings []Finding,
 		return nil, nil, err
 	}
 
-	scratchURL, cleanup, err := scratchdb.Provision(eng, againstURL)
+	// Open the target first, purely to read its server major version: the
+	// scratch database has to be the same major or the comparison reports
+	// rendering differences between versions as schema drift. Best-effort —
+	// an unknown version falls back to the default image.
+	targetDB, err := eng.Open(targetURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer targetDB.Close()
+	targetMajor := scratchdb.ServerMajor(targetDB, eng.Name())
+
+	scratchURL, cleanup, err := scratchdb.ProvisionMajor(eng, againstURL, targetMajor)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,11 +73,6 @@ func Run(cfg *config.Config, targetName, againstURL string) (findings []Finding,
 		return nil, nil, fmt.Errorf("introspecting scratch database: %w", err)
 	}
 
-	targetDB, err := eng.Open(targetURL)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer targetDB.Close()
 	targetSchema, _, err := eng.Introspect(targetDB, cfg.Generate.Exclude)
 	if err != nil {
 		return nil, nil, fmt.Errorf("introspecting target database: %w", err)

--- a/internal/diff/expression_test.go
+++ b/internal/diff/expression_test.go
@@ -1,0 +1,73 @@
+package diff
+
+import "testing"
+
+// Postgres renders a stored CHECK expression differently across major
+// versions: 16 gives "((total_jobs >= 0))" where 17 gives
+// "(total_jobs >= 0)" for the identical constraint. Comparing the two
+// raw produced a finding for every CHECK in the schema.
+func TestEqualExpressions_IgnoresRenderingDifferences(t *testing.T) {
+	equal := [][2]string{
+		{"(total_jobs >= 0)", "((total_jobs >= 0))"},
+		{"((completed_jobs + failed_jobs) <= total_jobs)", "(((completed_jobs + failed_jobs) <= total_jobs))"},
+		{"(status = ANY (ARRAY['a'::text, 'b'::text]))", "((status = ANY (ARRAY['a'::text, 'b'::text])))"},
+		{"(a >= 0)", "( a  >=  0 )"},
+		{"(x > 1)", "(x > 1)"},
+	}
+	for _, pair := range equal {
+		if !equalExpressions(pair[0], pair[1]) {
+			t.Errorf("equalExpressions(%q, %q) = false, want true", pair[0], pair[1])
+		}
+	}
+}
+
+// Normalisation must only absorb formatting. A real change to an operator,
+// a literal, or an identifier still has to be reported.
+func TestEqualExpressions_KeepsRealDifferences(t *testing.T) {
+	different := [][2]string{
+		{"(total_jobs >= 0)", "(total_jobs > 0)"},
+		{"(total_jobs >= 0)", "(total_jobs >= 1)"},
+		{"(total_jobs >= 0)", "(failed_jobs >= 0)"},
+		{"(status = ANY (ARRAY['a'::text]))", "(status = ANY (ARRAY['b'::text]))"},
+	}
+	for _, pair := range different {
+		if equalExpressions(pair[0], pair[1]) {
+			t.Errorf("equalExpressions(%q, %q) = true, want false", pair[0], pair[1])
+		}
+	}
+}
+
+// "(a) AND (b)" opens and closes a paren before the end, so the leading and
+// trailing ones are not a wrapper — stripping them would corrupt the
+// expression and could make two different constraints compare equal.
+func TestNormalizeExpression_DoesNotStripNonWrappingParens(t *testing.T) {
+	cases := map[string]string{
+		"((a) AND (b))":  "(a) AND (b)",
+		"(a) AND (b)":    "(a) AND (b)",
+		"((a))":          "a",
+		"(name ~ '(x)')": "name ~ '(x)'",
+	}
+	for in, want := range cases {
+		if got := normalizeExpression(in); got != want {
+			t.Errorf("normalizeExpression(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A parenthesis inside a string literal is data. Counting it would
+// mis-balance the scan and could strip a genuine wrapper or refuse a
+// legitimate one.
+func TestOuterParensBalanced_IgnoresStringLiterals(t *testing.T) {
+	cases := map[string]bool{
+		"(name ~ '(unclosed')":    true,
+		"(a = ')' AND b = '(')":   true,
+		"(a) AND (b)":             false,
+		"(a >= 0)":                true,
+		"(x = 'it''s' AND y = 1)": true,
+	}
+	for in, want := range cases {
+		if got := outerParensBalanced(in); got != want {
+			t.Errorf("outerParensBalanced(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/dump/dump.go
+++ b/internal/dump/dump.go
@@ -163,18 +163,124 @@ var (
 	pgSetConfigSearchPathRE = regexp.MustCompile(`(?m)^SELECT pg_catalog\.set_config\('search_path', '', false\);\n?`)
 	pgClientMinMessagesRE   = regexp.MustCompile(`(?m)^SET client_min_messages = warning;\n?`)
 	mssqlUseRE              = regexp.MustCompile(`(?im)^\s*USE\s+\[?[^;\n]+\]?\s*;?\s*(\r?\n)?`)
+
+	// pg_dump's preamble sets four timeout GUCs. They tune the restore
+	// session and say nothing about the schema, but they are not all
+	// present in every server version — transaction_timeout arrived in
+	// Postgres 17, so a dump taken with pg_dump 17+ fails to apply to a
+	// 16 server with `unrecognized configuration parameter`. pg_dump is
+	// explicitly supported dumping older servers, so this mismatch is a
+	// normal setup (a newer client package on the developer's machine),
+	// not a misconfiguration.
+	//
+	// Deliberately narrow: the other preamble SETs are kept, because some
+	// change behaviour that matters to a restore. check_function_bodies =
+	// false in particular is what lets a function referencing a
+	// not-yet-created object be defined at all.
+	pgTimeoutGUCRE = regexp.MustCompile(`(?m)^SET (statement_timeout|lock_timeout|idle_in_transaction_session_timeout|transaction_timeout) = [^;\n]*;\n?`)
 )
 
-// StripPostgresSessionState removes the two session-state lines pg_dump
-// emits by default that poison every later migration replayed through
-// the same connection: a search_path reset (breaks unqualified name
-// resolution) and a client_min_messages override (silently swallows
-// RAISE NOTICE for the rest of the session). See the design spec's
-// "Native schema dump" section.
+// StripPostgresSessionState removes the pg_dump output that a baseline
+// applied over the wire protocol cannot survive:
+//
+//   - a search_path reset (breaks unqualified name resolution for every
+//     later migration replayed through the same connection),
+//   - a client_min_messages override (silently swallows RAISE NOTICE for
+//     the rest of the session),
+//   - psql meta-commands (see StripPsqlMetaCommands),
+//   - the timeout GUCs, which are not present in every server version.
+//
+// See the design spec's "Native schema dump" section.
 func StripPostgresSessionState(sqlText string) string {
 	sqlText = pgSetConfigSearchPathRE.ReplaceAllString(sqlText, "")
 	sqlText = pgClientMinMessagesRE.ReplaceAllString(sqlText, "")
+	sqlText = pgTimeoutGUCRE.ReplaceAllString(sqlText, "")
+	sqlText = StripPsqlMetaCommands(sqlText)
 	return sqlText
+}
+
+// StripPsqlMetaCommands removes backslash meta-commands from dump output.
+//
+// These are psql client directives, not SQL: the wire protocol rejects them
+// outright ("syntax error at or near \"\\\""). pg_dump emits \restrict and
+// \unrestrict by default on 16.10+, 17.6+ and 18.x — a security hardening
+// measure — so on any current point release an unstripped baseline fails to
+// apply, both to squash's own verification database and later to any target
+// replaying the committed file.
+//
+// Only lines whose first non-whitespace character is a backslash are dropped,
+// and only outside dollar-quoted bodies: a function body is free to contain
+// backslash-led lines that are ordinary text, and removing those would
+// silently corrupt the routine rather than fail loudly.
+func StripPsqlMetaCommands(sqlText string) string {
+	if !strings.Contains(sqlText, `\`) {
+		return sqlText
+	}
+	lines := strings.Split(sqlText, "\n")
+	kept := make([]string, 0, len(lines))
+	dollarTag := "" // non-empty while inside a dollar-quoted body
+	for _, line := range lines {
+		if dollarTag == "" && strings.HasPrefix(strings.TrimLeft(line, " \t"), `\`) {
+			continue
+		}
+		dollarTag = trackDollarQuote(line, dollarTag)
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// trackDollarQuote returns the dollar-quote tag still open at the end of
+// line, given the tag open at its start ("" for none). Scanning is
+// tag-aware: a body opened by $func$ ends only at $func$, so a bare $$
+// inside it does not close it.
+func trackDollarQuote(line, open string) string {
+	for i := 0; i < len(line); {
+		if open != "" {
+			idx := strings.Index(line[i:], open)
+			if idx < 0 {
+				return open
+			}
+			i += idx + len(open)
+			open = ""
+			continue
+		}
+		idx := strings.IndexByte(line[i:], '$')
+		if idx < 0 {
+			return ""
+		}
+		i += idx
+		tag := dollarTagAt(line[i:])
+		if tag == "" {
+			i++
+			continue
+		}
+		open = tag
+		i += len(tag)
+	}
+	return open
+}
+
+// dollarTagAt returns the dollar-quote tag starting at s ("$$" or "$name$"),
+// or "" if s does not start one. Tag bodies follow Postgres's identifier
+// rules: letters, underscores, and digits after the first character.
+func dollarTagAt(s string) string {
+	if len(s) == 0 || s[0] != '$' {
+		return ""
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if c == '$' {
+			return s[:i+1]
+		}
+		isIdent := c == '_' ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9' && i > 1)
+		if !isIdent {
+			return ""
+		}
+	}
+	return ""
 }
 
 // StripMSSQLUseStatement removes any generated USE [database] commands

--- a/internal/dump/psqlmeta_test.go
+++ b/internal/dump/psqlmeta_test.go
@@ -1,0 +1,124 @@
+package dump_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/seanpham99/dbtools/internal/dump"
+)
+
+// Postgres 16.10+/17.6+/18 emit \restrict and \unrestrict from pg_dump by
+// default. They are psql meta-commands, so a baseline carrying them fails to
+// apply over the wire protocol with `syntax error at or near "\"`.
+func TestStripPsqlMetaCommands_RemovesRestrict(t *testing.T) {
+	in := strings.Join([]string{
+		"--",
+		"-- PostgreSQL database dump",
+		"--",
+		"",
+		`\restrict 1uYNqOvUnmIaYkfzMTbiPC77KU3sYnhJ3vg2BJ56ELY4LUh43l`,
+		"",
+		"CREATE TABLE public.b (total_jobs integer);",
+		`\unrestrict 1uYNqOvUnmIaYkfzMTbiPC77KU3sYnhJ3vg2BJ56ELY4LUh43l`,
+	}, "\n")
+
+	got := dump.StripPsqlMetaCommands(in)
+
+	if strings.Contains(got, `\restrict`) || strings.Contains(got, `\unrestrict`) {
+		t.Errorf("meta-commands survived:\n%s", got)
+	}
+	if !strings.Contains(got, "CREATE TABLE public.b") {
+		t.Errorf("real SQL was dropped:\n%s", got)
+	}
+}
+
+// A backslash-led line inside a dollar-quoted function body is data, not a
+// meta-command. Dropping it would silently corrupt the routine.
+func TestStripPsqlMetaCommands_PreservesDollarQuotedBody(t *testing.T) {
+	in := strings.Join([]string{
+		`\restrict abc`,
+		"CREATE FUNCTION f() RETURNS text AS $$",
+		`\this is not a meta-command`,
+		"SELECT 1;",
+		"$$ LANGUAGE sql;",
+		`\unrestrict abc`,
+	}, "\n")
+
+	got := dump.StripPsqlMetaCommands(in)
+
+	if !strings.Contains(got, `\this is not a meta-command`) {
+		t.Errorf("dollar-quoted body line was stripped:\n%s", got)
+	}
+	if strings.Contains(got, `\restrict`) || strings.Contains(got, `\unrestrict`) {
+		t.Errorf("meta-commands survived:\n%s", got)
+	}
+}
+
+// A tagged body ($func$) is only closed by its own tag, so a bare $$ inside
+// it must not be treated as the end of the body.
+func TestStripPsqlMetaCommands_TaggedDollarQuote(t *testing.T) {
+	in := strings.Join([]string{
+		"CREATE FUNCTION f() RETURNS text AS $func$",
+		"-- a bare $$ inside the body",
+		`\still inside`,
+		"$func$ LANGUAGE sql;",
+		`\restrict after`,
+	}, "\n")
+
+	got := dump.StripPsqlMetaCommands(in)
+
+	if !strings.Contains(got, `\still inside`) {
+		t.Errorf("line inside $func$ body was stripped:\n%s", got)
+	}
+	if strings.Contains(got, `\restrict`) {
+		t.Errorf("meta-command after the body survived:\n%s", got)
+	}
+}
+
+func TestStripPostgresSessionState_AlsoStripsMetaCommands(t *testing.T) {
+	in := "SELECT pg_catalog.set_config('search_path', '', false);\n" +
+		"\\restrict tok\n" +
+		"CREATE TABLE t (id int);\n"
+
+	got := dump.StripPostgresSessionState(in)
+
+	for _, unwanted := range []string{"set_config", `\restrict`} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("%q survived:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "CREATE TABLE t") {
+		t.Errorf("real SQL was dropped:\n%s", got)
+	}
+}
+
+// transaction_timeout is a Postgres 17 GUC. A dump taken with pg_dump 17+
+// against an older server carries it, and applying that to a 16 server
+// fails with `unrecognized configuration parameter "transaction_timeout"`.
+func TestStripPostgresSessionState_StripsTimeoutGUCs(t *testing.T) {
+	in := strings.Join([]string{
+		"SET statement_timeout = 0;",
+		"SET lock_timeout = 0;",
+		"SET idle_in_transaction_session_timeout = 0;",
+		"SET transaction_timeout = 0;",
+		"SET client_encoding = 'UTF8';",
+		"SET check_function_bodies = false;",
+		"CREATE TABLE t (id int);",
+	}, "\n")
+
+	got := dump.StripPostgresSessionState(in)
+
+	for _, unwanted := range []string{"statement_timeout", "lock_timeout", "transaction_timeout"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("%q survived:\n%s", unwanted, got)
+		}
+	}
+	// These change restore behaviour and must survive — dropping
+	// check_function_bodies breaks functions that reference objects
+	// created later in the same dump.
+	for _, wanted := range []string{"check_function_bodies", "client_encoding", "CREATE TABLE t"} {
+		if !strings.Contains(got, wanted) {
+			t.Errorf("%q was dropped:\n%s", wanted, got)
+		}
+	}
+}

--- a/internal/engine/postgresengine/postgresengine.go
+++ b/internal/engine/postgresengine/postgresengine.go
@@ -9,6 +9,7 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/seanpham99/dbtools/internal/dburl"
 	"github.com/seanpham99/dbtools/internal/engine"
 	"github.com/seanpham99/dbtools/internal/generate"
 )
@@ -24,8 +25,12 @@ func (Postgres) Name() string { return "postgres" }
 
 // Open opens a raw database/sql connection via lib/pq, which accepts
 // postgres:// URLs natively — no scheme rewriting needed.
+//
+// golang-migrate's x- parameters are stripped first: lib/pq validates
+// unknown query parameters as server settings and fails the connection
+// with `unrecognized configuration parameter "x-migrations-table"`.
 func (Postgres) Open(rawURL string) (*sql.DB, error) {
-	return sql.Open("postgres", rawURL)
+	return sql.Open("postgres", dburl.StripCustomParams(rawURL))
 }
 
 func (Postgres) DDL() engine.DDLDialect { return ddl{} }

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -119,9 +120,38 @@ func (mg *Migrator) Version() (version uint64, dirty bool, hasVersion bool, err 
 		return 0, false, false, nil
 	}
 	if err != nil {
-		return 0, false, false, fmt.Errorf("reading version: %w", err)
+		return 0, false, false, fmt.Errorf("reading version: %w", explainCursorCollision(err))
 	}
 	return uint64(v), d, true, nil
+}
+
+// explainCursorCollision turns the raw driver error produced by a version
+// cursor that collides with somebody else's table into an actionable one.
+//
+// golang-migrate keeps its cursor in a (version, dirty) table it calls
+// schema_migrations by default. That is also what golang-migrate itself,
+// Rails, Supabase and many hand-rolled runners name their *ledger*, and
+// those tables are shaped differently — commonly a text version column and
+// no dirty column at all. Pointed at one of those, every command that reads
+// the version fails with `column "dirty" does not exist`, which says
+// nothing about the actual problem or the fix.
+func explainCursorCollision(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"dirty"`) || !strings.Contains(msg, "does not exist") {
+		return err
+	}
+	return fmt.Errorf("%w\n\n"+
+		"This looks like a version-cursor table collision: the table dbtools uses for its\n"+
+		"version cursor already exists and belongs to another migration tool (it has no\n"+
+		"\"dirty\" column, so it is not golang-migrate's).\n\n"+
+		"Point the cursor at a table of its own in dbtools.toml:\n\n"+
+		"    [ledger]\n"+
+		"    cursor_table = \"dbtools_schema_version\"\n\n"+
+		"then re-run. To import the other tool's history afterwards: dbtools adopt <target>.",
+		err)
 }
 
 // Stamp marks version as the current applied migration WITHOUT executing

--- a/internal/migrator/pgreset.go
+++ b/internal/migrator/pgreset.go
@@ -33,7 +33,15 @@ func openPostgresResetDriver(rawURL string) (database.Driver, error) {
 		logger.Infof("postgres: %s: %s", n.Severity, n.Message)
 	})
 	db := sql.OpenDB(nhConnector)
-	inner, err := postgres.WithInstance(db, &postgres.Config{})
+	// WithInstance takes an explicit Config rather than the URL, so
+	// golang-migrate's own x-migrations-table handling never runs on this
+	// path. Carry the parameter across by hand, or a configured cursor
+	// table would be silently ignored for Postgres alone — the one engine
+	// where it is most likely to be needed. An empty value leaves
+	// golang-migrate's default in place.
+	inner, err := postgres.WithInstance(db, &postgres.Config{
+		MigrationsTable: purl.Query().Get("x-migrations-table"),
+	})
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("opening postgres driver: %w", err)

--- a/internal/scratchdb/scratchdb.go
+++ b/internal/scratchdb/scratchdb.go
@@ -15,6 +15,19 @@ import (
 // SQLite gets a tempfile (no server needed); every other engine gets an
 // ephemeral, --rm Docker container via container.StartScratch.
 func Provision(eng engine.Engine, against string) (url string, cleanup func() error, err error) {
+	return ProvisionMajor(eng, against, "")
+}
+
+// ProvisionMajor is Provision pinned to a server major version, so the
+// scratch database can be made to match the target it will be compared
+// against. An empty major means "use the engine's default image", making it
+// identical to Provision.
+//
+// Callers that compare schemas (diff, squash) should pass the target's major
+// from ServerMajor: catalog rendering is not stable across majors, and a
+// mismatched scratch database reports that difference as drift that does not
+// exist. See container.ScratchImageFor.
+func ProvisionMajor(eng engine.Engine, against, major string) (url string, cleanup func() error, err error) {
 	if against != "" {
 		return against, nil, nil
 	}
@@ -28,7 +41,7 @@ func Provision(eng engine.Engine, against string) (url string, cleanup func() er
 		os.Remove(path) // sqlite creates it fresh on first open
 		return "sqlite://" + path, func() error { return os.Remove(path) }, nil
 	}
-	url, c, err := container.StartScratch(eng.Name())
+	url, c, err := container.StartScratchMajor(eng.Name(), major)
 	if err != nil {
 		return "", nil, fmt.Errorf("provisioning scratch database: %w", err)
 	}

--- a/internal/scratchdb/version.go
+++ b/internal/scratchdb/version.go
@@ -1,0 +1,60 @@
+package scratchdb
+
+import (
+	"database/sql"
+	"strings"
+)
+
+// ServerMajor returns the major version of the server behind db, as a bare
+// string ("16", "17"), or "" when it cannot be determined.
+//
+// Callers use it to pin a scratch database to the same major version as the
+// target it will be compared against. It is deliberately best-effort: an
+// unknown version falls back to the default image, which is no worse than
+// the behaviour before it existed. It never returns an error, because
+// failing a read-only diff over a version probe would be a worse outcome
+// than comparing against a default-major scratch database.
+func ServerMajor(db *sql.DB, engineName string) string {
+	switch engineName {
+	case "postgres":
+		// server_version_num is an integer like 160014 (16.14) or 90624
+		// (9.6.24). Dividing by 10000 gives the major for 10+, which is
+		// every version dbtools supports; 9.x would give "9", which is
+		// not a usable image tag on its own and is filtered out by the
+		// caller's plausibility check anyway.
+		var num int
+		if err := db.QueryRow("SHOW server_version_num").Scan(&num); err != nil || num <= 0 {
+			return ""
+		}
+		return itoa(num / 10000)
+	case "mysql":
+		// VERSION() is like "8.0.36" or "8.4.2"; the image tag that
+		// matters is the leading major.
+		var v string
+		if err := db.QueryRow("SELECT VERSION()").Scan(&v); err != nil {
+			return ""
+		}
+		if i := strings.IndexByte(v, '.'); i > 0 {
+			return v[:i]
+		}
+		return ""
+	default:
+		// mssql and sqlite: no major-version-shaped image tag to pin to.
+		return ""
+	}
+}
+
+// itoa avoids pulling strconv in for one small positive integer.
+func itoa(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	var b [4]byte
+	i := len(b)
+	for n > 0 && i > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/squash/plan.go
+++ b/internal/squash/plan.go
@@ -32,7 +32,14 @@ type Plan struct {
 // structure via a second scratch database and diff.Compare, and returns
 // the result. Never writes to migrationsDir or to any named target —
 // every database it touches is scratch/throwaway.
-func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix string, uptoVersion uint64) (plan *Plan, err error) {
+//
+// targetMajor pins both scratch databases to the target's server major
+// version; pass "" to accept the engine's default image. It matters twice
+// over: the dump tool's output has to be accepted by the target that will
+// eventually replay the committed baseline, and the verification comparison
+// has to be free of the cross-version rendering differences described in
+// container.ScratchImageFor.
+func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix string, uptoVersion uint64, targetMajor string) (plan *Plan, err error) {
 	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
@@ -47,7 +54,7 @@ func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix st
 		return nil, fmt.Errorf("no migration versions at or below %d found in %s", uptoVersion, migrationsDir)
 	}
 
-	url1, cleanup1, err := scratchdb.Provision(eng, "")
+	url1, cleanup1, err := scratchdb.ProvisionMajor(eng, "", targetMajor)
 	if err != nil {
 		return nil, fmt.Errorf("provisioning replay scratch database: %w", err)
 	}
@@ -101,7 +108,7 @@ func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix st
 		return nil, fmt.Errorf("dumping scratch database schema: %w", err)
 	}
 
-	url2, cleanup2, err := scratchdb.Provision(eng, "")
+	url2, cleanup2, err := scratchdb.ProvisionMajor(eng, "", targetMajor)
 	if err != nil {
 		return nil, fmt.Errorf("provisioning verification scratch database: %w", err)
 	}

--- a/internal/squash/plan_test.go
+++ b/internal/squash/plan_test.go
@@ -37,7 +37,7 @@ func TestBuildPlan_CleanHistoryVerifies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 2)
+	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 2, "")
 	if err != nil {
 		t.Fatalf("BuildPlan() returned error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestBuildPlan_PartialUptoReplaysOnlyCollapsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 1)
+	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 1, "")
 	if err != nil {
 		t.Fatalf("BuildPlan() returned error: %v", err)
 	}


### PR DESCRIPTION
Fixes the four issues found re-spiking v0.6.0 against a live Postgres monorepo, plus one adjacent bug the squash fix uncovered.

Closes #78, closes #79, closes #80, closes #81.

## Why these four together

They are one story: v0.6.0 shipped `adopt`, `up_suffix` and ledger-free mode so dbtools could be pointed at a database an incumbent tool already migrated. The design works — but three defects meant it did not survive contact with a real one. Each fix below is what stood between that story and actually working.

Verified end to end against the original reproduction throughout: a throwaway Postgres migrated by the incumbent's own runner, real `schema_migrations (version text, applied_at timestamptz)`, 9 migrations, 48 tables, `pg_dump` baseline at version `0`.

## #79 — version cursor collided with the ledger it was meant to adopt

golang-migrate's cursor table defaulted to `schema_migrations`, which is also what golang-migrate, Rails, Supabase and many hand-rolled runners call their *ledger*. Those tables have a different shape — commonly a text version column and no `dirty` — so every version-reading command died on `pq: column "dirty" does not exist`. `internal/adopt/adopt.go` lists `schema_migrations` as its **first** source table, so the feature collided with itself.

- New `[ledger] cursor_table`, carried to golang-migrate as `x-migrations-table`. The Postgres path needed it wired by hand into `postgres.Config.MigrationsTable`, because `WithInstance` takes an explicit config and never parses the URL — a configured cursor would otherwise have been silently ignored on the one engine most likely to need it.
- **The default is unchanged.** I considered namespacing it as the issue suggested, but a database dbtools has already migrated keeps its cursor in `schema_migrations`; silently moving it would make dbtools believe nothing had been applied and try to replay the entire history against a live schema. Instead, setting `[ledger] table = "schema_migrations"` — the documented coexistence knob — now moves the *cursor* aside automatically, and an explicit collision between the two is rejected at config load.
- New `internal/dburl` strips golang-migrate's `x-` parameters before a URL reaches a driver. This is what made the documented `x-migrations-table` escape hatch unusable in the first place: lib/pq validates unknown query parameters as server settings and fails with `unrecognized configuration parameter "x-migrations-table"`. Without it, the config knob above would have been broken the same way.
- The raw driver error is wrapped with what actually happened and the exact fix.

```console
$ dbtools adopt local --yes
source table: schema_migrations
matched: [0 20260814150000 ... 20260824080000]
adopted 9 version(s) from schema_migrations

$ dbtools status local
local       up to date
```

Incumbent `schema_migrations` still has its original 9 rows and was never written to. **Zero migration files renamed** (`up_suffix = ".sql"`).

## #78 — diff reported 40 findings against a zero-drift database

**My original root-cause analysis in the issue was wrong** and is corrected [in a comment there](https://github.com/seanpham99/dbtools/issues/78). It is not string handling: both sides use the same `Introspect`. The scratch container was pinned to `postgres:17-alpine` regardless of the target's version, and the two majors render the same stored constraint differently:

```console
$ psql -d pg16 -tAc "select check_clause from information_schema.check_constraints ..."
((total_jobs >= 0))
$ psql -d pg17 -tAc "select check_clause from information_schema.check_constraints ..."
(total_jobs >= 0)
```

Identical `CHECK (total_jobs >= 0)`, one paren apart — hence exactly one layer, on 100% of CHECK constraints, reproducing even on a database dbtools built itself.

- Scratch databases are pinned to the target's server major (`SHOW server_version_num`), which removes the cause. Best-effort: an undetectable version falls back to the default image, and the major is validated before it is interpolated into a docker image reference.
- CHECK expressions compare modulo redundant outer parens and whitespace as a second line of defence — for point releases, `--against` databases the caller provisioned, and future rendering changes. Paren stripping is balance- and string-literal-aware, so `(a) AND (b)` and `(name ~ '(x)')` are not mangled.

```console
$ dbtools diff local          # zero-drift control, was 40 findings
local: no structural differences
$ echo $?
0
```

Still catches real drift — three deliberate out-of-migration changes, including a modified CHECK to prove normalisation causes no false negatives:

```console
CHANGED  check_constraint public.batches.batches_total_jobs_check expression "((total_jobs >= 0))" vs "((total_jobs >= 5))"
CHANGED  column           public.hotels.hotel_name        nullable false vs true
EXTRA    column           public.hotels.spike_hotfix_col  column exists in target but missing in migrations
```

Also retracted in that comment: my "diff ignores the configured `[ledger] table`" note was wrong — `config.go` already handles it, and the finding was an artefact of my own spike.

## #81 — squash produced a baseline it could not apply

`pg_dump` emits `\restrict` / `\unrestrict` on 16.10+, 17.6+ and 18. They are psql meta-commands and the wire protocol rejects them, so squash aborted — safely, before writing anything, which is the verification step doing its job.

Stripping is **dollar-quote aware**, so a backslash-led line inside a function body is left alone: dropping it would silently corrupt the routine rather than fail loudly. Tag-aware too, so a body opened by `$func$` is not closed by a bare `$$` inside it.

**A second dump-portability bug was hiding behind it.** With meta-commands stripped, squash got one step further and hit `pq: unrecognized configuration parameter "transaction_timeout"`. dbtools shells out to whatever `pg_dump` is on PATH — 18.6 on this machine, against a 16.14 server — and `transaction_timeout` is a Postgres 17 GUC. That is a normal setup, not a misconfiguration, and it would have resurfaced at `up` time from the committed baseline even if squash had let it through.

The four timeout GUCs are now stripped. Deliberately narrow: the other preamble SETs are kept, because some change restore behaviour — `check_function_bodies = false` in particular is what lets a function referencing a not-yet-created object be defined at all.

```console
$ dbtools squash local
baseline verified: collapsing versions [0 20260814150000 ... 20260824080000]
dry run — pass --yes to write the baseline and archive 9 file(s)
```

## #80 — doctor printed the usage block on its documented exit 2

Same `SilenceUsage`/`SilenceErrors` treatment `plan`, `verify` and `diff` already had, set only for the `ExitCodeError` path so a genuine invalid-flag error still shows usage. Exit code unchanged.

## Tests

Five new files, all covering the failure they were written for rather than the happy path:

- `internal/diff/expression_test.go` — cross-version rendering equivalence, real differences preserved, non-wrapping parens (`(a) AND (b)`), parens inside string literals.
- `internal/dump/psqlmeta_test.go` — `\restrict`/`\unrestrict` removal, dollar-quoted and `$func$`-tagged bodies surviving, timeout GUCs stripped while `check_function_bodies` is kept.
- `internal/config/cursor_test.go` — defaulting, auto-move, explicit override, collision rejection, and that a default cursor leaves the URL byte-identical.
- `internal/dburl/dburl_test.go` — stripping, round-trip, non-RFC3986 MySQL DSNs left unchanged.
- `internal/container/scratchimage_test.go` — image pinning, and rejection of anything that is not a plain 1–2 digit major.

`go build`, `go vet`, `gofmt` and `go test ./...` (28 packages) all clean.

## Deliberately not addressed

**`adopt` is still non-atomic.** The specific failure that exposed it is gone, but the ordering is unchanged — the ledger is written, then the cursor stamped, with no transaction spanning both — so a different mid-operation failure could still exit non-zero with the ledger already written. Whether adopt should be atomic or report partial success distinctly is a design decision, and bundling it into a bug-fix PR seemed wrong. Noted on #79.

**Worth considering as a follow-up:** dbtools already manages containers, so it could run `pg_dump` *inside* one matching the server major rather than trusting the host's client. That removes the whole dump-portability class rather than patching it version by version — see #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
