### PR TITLE
docs(adr): v0.7.0 design — native runner, version parity, owned toolchain

### DIFF
--- a/docs/adr/003-v0.7-native-runner.md
+++ b/docs/adr/003-v0.7-native-runner.md
@@ -1,0 +1,179 @@
+# v0.7.0 — native runner, version parity, owned toolchain
+
+**Status:** accepted, not yet implemented
+**Date:** 2026-08-27
+**Supersedes:** the compatibility approach taken in #82
+
+## Context
+
+Re-spiking v0.6.0 against a live Postgres monorepo produced five bugs
+(#78–#81, #84). Fixing them exposed that three were the same bug wearing
+different clothes: **dbtools' correctness depends on version and
+environment assumptions it neither owns nor verifies.**
+
+- #78 — the scratch database was pinned to `postgres:17-alpine` regardless
+  of the target's version, and Postgres 16 renders
+  `information_schema.check_clause` one parenthesis deeper than 17. Every
+  CHECK constraint in the schema reported as drift.
+- #81 — `pg_dump` on the host emitted `\restrict` (psql meta-command,
+  rejected by the wire protocol), and behind it a host `pg_dump` 18.6
+  dumping a 16.14 server emitted `SET transaction_timeout`, a GUC that
+  server does not have.
+- #84 — column defaults are still compared byte-exact, so the same
+  rendering-drift class is live for `column_default` on every engine, and
+  unmitigated for MSSQL, which cannot be version-pinned by tag shape.
+
+#82 fixed the symptoms and, in doing so, demonstrated the cost of the
+compatibility route: it added two config keys (`[ledger] table` and
+`[ledger] cursor_table`) where one concept should exist, precisely because
+the underlying design has **two ledgers** — golang-migrate's
+`(version, dirty)` cursor and dbtools' own `dbtools_migration_history`.
+That duality is the root of #79, not the table *name*.
+
+Investigation also found the split is already half-undone: `internal/migrator/dir.go`
+(305 LOC) fully owns migration file discovery, ordering, hashing and down-plans.
+golang-migrate's `source/file` exists only to feed its own executor — which is
+why `[migrations] up_suffix` is honoured by `plan`/`verify`/`doctor`/`adopt`
+and refused by `up`/`push`/`diff`/`squash`. Half the commands obey
+configuration the other half cannot see.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | One deliberate **v0.7.0** break, no compatibility shims | Pre-launch, effectively no install base. Shims are cheapest to refuse now and impossible to retract later |
+| 2 | **Drop golang-migrate entirely**; own the apply loop over the existing `dir.go` | Facade is already only 9 methods / 183 LOC. Collapses two ledgers to one, ends `x-migrations-table` plumbing, makes `up_suffix` work everywhere |
+| 3 | **One ledger table**, per-migration rows; current version *derived* as `max(version) where status='applied'` | One source of truth cannot disagree with itself. Makes `adopt` atomic for free |
+| 4 | Dirtiness = a surviving `status='applying'` row | Names *which* migration died; a boolean `dirty` cannot |
+| 5 | **Version parity, not canonicalisation**: both sides of a comparison always rendered by the same server major | Kills the cause. No SQL parser, no per-engine normalisers, no ongoing patches |
+| 6 | **Delete** the expression normaliser added in #82 | Once parity holds, byte-exact comparison is correct by construction |
+| 7 | Dump tools run **in a container matching the server major**; `--use-host-tools` is an explicit opt-in | Removes the host toolchain from a correctness-critical path |
+| 8 | Supported window: **Postgres 15–18, MySQL 8.0 + 8.4, MSSQL 2019 + 2022**. CI tests oldest + newest per engine | Everything with upstream support for this release's life. Rendering differences cluster at boundaries |
+| 9 | Outside the window: **warn and proceed**, never refuse | Refusing a read-only `doctor` against someone's old production box would be wrong |
+| 10 | Warnings surface **layered**: structured `notes` + stderr + a `doctor` check | A caveat that exists only on stderr is one CI throws away (cf. #55) |
+| 11 | **Reimplement locking** per engine, tests written first | The only part of this with no inherited safety net |
+| 12 | v0.6 state is migrated by **`adopt`**, not a new command | v0.6's own tables are just another foreign ledger. Reuses tested machinery, adds no surface |
+
+## Explicitly refused
+
+Recorded so they are not relitigated:
+
+- **SQL-parser canonicalisation (`pg_query_go`).** Trades dbtools' pure-Go
+  static binary — and with it the cross-compilation and minimal-image story
+  that #60 depends on — for expression-diff fidelity that version parity
+  already provides. Revisit only if real false positives survive parity.
+- **Partially shrinking golang-migrate** (own the cursor, keep the executor).
+  Owning the cursor means implementing `Version()`/`SetVersion()`, therefore
+  `database.Driver`, and the driver shim is exactly where the complexity
+  already lives. Pays most of the cost of dropping it for none of the
+  simplification.
+- **Keeping the normaliser as belt-and-braces alongside parity.** Once it
+  exists nobody deletes it, and every future rendering difference gets
+  "fixed" there instead of in the parity guarantee — which is how the
+  current situation accumulated.
+- **Automatic reconciliation of v0.6 state on first run.** A migration tool
+  that silently rewrites migration state, on whatever target the user
+  happened to run first, is asking for the trust it can least afford to lose.
+- **Shipping the native runner without locking.** dbtools has an explicit
+  private-network job-container story (#60) — precisely the deployment shape
+  where two job executions overlap.
+
+## Plan
+
+Four PRs. Ordered so each is independently valuable and independently
+revertible; only PR3 must land atomically.
+
+### PR1 — version parity
+
+Closes #84, completes #78.
+
+- Extend `container.ScratchImageFor` to MSSQL via a major→tag map
+  (15→`2019-latest`, 16→`2022-latest`, 17→`2025-latest`). MSSQL majors come
+  from `SERVERPROPERTY('ProductMajorVersion')`; add the case to
+  `scratchdb.ServerMajor`.
+- `diff --against` and `squash`: probe the supplied scratch database's
+  version and **refuse on major mismatch** rather than produce a wrong
+  answer.
+- Delete `equalExpressions` / `normalizeExpression` from `internal/diff/compare.go`;
+  `Compare` returns to exact equality for every field.
+- Change `internal/container/container.go`'s MSSQL default from
+  `2025-latest` to `2022-latest`, matching CI and the supported window.
+
+**Verify:** the #78 control case (zero-drift database) returns zero findings
+on PG 15, 16, 17, 18 and on MSSQL 2019 + 2022; a deliberately mismatched
+`--against` is refused with a message naming both versions.
+
+### PR2 — owned dump toolchain
+
+Completes #81.
+
+- Run `pg_dump` / `mysqldump` inside a container matching the server major
+  rather than resolving them from `$PATH`.
+- `--use-host-tools` opts back into the host binary for `--against` users
+  and Docker-less environments.
+- Keep `StripPsqlMetaCommands`: `\restrict` is emitted even by a
+  version-matched `pg_dump`, and psql meta-commands are never valid over the
+  wire protocol — this is not a version workaround. The timeout-GUC strip
+  stays too, but becomes relevant only on the `--use-host-tools` path; note
+  that in its comment so it is not mistaken for load-bearing.
+
+**Verify:** `squash` succeeds with no `pg_dump` on `$PATH`; and with a
+deliberately mismatched host `pg_dump`, which is the #81 reproduction.
+
+### PR3 — native runner
+
+Closes #79 properly. Must land atomically.
+
+Order matters — locking is the only part with no existing safety net, so its
+tests come first:
+
+1. Concurrency tests for `Lock`/`Unlock` per engine (currently **zero**
+   coverage; today it is pure delegation).
+2. Lock implementations: `pg_advisory_lock`, MySQL `GET_LOCK`,
+   `sp_getapplock`, SQLite no-op — including release-on-panic and
+   release-on-close paths.
+3. Unified ledger: `(version, name, hash, status, applied_at)`, with
+   `status ∈ {applied, applying, reverted}`. Version derived, never stored
+   separately.
+4. Runner: `Up`/`Step`/`StepDown`/`Down`/`Force` over `dir.go`, preserving
+   the existing `Migrator` API so all ~14 call sites are untouched.
+5. Delete `pgdriver.go`, `mysqldriver.go`, `sqlitedriver.go`, the
+   `database.Driver` shims, the `[ledger] cursor_table` key and the
+   `internal/dburl` `x-` plumbing — all introduced by #82 to work around
+   what this PR removes.
+6. Add v0.6's `dbtools_migration_history` and golang-migrate's
+   `schema_migrations` to `adopt.KnownSourceTables`.
+7. Remove the `up_suffix` refusal from `up`/`push`; `diff` and `squash`
+   inherit the fix.
+
+**Verify:** the #79 reproduction — an incumbent-managed database with a real
+`schema_migrations` ledger, adopted with **zero file renames**; plus a
+concurrent-apply test proving the second runner blocks.
+
+### PR4 — window, matrix, warnings
+
+- CI matrix becomes engine × {oldest, newest}: PG 15 + 18, MySQL 8.0 + 8.4,
+  MSSQL 2019 + 2022, SQLite.
+- The Postgres leg currently runs only `./internal/engine/postgresengine/...`
+  and `./internal/verify/...`; only the MSSQL leg sweeps `go list ./...`.
+  Give every engine the full sweep, or #78's class can recur untested.
+- `doctor` gains a `server-version` check; out-of-window warnings also enter
+  `notes` in structured output.
+
+## Risks
+
+- **Locking is the sharp edge.** It fails rarely and silently, and corrupts
+  schemas when it does. Tests before implementation, and a concurrency test
+  in CI rather than a unit test with a fake.
+- **Point-release rendering differences** survive major-version parity. Known
+  and accepted. The escalation, if it ever bites, is round-trip
+  canonicalisation — re-render both sides through one server — which is exact
+  and still needs no parser. Do not pre-build it.
+- **MSSQL major→tag mapping** must be verified against real images at
+  implementation time rather than trusted from documentation.
+- **`internal/engine/postgresengine/introspect.go:231`** filters NOT NULL
+  constraints with a predicate on *rendered text*
+  (`check_clause NOT LIKE '%IS NOT NULL'`). If a major changes that spelling,
+  every NOT NULL column surfaces as a phantom CHECK. Same assumption as #78,
+  in a place where it changes *what* is compared rather than *how*. Not in
+  scope for these four PRs; worth its own issue.


### PR DESCRIPTION
Records the design settled after reviewing the five bugs found re-spiking v0.4.0→v0.6.0 (#78, #79, #80, #81, #84).

## The through-line

Three of the five bugs were the same bug: **dbtools' correctness depends on version and environment assumptions it neither owns nor verifies.** A scratch database pinned to the wrong major (#78), a host `pg_dump` newer than the server it dumps (#81), and byte-exact comparison of server-rendered text (#84) are one problem seen from three angles.

#82 fixed the symptoms. It also added two config keys where one concept should exist — `[ledger] table` and `[ledger] cursor_table` — because the underlying design has two ledgers. That is the argument for fixing the cause instead, and this ADR is that decision.

## Headlines

- **Drop golang-migrate.** The facade is already 9 methods / 183 LOC, and `dir.go` (305 LOC) already owns file discovery entirely — golang-migrate's source exists only to feed its own executor, which is exactly why `up_suffix` is honoured by half the commands and refused by the other half.
- **One ledger**, per-migration rows, version derived. Makes `adopt` atomic for free.
- **Version parity instead of canonicalisation.** Guarantee both sides are rendered by the same server major, then *delete* the normaliser #82 added. No SQL parser, no per-engine normalisers, no ongoing patches.
- **Own the dump toolchain** — run it in a version-matched container, host binary by opt-in only.
- **Locking is reimplemented with tests first** — it is the only part of this work with no inherited safety net.
- **v0.6 state migrates via `adopt`**, not a new command: v0.6's own tables are just another foreign ledger.

The ADR also records what was **explicitly refused** and why — SQL-parser canonicalisation, partially shrinking golang-migrate, keeping the normaliser alongside parity, automatic state reconciliation, and shipping the runner without locking — so those are not relitigated later.

Plan is four PRs, ordered so each is independently revertible; only the runner PR must land atomically.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architectural decision record outlining the planned native migration runner for version 0.7.0.
  * Documented migration tracking, database locking, engine-version compatibility, and server-version checks.
  * Covered containerized database tooling, diagnostics, CI expansion, migration ledger adoption, and implementation risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->