### PR TITLE
feat(squash): run the dump tool inside the server's own container

### DIFF
--- a/cmd/squash.go
+++ b/cmd/squash.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	squashUpto   uint64
-	squashOut    string
-	squashYes    bool
-	squashDryRun bool
+	squashUseHostTools bool
+	squashUpto         uint64
+	squashOut          string
+	squashYes          bool
+	squashDryRun       bool
 )
 
 var squashCmd = &cobra.Command{
@@ -30,6 +31,8 @@ var squashCmd = &cobra.Command{
 }
 
 func init() {
+	squashCmd.Flags().BoolVar(&squashUseHostTools, "use-host-tools", false,
+		"run the dump tool from PATH instead of inside the scratch container (no Docker, or you know your client and server versions agree)")
 	squashCmd.Flags().Uint64Var(&squashUpto, "upto", 0, "highest version to collapse (default: highest version on disk)")
 	squashCmd.Flags().StringVar(&squashOut, "out", "", "baseline filename override (default: 0000000000000_squashed_baseline.up.sql)")
 	squashCmd.Flags().BoolVar(&squashYes, "yes", false, "write the baseline, archive collapsed files, and re-stamp the target (omit to only print the plan)")
@@ -74,7 +77,7 @@ func runSquash(targetName string) error {
 		targetDB.Close()
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, migrationsDir, upSuffix, upto, targetSeries)
+	plan, err := squash.BuildPlan(cfg, eng, migrationsDir, upSuffix, upto, targetSeries, squashUseHostTools)
 	if err != nil {
 		return err
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -456,7 +456,8 @@ func waitReadyWithTimeout(s spec, timeout time.Duration) error {
 // StartScratch starts a throwaway, --rm container for engineName and waits
 // up to 60s for readiness.
 func StartScratch(engineName string) (rawURL string, cleanup func() error, err error) {
-	return StartScratchWithTimeout(engineName, 60*time.Second)
+	rawURL, _, cleanup, err = startScratch(engineName, "", 60*time.Second)
+	return rawURL, cleanup, err
 }
 
 // StartScratchSeries is StartScratch pinned to a server version series, so a
@@ -464,7 +465,7 @@ func StartScratch(engineName string) (rawURL string, cleanup func() error, err e
 // against. An empty or unrecognised series falls back to the engine's default
 // image. See ScratchImageFor for why the match matters, and
 // scratchdb.ServerSeries for what a series is per engine.
-func StartScratchSeries(engineName, series string) (rawURL string, cleanup func() error, err error) {
+func StartScratchSeries(engineName, series string) (rawURL, containerName string, cleanup func() error, err error) {
 	return startScratch(engineName, series, 60*time.Second)
 }
 
@@ -475,7 +476,8 @@ func StartScratchSeries(engineName, series string) (rawURL string, cleanup func(
 // container, since a scratch database must start empty. Returns an error
 // for engines with no scratchRunArgs (sqlite — callers use a tempfile).
 func StartScratchWithTimeout(engineName string, timeout time.Duration) (rawURL string, cleanup func() error, err error) {
-	return startScratch(engineName, "", timeout)
+	rawURL, _, cleanup, err = startScratch(engineName, "", timeout)
+	return rawURL, cleanup, err
 }
 
 // mssqlYearTag maps a SQL Server ProductMajorVersion to its image tag.
@@ -563,16 +565,16 @@ func plausibleSeries(v string) bool {
 	return true
 }
 
-func startScratch(engineName, series string, timeout time.Duration) (rawURL string, cleanup func() error, err error) {
+func startScratch(engineName, series string, timeout time.Duration) (rawURL, containerName string, cleanup func() error, err error) {
 	s, err := specFor(engineName)
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	if s.scratchRunArgs == nil {
-		return "", nil, fmt.Errorf("no scratch container template for engine %q", engineName)
+		return "", "", nil, fmt.Errorf("no scratch container template for engine %q", engineName)
 	}
 	if err := checkDocker(); err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	if img := ScratchImageFor(engineName, series); img != "" {
 		s.image = img
@@ -581,7 +583,7 @@ func startScratch(engineName, series string, timeout time.Duration) (rawURL stri
 	s.hostPort = "0"
 
 	if out, err := exec.Command("docker", s.scratchRunArgs(s)...).CombinedOutput(); err != nil {
-		return "", nil, fmt.Errorf("docker run failed: %w: %s", err, strings.TrimSpace(string(out)))
+		return "", "", nil, fmt.Errorf("docker run failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	cleanup = func() error {
 		out, err := exec.Command("docker", "stop", s.name).CombinedOutput()
@@ -604,19 +606,19 @@ func startScratch(engineName, series string, timeout time.Duration) (rawURL stri
 
 	port, err := discoverHostPort(s.name, s.containerPort)
 	if err != nil {
-		return "", nil, abortWith(err)
+		return "", "", nil, abortWith(err)
 	}
 	s.hostPort = port
 
 	if err := waitReadyWithTimeout(s, timeout); err != nil {
-		return "", nil, abortWith(err)
+		return "", "", nil, abortWith(err)
 	}
 	if s.createDBArgs != nil {
 		if out, err := exec.Command("docker", s.createDBArgs(s)...).CombinedOutput(); err != nil {
-			return "", nil, abortWith(fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out))))
+			return "", "", nil, abortWith(fmt.Errorf("creating %s: %w: %s", DatabaseName, err, strings.TrimSpace(string(out))))
 		}
 	}
-	return s.url(s, DatabaseName), cleanup, nil
+	return s.url(s, DatabaseName), s.name, cleanup, nil
 }
 
 // StopFor stops and removes engineName's tool-owned local container

--- a/internal/container/exec.go
+++ b/internal/container/exec.go
@@ -1,0 +1,64 @@
+package container
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// InContainerURL returns the connection URL for DatabaseName as seen from
+// *inside* the container itself, where the engine listens on its fixed port
+// and the host port mapping is irrelevant.
+//
+// It exists so a dump tool can run inside the container that hosts the
+// database it is dumping. That guarantees the tool's version matches the
+// server's — a client newer than the server emits statements the server
+// cannot execute (`SET transaction_timeout` from pg_dump 17+ against a 16
+// server), and the resulting baseline is committed, so the mismatch would
+// resurface at apply time long after the dump.
+func InContainerURL(engineName string) (string, error) {
+	s, err := specFor(engineName)
+	if err != nil {
+		return "", err
+	}
+	// Reuse the engine's own URL template with the in-container port, so
+	// there is one place that knows each engine's URL shape.
+	s.hostPort = s.containerPort
+	return s.url(s, DatabaseName), nil
+}
+
+// SupportsInContainerDump reports whether engineName's image ships the dump
+// tool dbtools needs.
+//
+// Postgres and MySQL images carry pg_dump and mysqldump. SQL Server's does
+// not ship mssql-scripter — it is a separate Python package — so MSSQL dumps
+// still run on the host, and version skew there remains the operator's to
+// manage.
+func SupportsInContainerDump(engineName string) bool {
+	switch engineName {
+	case "postgres", "mysql":
+		return true
+	default:
+		return false
+	}
+}
+
+// Exec runs argv inside containerName via `docker exec` and returns its
+// combined output. Used to run an engine's own dump tool at the engine's own
+// version.
+func Exec(containerName string, argv ...string) ([]byte, error) {
+	if containerName == "" {
+		return nil, fmt.Errorf("no container to exec in")
+	}
+	args := append([]string{"exec", containerName}, argv...)
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		tool := ""
+		if len(argv) > 0 {
+			tool = argv[0] + " "
+		}
+		return nil, fmt.Errorf("%sin container %s failed: %w: %s",
+			tool, containerName, err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -51,11 +51,12 @@ func Run(cfg *config.Config, targetName, againstURL string) (findings []Finding,
 				"so version-specific rendering differences may appear as findings", eng.Name()))
 	}
 
-	scratchURL, cleanup, err := scratchdb.ProvisionSeries(eng, againstURL, targetSeries)
+	scratch, err := scratchdb.ProvisionSeries(eng, againstURL, targetSeries)
 	if err != nil {
 		return nil, nil, err
 	}
-	if cleanup != nil {
+	scratchURL := scratch.URL
+	if cleanup := scratch.Cleanup; cleanup != nil {
 		defer func() {
 			cerr := cleanup()
 			if cerr == nil {

--- a/internal/dump/dump.go
+++ b/internal/dump/dump.go
@@ -10,21 +10,42 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/seanpham99/dbtools/internal/container"
 	"github.com/seanpham99/dbtools/internal/engine"
 )
 
-// Schema returns the DDL that reproduces eng's schema at scratchURL, via
-// the engine's native dump tool (pg_dump/mysqldump/mssql-scripter on the
-// host, connecting to scratchURL's published port) or, for SQLite, a
-// direct catalog query — no external tool needed. Any tables in excludeTables
-// (e.g. migration tracking tables) are omitted from the dump.
-func Schema(eng engine.Engine, scratchURL string, excludeTables ...string) (string, error) {
+// Options controls where Schema runs the engine's dump tool.
+type Options struct {
+	// ExecIn names a Docker container hosting the database being dumped.
+	// When set, and the engine's image ships the tool, the dump runs inside
+	// that container so the tool's version always matches the server's.
+	// Empty means "run the tool on the host".
+	ExecIn string
+	// UseHostTools forces the host binary even when ExecIn is available —
+	// the escape hatch for environments without Docker, or operators who
+	// know their client and server versions agree.
+	UseHostTools bool
+}
+
+// Schema returns the DDL that reproduces eng's schema at scratchURL, via the
+// engine's native dump tool (pg_dump/mysqldump/mssql-scripter) or, for
+// SQLite, a direct catalog query — no external tool needed. Any tables in
+// excludeTables (e.g. migration tracking tables) are omitted.
+//
+// The tool runs inside opts.ExecIn when it can (see Options), because a dump
+// tool newer than the server it dumps emits statements that server cannot
+// execute — pg_dump 17+ writes `SET transaction_timeout`, which Postgres 16
+// rejects. The output is committed as a baseline, so a mismatch does not stay
+// contained: it resurfaces whenever that baseline is applied.
+func Schema(eng engine.Engine, scratchURL string, opts Options, excludeTables ...string) (string, error) {
 	switch eng.Name() {
 	case "postgres":
-		return dumpPostgres(scratchURL, excludeTables)
+		return dumpPostgres(scratchURL, opts, excludeTables)
 	case "mysql":
-		return dumpMySQL(scratchURL, excludeTables)
+		return dumpMySQL(scratchURL, opts, excludeTables)
 	case "mssql":
+		// mssql-scripter is a separate Python package, not part of the
+		// SQL Server image, so this one always runs on the host.
 		return dumpMSSQL(scratchURL, excludeTables)
 	case "sqlite":
 		db, err := eng.Open(scratchURL)
@@ -38,35 +59,74 @@ func Schema(eng engine.Engine, scratchURL string, excludeTables ...string) (stri
 	}
 }
 
-func dumpPostgres(scratchURL string, excludeTables []string) (string, error) {
+func dumpPostgres(scratchURL string, opts Options, excludeTables []string) (string, error) {
 	const toolName = "pg_dump"
-	if _, err := exec.LookPath(toolName); err != nil {
-		return "", fmt.Errorf("%s not found on PATH — install postgresql-client to use squash with postgres: %w", toolName, err)
-	}
 	args := []string{"--no-owner", "--schema-only"}
 	for _, tbl := range excludeTables {
 		if tbl != "" {
 			args = append(args, "-T", tbl, "-T", "*."+tbl)
 		}
 	}
-	args = append(args, scratchURL)
+	connURL, inContainer, err := dumpTarget("postgres", scratchURL, opts)
+	if err != nil {
+		return "", err
+	}
+	out, err := runDumpTool(toolName, append(args, connURL), opts, inContainer,
+		"install postgresql-client to use squash with postgres")
+	if err != nil {
+		return "", err
+	}
+	return StripPostgresSessionState(out), nil
+}
+
+// dumpTarget decides where the dump tool will run and which connection URL
+// it should use. Inside the container the engine listens on its own fixed
+// port, so the host port mapping does not apply.
+func dumpTarget(engineName, hostURL string, opts Options) (connURL string, inContainer bool, err error) {
+	if opts.ExecIn == "" || opts.UseHostTools || !container.SupportsInContainerDump(engineName) {
+		return hostURL, false, nil
+	}
+	inURL, err := container.InContainerURL(engineName)
+	if err != nil {
+		return "", false, err
+	}
+	return inURL, true, nil
+}
+
+// runDumpTool executes toolName with args, either inside opts.ExecIn or on
+// the host. args must already carry the connection details — the engines
+// differ on whether that is a trailing URL or a set of flags. hostHint tells
+// the user how to install the tool when the host path is taken and it is
+// missing.
+func runDumpTool(toolName string, args []string, opts Options, inContainer bool, hostHint string) (string, error) {
+	if inContainer {
+		out, err := container.Exec(opts.ExecIn, append([]string{toolName}, args...)...)
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	}
+	if _, err := exec.LookPath(toolName); err != nil {
+		return "", fmt.Errorf("%s not found on PATH — %s: %w", toolName, hostHint, err)
+	}
 	out, err := exec.Command(toolName, args...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s failed: %w: %s", toolName, err, strings.TrimSpace(string(out)))
 	}
-	return StripPostgresSessionState(string(out)), nil
+	return string(out), nil
 }
 
-func dumpMySQL(scratchURL string, excludeTables []string) (string, error) {
+func dumpMySQL(scratchURL string, opts Options, excludeTables []string) (string, error) {
 	const toolName = "mysqldump"
-	if _, err := exec.LookPath(toolName); err != nil {
-		return "", fmt.Errorf("%s not found on PATH — install mysql-client or mariadb-client to use squash with mysql: %w", toolName, err)
+	connURL, inContainer, err := dumpTarget("mysql", scratchURL, opts)
+	if err != nil {
+		return "", err
 	}
 
 	args := []string{"--no-tablespaces", "--skip-comments", "--no-data"}
-	raw := strings.TrimPrefix(scratchURL, "mysql://")
-	cfg, err := mysql.ParseDSN(raw)
-	if err == nil && cfg != nil {
+	raw := strings.TrimPrefix(connURL, "mysql://")
+	cfg, parseErr := mysql.ParseDSN(raw)
+	if parseErr == nil && cfg != nil {
 		if cfg.Addr != "" {
 			host, port, splitErr := net.SplitHostPort(cfg.Addr)
 			if splitErr == nil {
@@ -94,14 +154,11 @@ func dumpMySQL(scratchURL string, excludeTables []string) (string, error) {
 			args = append(args, cfg.DBName)
 		}
 	} else {
-		args = append(args, scratchURL)
+		args = append(args, connURL)
 	}
 
-	out, err := exec.Command(toolName, args...).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("%s failed: %w: %s", toolName, err, strings.TrimSpace(string(out)))
-	}
-	return string(out), nil
+	return runDumpTool(toolName, args, opts, inContainer,
+		"install mysql-client or mariadb-client to use squash with mysql")
 }
 
 func dumpMSSQL(scratchURL string, excludeTables []string) (string, error) {
@@ -168,10 +225,13 @@ var (
 	// session and say nothing about the schema, but they are not all
 	// present in every server version — transaction_timeout arrived in
 	// Postgres 17, so a dump taken with pg_dump 17+ fails to apply to a
-	// 16 server with `unrecognized configuration parameter`. pg_dump is
-	// explicitly supported dumping older servers, so this mismatch is a
-	// normal setup (a newer client package on the developer's machine),
-	// not a misconfiguration.
+	// 16 server with `unrecognized configuration parameter`.
+	//
+	// Running the dump tool inside the server's own container removes the
+	// mismatch at the source, so this is now only reachable on the
+	// --use-host-tools path, where the operator has taken responsibility
+	// for matching versions. Kept because that path still exists and
+	// because stripping restore-tuning settings costs nothing.
 	//
 	// Deliberately narrow: the other preamble SETs are kept, because some
 	// change behaviour that matters to a restore. check_function_bodies =

--- a/internal/dump/dump_test.go
+++ b/internal/dump/dump_test.go
@@ -29,7 +29,7 @@ func TestSchema_MissingToolGivesInstallHint(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = dump.Schema(eng, tt.engine+"://ignored")
+			_, err = dump.Schema(eng, tt.engine+"://ignored", dump.Options{})
 			if err == nil || !strings.Contains(err.Error(), tt.toolName) {
 				t.Fatalf("Schema() with no %s on PATH = %v, want an error naming %s", tt.toolName, err, tt.toolName)
 			}
@@ -72,7 +72,7 @@ func TestSchema_SQLiteNeedsNoExternalTool(t *testing.T) {
 	}
 
 	// Also test dump.Schema on sqlite
-	sqlTextFromSchema, err := dump.Schema(eng, "sqlite://"+dbPath)
+	sqlTextFromSchema, err := dump.Schema(eng, "sqlite://"+dbPath, dump.Options{})
 	if err != nil {
 		t.Fatalf("Schema() returned error: %v", err)
 	}
@@ -100,7 +100,7 @@ CREATE TABLE dbtools_migration_history (version bigint);
 		t.Fatal(err)
 	}
 
-	sqlText, err := dump.Schema(eng, "sqlite://"+dbPath, "schema_migrations", "dbtools_migration_history")
+	sqlText, err := dump.Schema(eng, "sqlite://"+dbPath, dump.Options{}, "schema_migrations", "dbtools_migration_history")
 	if err != nil {
 		t.Fatalf("Schema() returned error: %v", err)
 	}

--- a/internal/dump/target_test.go
+++ b/internal/dump/target_test.go
@@ -1,0 +1,64 @@
+package dump
+
+import (
+	"strings"
+	"testing"
+)
+
+// The dump tool runs inside the server's own container so its version always
+// matches the server's. Everything that opts out of that has to be
+// deliberate: no container, an explicit --use-host-tools, or an engine whose
+// image does not ship the tool.
+func TestDumpTarget(t *testing.T) {
+	const hostURL = "postgres://u:p@127.0.0.1:54321/db?sslmode=disable"
+
+	cases := []struct {
+		name            string
+		engine          string
+		opts            Options
+		wantInContainer bool
+	}{
+		{"container available", "postgres", Options{ExecIn: "scratch-1"}, true},
+		{"mysql image ships mysqldump", "mysql", Options{ExecIn: "scratch-1"}, true},
+		{"no container", "postgres", Options{}, false},
+		{"host tools forced", "postgres", Options{ExecIn: "scratch-1", UseHostTools: true}, false},
+		// mssql-scripter is a separate Python package, not in the image.
+		{"mssql has no in-image tool", "mssql", Options{ExecIn: "scratch-1"}, false},
+	}
+
+	for _, c := range cases {
+		connURL, inContainer, err := dumpTarget(c.engine, hostURL, c.opts)
+		if err != nil {
+			t.Errorf("%s: dumpTarget returned error: %v", c.name, err)
+			continue
+		}
+		if inContainer != c.wantInContainer {
+			t.Errorf("%s: inContainer = %v, want %v", c.name, inContainer, c.wantInContainer)
+		}
+		if !inContainer && connURL != hostURL {
+			t.Errorf("%s: host path should use the host URL, got %q", c.name, connURL)
+		}
+		if inContainer && connURL == hostURL {
+			t.Errorf("%s: container path must not use the host URL — the published port "+
+				"does not exist inside the container", c.name)
+		}
+	}
+}
+
+// Inside the container the engine listens on its own fixed port, so the
+// in-container URL must not carry the host's published port.
+func TestDumpTarget_InContainerURLUsesTheEnginePort(t *testing.T) {
+	connURL, inContainer, err := dumpTarget("postgres", "postgres://u:p@127.0.0.1:54321/db", Options{ExecIn: "c"})
+	if err != nil {
+		t.Fatalf("dumpTarget: %v", err)
+	}
+	if !inContainer {
+		t.Fatal("expected the container path")
+	}
+	if !strings.Contains(connURL, ":5432/") {
+		t.Errorf("in-container URL %q should use postgres's fixed port 5432", connURL)
+	}
+	if strings.Contains(connURL, "54321") {
+		t.Errorf("in-container URL %q still carries the host's published port", connURL)
+	}
+}

--- a/internal/scratchdb/scratchdb.go
+++ b/internal/scratchdb/scratchdb.go
@@ -8,13 +8,25 @@ import (
 	"github.com/seanpham99/dbtools/internal/engine"
 )
 
-// Provision returns a connection URL to a throwaway database for eng,
-// plus a cleanup function to tear it down. If against is non-empty, it's
-// returned unchanged with a nil cleanup — the caller supplied their own
-// pre-provisioned scratch database and owns its lifecycle. Otherwise:
-// SQLite gets a tempfile (no server needed); every other engine gets an
-// ephemeral, --rm Docker container via container.StartScratch.
-func Provision(eng engine.Engine, against string) (url string, cleanup func() error, err error) {
+// Scratch is a throwaway database and whatever is needed to tear it down.
+type Scratch struct {
+	// URL connects to the scratch database from this process.
+	URL string
+	// Container names the Docker container hosting it, or "" when there
+	// isn't one — a SQLite tempfile, or a database the caller supplied via
+	// --against and owns themselves. Callers that need a version-matched
+	// engine tool (see dump.Schema) run it inside this container.
+	Container string
+	// Cleanup tears the scratch database down. nil when the caller owns it.
+	Cleanup func() error
+}
+
+// Provision returns a throwaway database for eng. If against is non-empty,
+// it is returned unchanged with no container and no cleanup — the caller
+// supplied their own and owns its lifecycle. Otherwise: SQLite gets a
+// tempfile (no server needed); every other engine gets an ephemeral, --rm
+// Docker container.
+func Provision(eng engine.Engine, against string) (Scratch, error) {
 	return ProvisionSeries(eng, against, "")
 }
 
@@ -23,27 +35,30 @@ func Provision(eng engine.Engine, against string) (url string, cleanup func() er
 // against. An empty series means "use the engine's default image", making it
 // identical to Provision.
 //
-// Callers that compare schemas (diff, squash) should pass the target's major
+// Callers that compare schemas (diff, squash) should pass the target's series
 // from ServerSeries: catalog rendering is not stable across versions, and a
 // mismatched scratch database reports that difference as drift that does not
 // exist. See container.ScratchImageFor.
-func ProvisionSeries(eng engine.Engine, against, series string) (url string, cleanup func() error, err error) {
+func ProvisionSeries(eng engine.Engine, against, series string) (Scratch, error) {
 	if against != "" {
-		return against, nil, nil
+		return Scratch{URL: against}, nil
 	}
 	if eng.Name() == "sqlite" {
 		f, err := os.CreateTemp("", "dbtools-scratch-*.db")
 		if err != nil {
-			return "", nil, fmt.Errorf("creating scratch file: %w", err)
+			return Scratch{}, fmt.Errorf("creating scratch file: %w", err)
 		}
 		path := f.Name()
 		f.Close()
 		os.Remove(path) // sqlite creates it fresh on first open
-		return "sqlite://" + path, func() error { return os.Remove(path) }, nil
+		return Scratch{
+			URL:     "sqlite://" + path,
+			Cleanup: func() error { return os.Remove(path) },
+		}, nil
 	}
-	url, c, err := container.StartScratchSeries(eng.Name(), series)
+	url, name, cleanup, err := container.StartScratchSeries(eng.Name(), series)
 	if err != nil {
-		return "", nil, fmt.Errorf("provisioning scratch database: %w", err)
+		return Scratch{}, fmt.Errorf("provisioning scratch database: %w", err)
 	}
-	return url, c, nil
+	return Scratch{URL: url, Container: name, Cleanup: cleanup}, nil
 }

--- a/internal/scratchdb/scratchdb_test.go
+++ b/internal/scratchdb/scratchdb_test.go
@@ -14,15 +14,15 @@ func TestProvision_AgainstSkipsProvisioning(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	url, cleanup, err := scratchdb.Provision(eng, "sqlite:///already/there.db")
+	sc, err := scratchdb.Provision(eng, "sqlite:///already/there.db")
 	if err != nil {
 		t.Fatalf("Provision() returned error: %v", err)
 	}
-	if url != "sqlite:///already/there.db" {
-		t.Errorf("url = %q, want the against value unchanged", url)
+	if sc.URL != "sqlite:///already/there.db" {
+		t.Errorf("url = %q, want the against value unchanged", sc.URL)
 	}
-	if cleanup != nil {
-		t.Error("cleanup should be nil when against skips provisioning — nothing to tear down")
+	if sc.Cleanup != nil {
+		t.Error("sc.Cleanup should be nil when against skips provisioning — nothing to tear down")
 	}
 }
 
@@ -31,14 +31,14 @@ func TestProvision_SQLiteCreatesAndCleansUpTempfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	url, cleanup, err := scratchdb.Provision(eng, "")
+	sc, err := scratchdb.Provision(eng, "")
 	if err != nil {
 		t.Fatalf("Provision() returned error: %v", err)
 	}
-	path := sqliteengine.PathFromURL(url)
-	db, err := eng.Open(url)
+	path := sqliteengine.PathFromURL(sc.URL)
+	db, err := eng.Open(sc.URL)
 	if err != nil {
-		t.Fatalf("eng.Open(%q): %v", url, err)
+		t.Fatalf("eng.Open(%q): %v", sc.URL, err)
 	}
 	if err := db.Ping(); err != nil {
 		t.Fatalf("db.Ping(): %v", err)
@@ -47,13 +47,13 @@ func TestProvision_SQLiteCreatesAndCleansUpTempfile(t *testing.T) {
 	if _, statErr := os.Stat(path); statErr != nil {
 		t.Fatalf("expected scratch file to exist at %s: %v", path, statErr)
 	}
-	if cleanup == nil {
-		t.Fatal("cleanup should not be nil for a provisioned sqlite scratch file")
+	if sc.Cleanup == nil {
+		t.Fatal("sc.Cleanup should not be nil for a provisioned sqlite scratch file")
 	}
-	if err := cleanup(); err != nil {
-		t.Errorf("cleanup() returned error: %v", err)
+	if err := sc.Cleanup(); err != nil {
+		t.Errorf("sc.Cleanup() returned error: %v", err)
 	}
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
-		t.Errorf("scratch file still exists after cleanup: statErr = %v", statErr)
+		t.Errorf("scratch file still exists after sc.Cleanup: statErr = %v", statErr)
 	}
 }

--- a/internal/squash/plan.go
+++ b/internal/squash/plan.go
@@ -38,7 +38,11 @@ type Plan struct {
 // eventually replay the committed baseline, and the verification comparison
 // has to be free of the cross-version rendering differences described in
 // container.ScratchImageFor and scratchdb.ServerSeries.
-func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix string, uptoVersion uint64, targetSeries string) (plan *Plan, err error) {
+//
+// useHostTools forces the host's dump binary instead of running the engine's
+// own inside the scratch container — the escape hatch for environments
+// without Docker.
+func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix string, uptoVersion uint64, targetSeries string, useHostTools bool) (plan *Plan, err error) {
 	dir, err := migrator.ReadDir(migrationsDir, upSuffix)
 	if err != nil {
 		return nil, err
@@ -53,11 +57,12 @@ func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix st
 		return nil, fmt.Errorf("no migration versions at or below %d found in %s", uptoVersion, migrationsDir)
 	}
 
-	url1, cleanup1, err := scratchdb.ProvisionSeries(eng, "", targetSeries)
+	replay, err := scratchdb.ProvisionSeries(eng, "", targetSeries)
 	if err != nil {
 		return nil, fmt.Errorf("provisioning replay scratch database: %w", err)
 	}
-	if cleanup1 != nil {
+	url1 := replay.URL
+	if cleanup1 := replay.Cleanup; cleanup1 != nil {
 		defer func() {
 			if cerr := cleanup1(); cerr != nil && err == nil {
 				err = fmt.Errorf("scratch database cleanup failed: %w", cerr)
@@ -102,16 +107,22 @@ func BuildPlan(cfg *config.Config, eng engine.Engine, migrationsDir, upSuffix st
 
 	_, _, ledgerTable := config.ResolveDefaults(cfg.MigrationsDir, cfg.Migrations.UpSuffix, cfg.Ledger.Table)
 	excludeTables := []string{"schema_migrations", "dbtools_migration_history", ledgerTable}
-	baselineSQL, err := dump.Schema(eng, url1, excludeTables...)
+	// Dump from inside the replay container when the image ships the tool,
+	// so the dump tool's version always matches the server it dumps.
+	baselineSQL, err := dump.Schema(eng, url1, dump.Options{
+		ExecIn:       replay.Container,
+		UseHostTools: useHostTools,
+	}, excludeTables...)
 	if err != nil {
 		return nil, fmt.Errorf("dumping scratch database schema: %w", err)
 	}
 
-	url2, cleanup2, err := scratchdb.ProvisionSeries(eng, "", targetSeries)
+	verify, err := scratchdb.ProvisionSeries(eng, "", targetSeries)
 	if err != nil {
 		return nil, fmt.Errorf("provisioning verification scratch database: %w", err)
 	}
-	if cleanup2 != nil {
+	url2 := verify.URL
+	if cleanup2 := verify.Cleanup; cleanup2 != nil {
 		defer func() {
 			if cerr := cleanup2(); cerr != nil && err == nil {
 				err = fmt.Errorf("verification database cleanup failed: %w", cerr)

--- a/internal/squash/plan_test.go
+++ b/internal/squash/plan_test.go
@@ -37,7 +37,7 @@ func TestBuildPlan_CleanHistoryVerifies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 2, "")
+	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 2, "", false)
 	if err != nil {
 		t.Fatalf("BuildPlan() returned error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestBuildPlan_PartialUptoReplaysOnlyCollapsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 1, "")
+	plan, err := squash.BuildPlan(cfg, eng, dir, ".up.sql", 1, "", false)
 	if err != nil {
 		t.Fatalf("BuildPlan() returned error: %v", err)
 	}


### PR DESCRIPTION
PR2 of the v0.7.0 plan (`docs/adr/003-v0.7-native-runner.md`). Completes #81.

**Stacked on #86** — based on `fix/version-parity`, so review that first. Retarget to `main` once it lands.

## Why

`dump.Schema` shelled out to whatever `pg_dump`/`mysqldump` happened to be on `PATH`: an unversioned, unvalidated dependency on the developer's machine, sitting in the middle of a correctness-critical path whose output is **committed as a baseline**.

#81 was the visible half — `\restrict`, a psql meta-command the wire protocol rejects. Behind it sat a second failure: a host `pg_dump` 18.6 dumping a 16.14 server emits `SET transaction_timeout`, a GUC that server does not have. Neither stays contained, because the baseline is committed and the mismatch resurfaces whenever it is applied.

## What changed

Run the tool **inside the container hosting the database**. Its version then matches the server's by construction — it is the server's own image.

- `container.InContainerURL` gives the connection URL as seen from inside, where the engine listens on its fixed port and the host mapping does not apply. `container.Exec` runs the tool there.
- `scratchdb.Provision` now returns `Scratch{URL, Container, Cleanup}` so callers know which container to dump inside. `Container` is empty for a SQLite tempfile and for a caller-supplied `--against` database — both correctly fall back to the host.
- **MSSQL keeps using the host.** `mssql-scripter` is a separate Python package, not part of the SQL Server image. Version skew there remains the operator's to manage, and `SupportsInContainerDump` states that in one place rather than leaving it implicit.
- `squash --use-host-tools` forces the host binary — the escape hatch for environments without Docker, or operators who know their versions agree.

## What deliberately stayed

- **`\restrict` stripping.** psql meta-commands are never valid over the wire protocol, whatever version emitted them. That is not a version workaround and does not go away with parity.
- **Timeout-GUC stripping**, but its comment now says it is only reachable via `--use-host-tools`, so it does not keep looking load-bearing.

## Verification

Against a Postgres **16.14** target with a deliberately mismatched host `pg_dump` **18.6** — the #81 reproduction:

```console
$ dbtools squash local
baseline verified: collapsing versions [0 20260814150000 … 20260824080000]
dry run — pass --yes to write the baseline and archive 9 file(s)
```

Then with the host binary replaced by a stub that fails loudly if invoked, to prove the container path is genuinely used rather than merely available:

```console
$ PATH=/tmp/stub:$PATH dbtools squash local
baseline verified: collapsing versions […]          # stub never called

$ PATH=/tmp/stub:$PATH dbtools squash local --use-host-tools
Error: dumping scratch database schema: pg_dump failed: exit status 1: HOST_PG_DUMP_WAS_CALLED
```

Both directions proven rather than assumed.

`gofmt`, `go vet`, `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)