### PR TITLE
feat(dblock): own the migration lock, with the tests it never had

### DIFF
--- a/internal/dblock/concurrency_integration_test.go
+++ b/internal/dblock/concurrency_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package dblock_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/seanpham99/dbtools/internal/dblock"
+	"github.com/seanpham99/dbtools/internal/engine"
+
+	_ "github.com/seanpham99/dbtools/internal/engine/mssqlengine"
+	_ "github.com/seanpham99/dbtools/internal/engine/mysqlengine"
+	_ "github.com/seanpham99/dbtools/internal/engine/postgresengine"
+)
+
+// The property that matters: while one run holds the migration lock, a
+// second run cannot take it. Nothing about that is provable with a fake —
+// the whole point is the server's own arbitration between two sessions — so
+// this is an integration test against each real engine.
+//
+// Before this existed, dbtools implemented no locking at all: Lock/Unlock
+// were pure delegation to golang-migrate, and had zero test coverage in
+// this repo.
+func TestIntegrationLockIsMutuallyExclusive(t *testing.T) {
+	for _, tc := range []struct {
+		engineName string
+		envVar     string
+	}{
+		{"postgres", "DBTOOLS_TEST_POSTGRES_URL"},
+		{"mysql", "DBTOOLS_TEST_MYSQL_URL"},
+		{"mssql", "DBTOOLS_TEST_MSSQL_URL"},
+	} {
+		t.Run(tc.engineName, func(t *testing.T) {
+			rawURL := os.Getenv(tc.envVar)
+			if rawURL == "" {
+				t.Skipf("%s not set, skipping", tc.envVar)
+			}
+			eng, err := engine.ForName(tc.engineName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			acquire, release, err := dblock.ForEngine(tc.engineName)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Two independent pools stand in for two dbtools processes.
+			first, err := eng.Open(rawURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer first.Close()
+			second, err := eng.Open(rawURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer second.Close()
+
+			ctx := context.Background()
+			key := dblock.KeyFor("dblock-mutual-exclusion-test")
+
+			held, err := dblock.Acquire(ctx, first, key, acquire, release)
+			if err != nil {
+				t.Fatalf("first Acquire: %v", err)
+			}
+
+			// The second acquisition must block. Give it a deadline: if it
+			// returns success before the first is released, the lock does
+			// not exclude and two runners could apply migrations together.
+			blocked := make(chan error, 1)
+			go func() {
+				waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+				defer cancel()
+				l, err := dblock.Acquire(waitCtx, second, key, acquire, release)
+				if err == nil {
+					// Should not happen while the first is held; hand it back
+					// so the test cannot wedge the shared server.
+					_ = l.Release(ctx)
+				}
+				blocked <- err
+			}()
+
+			select {
+			case err := <-blocked:
+				if err == nil {
+					t.Fatal("second Acquire succeeded while the lock was held — the lock does not exclude")
+				}
+				// Timed out waiting, which is the expected outcome.
+			case <-time.After(5 * time.Second):
+				t.Fatal("second Acquire neither returned nor timed out")
+			}
+
+			if err := held.Release(ctx); err != nil {
+				t.Fatalf("Release: %v", err)
+			}
+
+			// Once released, the lock must be takeable again — a lock that
+			// excludes forever is just as broken as one that never does.
+			retakeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			retaken, err := dblock.Acquire(retakeCtx, second, key, acquire, release)
+			if err != nil {
+				t.Fatalf("Acquire after Release: %v — the lock was not handed back", err)
+			}
+			if err := retaken.Release(ctx); err != nil {
+				t.Fatalf("Release of retaken lock: %v", err)
+			}
+		})
+	}
+}
+
+// Releasing a lock this session does not hold must be reported, not
+// swallowed: on Postgres the unlock is refcounted, so a silent double
+// release would hand back a lock another run currently owns.
+func TestIntegrationReleaseWithoutHoldingIsAnError(t *testing.T) {
+	rawURL := os.Getenv("DBTOOLS_TEST_POSTGRES_URL")
+	if rawURL == "" {
+		t.Skip("DBTOOLS_TEST_POSTGRES_URL not set, skipping")
+	}
+	eng, err := engine.ForName("postgres")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := eng.Open(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	_, release, err := dblock.ForEngine("postgres")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := release(ctx, conn, dblock.KeyFor("never-acquired")); err == nil {
+		t.Error("releasing a lock that was never held should report it, not succeed silently")
+	}
+}

--- a/internal/dblock/dblock.go
+++ b/internal/dblock/dblock.go
@@ -1,0 +1,110 @@
+// Package dblock provides the cross-process mutual exclusion that keeps two
+// dbtools runs from applying migrations to one database at the same time.
+//
+// This is the one guarantee dbtools cannot get slightly wrong and still be
+// useful. Two concurrent runners interleaving DDL corrupts a schema in ways
+// that are hard to detect and harder to unwind, and it fails rarely enough
+// that nobody notices until production. It matters most in exactly the
+// deployment shape dbtools targets with its private-network job story: a
+// migration job that can be triggered twice, or retried while the first
+// execution is still running.
+//
+// Scope is the whole apply run, not one statement or one transaction:
+// migrations are multi-statement, span multiple files, and on some engines
+// cannot run inside a transaction at all. That rules out relying on
+// transactional locking, and is why each engine's session-scoped advisory
+// lock is used instead.
+package dblock
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"hash/fnv"
+)
+
+// Lock is a held advisory lock. Release must be called to hand it back;
+// holding it open for the life of a process would block every later run.
+type Lock struct {
+	release func(context.Context) error
+	// conn is the single connection the lock lives on. Advisory locks are
+	// session-scoped on every engine dbtools supports, so the lock and its
+	// release have to run on the same connection — a pooled *sql.DB would
+	// happily release on a different one, silently doing nothing.
+	conn *sql.Conn
+}
+
+// Release hands the lock back and returns the connection to the pool.
+// Safe to call more than once; only the first call does anything.
+func (l *Lock) Release(ctx context.Context) error {
+	if l == nil || l.conn == nil {
+		return nil
+	}
+	relErr := l.release(ctx)
+	closeErr := l.conn.Close()
+	l.conn = nil
+	if relErr != nil {
+		return relErr
+	}
+	return closeErr
+}
+
+// Acquirer takes an engine's advisory lock on conn. Implementations block
+// until the lock is available or ctx is done — they never return "busy" as
+// a success.
+type Acquirer func(ctx context.Context, conn *sql.Conn, key string) error
+
+// Releaser hands an engine's advisory lock back on conn.
+type Releaser func(ctx context.Context, conn *sql.Conn, key string) error
+
+// Acquire takes the advisory lock named key on db and returns a handle that
+// must be released.
+//
+// It deliberately blocks rather than failing fast when another run holds the
+// lock: the common case is a second job execution starting while the first
+// is still applying, and waiting is what the operator wants. A caller that
+// prefers to give up passes a ctx with a deadline.
+func Acquire(ctx context.Context, db *sql.DB, key string, acquire Acquirer, release Releaser) (*Lock, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening a connection for the migration lock: %w", err)
+	}
+	if err := acquire(ctx, conn, key); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("acquiring the migration lock: %w", err)
+	}
+	return &Lock{
+		conn: conn,
+		release: func(ctx context.Context) error {
+			if err := release(ctx, conn, key); err != nil {
+				return fmt.Errorf("releasing the migration lock: %w", err)
+			}
+			return nil
+		},
+	}, nil
+}
+
+// KeyFor derives a stable lock key for a database.
+//
+// The key is scoped to the database being migrated rather than global, so
+// two dbtools runs against different databases on the same server do not
+// serialise against each other for no reason.
+func KeyFor(database string) string {
+	if database == "" {
+		return "dbtools"
+	}
+	return "dbtools-" + database
+}
+
+// NumericKey folds a key into the 64-bit integer engines that only accept
+// numeric lock identifiers (Postgres) require.
+//
+// A hash collision would make two different databases share a lock, which
+// costs concurrency but is never incorrect — the opposite trade would be
+// unsafe, so this is the right direction to fail.
+func NumericKey(key string) int64 {
+	h := fnv.New64a()
+	// Write never returns an error for a hash.
+	_, _ = h.Write([]byte(key))
+	return int64(h.Sum64())
+}

--- a/internal/dblock/dblock_test.go
+++ b/internal/dblock/dblock_test.go
@@ -9,8 +9,12 @@ func TestKeyFor_ScopesToDatabase(t *testing.T) {
 	if KeyFor("app") == KeyFor("other") {
 		t.Error("different databases must not share a lock key — unrelated runs would serialise")
 	}
-	if KeyFor("app") != KeyFor("app") {
-		t.Error("KeyFor must be stable: two runs against one database must agree on the key")
+	// Assigned first: comparing the two calls inline reads as a tautology
+	// to staticcheck, but the property under test is that the function is
+	// deterministic — two dbtools processes derive the key independently.
+	first, second := KeyFor("app"), KeyFor("app")
+	if first != second {
+		t.Errorf("KeyFor is not stable (%q vs %q): two runs against one database must agree on the key", first, second)
 	}
 	if KeyFor("") == "" {
 		t.Error("an unknown database name still needs a usable key")
@@ -18,8 +22,9 @@ func TestKeyFor_ScopesToDatabase(t *testing.T) {
 }
 
 func TestNumericKey_StableAndDistinct(t *testing.T) {
-	if NumericKey("dbtools-app") != NumericKey("dbtools-app") {
-		t.Fatal("NumericKey must be stable across calls, or two runs would take different locks")
+	first, second := NumericKey("dbtools-app"), NumericKey("dbtools-app")
+	if first != second {
+		t.Fatalf("NumericKey is not stable (%d vs %d): two runs would take different locks", first, second)
 	}
 	if NumericKey("dbtools-app") == NumericKey("dbtools-other") {
 		t.Error("distinct keys collided; unrelated databases would serialise")

--- a/internal/dblock/dblock_test.go
+++ b/internal/dblock/dblock_test.go
@@ -1,0 +1,47 @@
+package dblock
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKeyFor_ScopesToDatabase(t *testing.T) {
+	if KeyFor("app") == KeyFor("other") {
+		t.Error("different databases must not share a lock key — unrelated runs would serialise")
+	}
+	if KeyFor("app") != KeyFor("app") {
+		t.Error("KeyFor must be stable: two runs against one database must agree on the key")
+	}
+	if KeyFor("") == "" {
+		t.Error("an unknown database name still needs a usable key")
+	}
+}
+
+func TestNumericKey_StableAndDistinct(t *testing.T) {
+	if NumericKey("dbtools-app") != NumericKey("dbtools-app") {
+		t.Fatal("NumericKey must be stable across calls, or two runs would take different locks")
+	}
+	if NumericKey("dbtools-app") == NumericKey("dbtools-other") {
+		t.Error("distinct keys collided; unrelated databases would serialise")
+	}
+}
+
+// A released lock must not release twice. On Postgres, pg_advisory_unlock is
+// refcounted, so a double release would hand back a lock this run no longer
+// owns — releasing someone else's.
+func TestLock_ReleaseIsIdempotent(t *testing.T) {
+	if err := (*Lock)(nil).Release(context.Background()); err != nil {
+		t.Errorf("Release on a nil lock should be a no-op, got %v", err)
+	}
+
+	calls := 0
+	l := &Lock{release: func(context.Context) error { calls++; return nil }}
+	// conn is nil, which is the state Release leaves behind. Releasing again
+	// must be a no-op rather than calling the releaser a second time.
+	if err := l.Release(context.Background()); err != nil {
+		t.Fatalf("Release on an already-released lock: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("releaser called %d times on an already-released lock, want 0", calls)
+	}
+}

--- a/internal/dblock/engines.go
+++ b/internal/dblock/engines.go
@@ -1,0 +1,136 @@
+package dblock
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// ForEngine returns the acquire/release pair for engineName.
+//
+// Every engine here uses a *session*-scoped advisory lock rather than a
+// transactional one, because an apply run spans many statements and files
+// and, on some engines, DDL that cannot sit inside a transaction at all.
+func ForEngine(engineName string) (Acquirer, Releaser, error) {
+	switch engineName {
+	case "postgres":
+		return postgresAcquire, postgresRelease, nil
+	case "mysql":
+		return mysqlAcquire, mysqlRelease, nil
+	case "mssql":
+		return mssqlAcquire, mssqlRelease, nil
+	case "sqlite":
+		// SQLite serialises writers itself: a second writer gets SQLITE_BUSY
+		// rather than interleaving. There is also no second process sharing a
+		// server to coordinate with — the file *is* the database.
+		return noopAcquire, noopRelease, nil
+	default:
+		return nil, nil, fmt.Errorf("no migration lock implemented for engine %q", engineName)
+	}
+}
+
+func noopAcquire(context.Context, *sql.Conn, string) error { return nil }
+func noopRelease(context.Context, *sql.Conn, string) error { return nil }
+
+// pg_advisory_lock blocks until the lock is free and takes only a numeric
+// key. It is refcounted per session, so every acquire needs exactly one
+// release — which is why Lock.Release is idempotent.
+func postgresAcquire(ctx context.Context, conn *sql.Conn, key string) error {
+	_, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", NumericKey(key))
+	return err
+}
+
+func postgresRelease(ctx context.Context, conn *sql.Conn, key string) error {
+	// pg_advisory_unlock returns false when this session did not hold the
+	// lock. That means the lock was lost or released twice, and silently
+	// ignoring it would hide a bug that lets two runners proceed together.
+	var released bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_advisory_unlock($1)", NumericKey(key)).Scan(&released); err != nil {
+		return err
+	}
+	if !released {
+		return fmt.Errorf("advisory lock %q was not held by this session at release time", key)
+	}
+	return nil
+}
+
+// GET_LOCK takes a name and a timeout in seconds. A negative timeout waits
+// indefinitely, which matches the blocking semantics of the other engines;
+// ctx cancellation is what bounds the wait.
+func mysqlAcquire(ctx context.Context, conn *sql.Conn, key string) error {
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, -1)", mysqlKey(key)).Scan(&got); err != nil {
+		return err
+	}
+	// 1 = acquired, 0 = timed out, NULL = error.
+	if !got.Valid || got.Int64 != 1 {
+		return fmt.Errorf("could not acquire advisory lock %q", key)
+	}
+	return nil
+}
+
+func mysqlRelease(ctx context.Context, conn *sql.Conn, key string) error {
+	var released sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", mysqlKey(key)).Scan(&released); err != nil {
+		return err
+	}
+	if !released.Valid || released.Int64 != 1 {
+		return fmt.Errorf("advisory lock %q was not held by this session at release time", key)
+	}
+	return nil
+}
+
+// MySQL lock names are limited to 64 characters since 5.7. Keys are short by
+// construction, but a long database name could push past it, so truncate
+// deterministically rather than letting the server reject the call.
+func mysqlKey(key string) string {
+	const maxLockName = 64
+	if len(key) <= maxLockName {
+		return key
+	}
+	return key[:maxLockName]
+}
+
+// sp_getapplock with @LockOwner='Session' outlives the calling batch, which
+// is what an apply run needs. @LockTimeout=-1 waits indefinitely.
+func mssqlAcquire(ctx context.Context, conn *sql.Conn, key string) error {
+	var result int
+	err := conn.QueryRowContext(ctx, `
+		DECLARE @r INT;
+		EXEC @r = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive',
+			@LockOwner = 'Session', @LockTimeout = -1;
+		SELECT @r`, mssqlKey(key)).Scan(&result)
+	if err != nil {
+		return err
+	}
+	// 0 = granted, 1 = granted after waiting; negatives are failures.
+	if result < 0 {
+		return fmt.Errorf("could not acquire advisory lock %q (sp_getapplock returned %d)", key, result)
+	}
+	return nil
+}
+
+func mssqlRelease(ctx context.Context, conn *sql.Conn, key string) error {
+	var result int
+	err := conn.QueryRowContext(ctx, `
+		DECLARE @r INT;
+		EXEC @r = sp_releaseapplock @Resource = @p1, @LockOwner = 'Session';
+		SELECT @r`, mssqlKey(key)).Scan(&result)
+	if err != nil {
+		return err
+	}
+	if result < 0 {
+		return fmt.Errorf("advisory lock %q was not held by this session at release time "+
+			"(sp_releaseapplock returned %d)", key, result)
+	}
+	return nil
+}
+
+// sp_getapplock resource names are limited to 255 characters.
+func mssqlKey(key string) string {
+	const maxResourceName = 255
+	if len(key) <= maxResourceName {
+		return key
+	}
+	return key[:maxResourceName]
+}

--- a/internal/dblock/engines.go
+++ b/internal/dblock/engines.go
@@ -134,3 +134,32 @@ func mssqlKey(key string) string {
 	}
 	return key[:maxResourceName]
 }
+
+// DatabaseName asks the server which database this connection is on.
+//
+// Deriving it from the connection URL instead would be a correctness hole:
+// the same database reached through two URL forms (postgres:// vs
+// postgresql://, 127.0.0.1 vs localhost, MySQL's tcp(host:port)) would
+// produce two different lock keys, and two runs that must exclude each
+// other would not. One round trip removes the whole class.
+//
+// Returns "" when it cannot be determined, which KeyFor turns into a
+// global key — less concurrency, never less safety.
+func DatabaseName(ctx context.Context, db *sql.DB, engineName string) string {
+	var query string
+	switch engineName {
+	case "postgres":
+		query = "SELECT current_database()"
+	case "mysql":
+		query = "SELECT DATABASE()"
+	case "mssql":
+		query = "SELECT DB_NAME()"
+	default:
+		return ""
+	}
+	var name sql.NullString
+	if err := db.QueryRowContext(ctx, query).Scan(&name); err != nil || !name.Valid {
+		return ""
+	}
+	return name.String
+}


### PR DESCRIPTION
First of two PRs completing the v0.7.0 plan (`docs/adr/003-v0.7-native-runner.md`). Additive — nothing calls this yet; the runner PR follows and wires it in.

## Why this is separate

The ADR sequences locking before the runner because it is the one part of that work with **no inherited safety net**. Reviewing it inside a ~900-line runner rewrite would have buried it.

dbtools implements no locking today: `Lock`/`Unlock` are pure delegation to golang-migrate, there is no advisory-lock SQL anywhere in the repo, and there is no test coverage for any of it. Dropping golang-migrate means owning it — and owning it badly is worse than not owning it. Two runners interleaving DDL corrupts a schema in ways that are hard to detect and harder to unwind, and it fails rarely enough that nobody notices until production. It matters most in exactly the deployment shape #60 describes: a migration job that can be triggered twice, or retried while the first execution is still running.

## What it does

Session-scoped advisory locks per engine, because an apply run spans many statements and files and, on some engines, DDL that cannot sit inside a transaction at all — so transactional locking cannot cover it:

| engine | mechanism |
|---|---|
| postgres | `pg_advisory_lock` / `pg_advisory_unlock` |
| mysql | `GET_LOCK` / `RELEASE_LOCK` |
| mssql | `sp_getapplock` / `sp_releaseapplock`, `@LockOwner = 'Session'` |
| sqlite | no-op — SQLite serialises writers itself, and there is no second process sharing a server |

Details that are easy to get wrong, and why they are the way they are:

- The lock is held on a **dedicated `*sql.Conn`**, not the pool. These locks are session-scoped on every engine, so releasing from a pooled connection would silently do nothing.
- **Release is idempotent.** Postgres refcounts `pg_advisory_unlock`, so a double release would hand back a lock the run no longer owns.
- A release reporting "not held" is **surfaced, not swallowed** — that is the signature of two runners both believing they hold it.
- Keys are **scoped per database**, so runs against different databases on one server do not serialise for no reason. Numeric folding for Postgres can collide in principle, which costs concurrency but is never unsafe — the opposite trade would be.

## Verification

Mutual exclusion is not provable with a fake: it *is* the server arbitrating between two sessions. So the test holds the lock on one pool and asserts a second pool cannot take it, then asserts it can once released — a lock that excludes forever is as broken as one that never does.

Run against real servers: **Postgres 16.14** and **MySQL 8.0.46**, both blocking for the full timeout and both retaking cleanly after release. MSSQL is covered by the same test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database-scoped locking to coordinate migration operations across processes.
  * Added support for PostgreSQL, MySQL, MSSQL, and SQLite locking behavior.
  * Locks now support context cancellation, safe release, and consistent database-specific keys.

* **Bug Fixes**
  * Prevented duplicate lock releases and reported errors when releasing unheld locks.

* **Tests**
  * Added unit and integration coverage for lock exclusivity, key stability, and release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->