### PR TITLE
chore: keep 0.x versioning until dbtools is deliberately 1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,14 +3,22 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false
     },
     "npm": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "package.json", "jsonpath": "$.binaryVersion" }
-      ]
+        {
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.binaryVersion"
+        }
+      ],
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false
     }
   }
 }


### PR DESCRIPTION
release-please opened #83 as **1.0.0**, not 0.7.0.

Its default treats a `feat!` as a major bump regardless of the current version. dbtools is not claiming API stability yet — a runner rewrite is precisely the kind of change 0.x exists to permit — so going 1.0 should be a decision, not a side effect of a commit prefix.

`bump-minor-pre-major` keeps breaking changes on the minor while below 1.0. Once this merges, release-please recomputes #83 as **0.7.0**.

Config only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)