### PR TITLE
ci: make the release runnable for release-please tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,21 @@ on:
   push:
     tags:
       - "v*"
+  # release-please creates its tag with GITHUB_TOKEN, and GitHub does not
+  # trigger workflows from token-created refs — so the push trigger above
+  # never fires for an automated release. Every release since the workflow
+  # was added has therefore shipped with no goreleaser binaries and no npm
+  # publish, which is why npm's `latest` sat several versions behind the
+  # GitHub releases.
+  #
+  # This makes the release runnable by hand for those tags. The durable fix
+  # is to give release-please a PAT so its tags trigger workflows normally;
+  # until then, run this after a release PR merges.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and publish (e.g. v0.7.0)"
+        required: true
 
 permissions:
   contents: write
@@ -19,10 +34,19 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve the release tag
+        id: release_tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then TAG="${GITHUB_REF#refs/tags/}"; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Check CHANGELOG entry
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${{ steps.release_tag.outputs.version }}"
           # awk string-compare (no regex) on line start; grep -F would treat ^ as literal
           if ! awk -v v="## [$VERSION]" 'index($0, v) == 1 { found=1 } END { exit !found }' CHANGELOG.md; then
             echo "::error::CHANGELOG.md is missing an entry for [$VERSION]. Add one (Keep a Changelog format) before tagging."
@@ -64,7 +88,7 @@ jobs:
       - name: Publish to npm
         run: |
           npm install -g npm@latest
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${{ steps.release_tag.outputs.version }}"
           cd npm
           if [ "$(node -p "require('./package.json').version")" != "$VERSION" ]; then
             npm version "$VERSION" --no-git-tag-version
@@ -73,7 +97,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${{ steps.release_tag.outputs.version }}"
           rm -rf /tmp/gh-pkg && cp -r npm /tmp/gh-pkg
           cd /tmp/gh-pkg
           npm pkg set name="@${GITHUB_REPOSITORY_OWNER,,}/dbtools-cli"


### PR DESCRIPTION
v0.7.0 tagged, and `release.yml` never ran. Nor did it for v0.6.0 — that release has **zero assets** too.

## Root cause

release-please creates its tag with `GITHUB_TOKEN`, and GitHub deliberately does not trigger workflows from token-created refs. The `push: tags: v*` trigger has therefore never fired for an automated release, so goreleaser and `npm publish` have never run for one.

**This is why npm `latest` has been stranded behind the GitHub releases** — 0.3.0 while GitHub had 0.4.0, then still 0.3.0 at 0.6.0. Two separate integration spikes flagged that as a distribution bug; neither found the cause, because the symptom looks like a publish failure rather than a workflow that never started.

## What this does

`workflow_dispatch` with a tag input, so the release can be run by hand for those tags. The tag is resolved once into a step output and reused by the CHANGELOG check, npm publish and GitHub Packages — under a manual run `GITHUB_REF` is the branch, so every one of those would otherwise have built the wrong version.

## Follow-up worth doing

The durable fix is giving release-please a PAT so its tags trigger workflows like any other push. That needs a secret only you can create, so this unblocks shipping v0.7.0 without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)