### PR TITLE
ci: give the GitHub Packages publish a credential it can actually use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
           npm pkg set name="@${GITHUB_REPOSITORY_OWNER,,}/dbtools-cli"
           npm pkg set version="$VERSION"
           npm pkg set publishConfig.registry="https://npm.pkg.github.com"
+          # setup-node wrote an .npmrc pointing at npmjs for the provenance
+          # publish above, so npm has no credential for GitHub's registry and
+          # fails with ENEEDAUTH. Write the mapping next to the package being
+          # published rather than editing the shared one.
+          printf '//npm.pkg.github.com/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > .npmrc
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The v0.7.0 release run got everything out — 6 goreleaser binaries attached, npm `latest` now 0.7.0 — and failed on its last step: `npm error code ENEEDAUTH` publishing to GitHub Packages.

`NODE_AUTH_TOKEN` is set, but npm only reads it via an `.npmrc` registry mapping, and the `.npmrc` `setup-node` wrote points at npmjs for the provenance publish earlier in the same job. So npm had no credential for `npm.pkg.github.com`.

Writes the mapping into the copied package directory, beside the thing being published, rather than mutating the shared config the npmjs publish depends on.

Never noticed before because this workflow had never run at all — release-please tags do not trigger it (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing reliability by ensuring authentication is correctly applied when publishing to GitHub Packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->