### PR TITLE
ci: let release-please use a PAT so its tags trigger the release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,15 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # A PAT so the tag release-please pushes triggers release.yml.
+          # GitHub deliberately does not run workflows for refs created with
+          # GITHUB_TOKEN, which is why every release before v0.7.1 shipped
+          # with no binaries and no npm publish — the release workflow never
+          # started (#92).
+          #
+          # Falls back to the default token when the secret is absent, so
+          # this stays working (minus the trigger) rather than failing shut.
+          # Needs Contents and Pull requests: read and write, on this repo.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Closes the loop on #92.

GitHub does not run workflows for refs created with `GITHUB_TOKEN`, so the tag release-please pushes never started `release.yml`. That is why every release before v0.7.1 shipped with no binaries and no npm publish — and why npm `latest` sat several versions behind for months.

Reads `RELEASE_PLEASE_TOKEN` when present, falls back to the default token otherwise, so **this is safe to merge before the secret exists** — it stays working (minus the trigger) rather than failing shut.

## To finish it

1. Fine-grained PAT at https://github.com/settings/personal-access-tokens/new — only `seanpham99/dbtools`, with **Contents: read and write** and **Pull requests: read and write**
2. `gh secret set RELEASE_PLEASE_TOKEN --repo seanpham99/dbtools`

After that, releasing is merging the release PR — no `gh workflow run` dispatch.

Note the token expiry: when it lapses, release PRs stop appearing rather than failing loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)